### PR TITLE
Update any references to the old GitHub URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All documentation can be found at [https://gravitypdf.com](http://gravitypdf.com
 
 # Contributions
 
-You are more than welcome to contribute to Gravity PDF but we recommend you [open a new issue on GitHub](https://github.com/GravityPDF/gravity-forms-pdf-extended/issues) and discuss your use-case before creating a pull request.
+You are more than welcome to contribute to Gravity PDF but we recommend you [open a new issue on GitHub](https://github.com/GravityPDF/gravity-pdf/issues) and discuss your use-case before creating a pull request.
 
 There are a few rules that need to be followed to ensure a smooth pull request. These include:
 

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -1372,7 +1372,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				 * eg. class Fields_New_Text extends \GFPDF\Helper\Helper_Abstract_Fields or Fields_New_Text extends \GFPDF\Helper\Fields\Field_Text
 				 *
 				 * To make your life more simple you should either use the same namespace as the field classes (\GFPDF\Helper\Fields) or import the class directly (use \GFPDF\Helper\Fields\Field_Text)
-				 * We've tried to make the fields as modular as possible. If you have any feedback about this approach please submit a ticket on GitHub (https://github.com/blueliquiddesigns/gravity-forms-pdf-extended/issues)
+				 * We've tried to make the fields as modular as possible. If you have any feedback about this approach please submit a ticket on GitHub (https://github.com/GravityPDF/gravity-pdf/issues)
 				 */
 				if ( GFCommon::is_product_field( $field->type ) ) {
 


### PR DESCRIPTION
Fixed references in the plugin to old GitHub repo name. 

Also fixed any links in current documentation. See https://github.com/GravityPDF/v4-documentation/commit/2c74ed9a21b19a7fc13fe86b834b91295ac25ad4