### PR TITLE
Cleanup our View layer and fix the $data reference conflict with our Helper_Data class

### DIFF
--- a/src/helper/abstract/Helper_Abstract_View.php
+++ b/src/helper/abstract/Helper_Abstract_View.php
@@ -57,8 +57,15 @@ abstract class Helper_Abstract_View extends Helper_Abstract_Model {
 	 * @var array
 	 * @since 4.0
 	 */
-	protected $data = array();
+	protected $data_cache = array();
 
+	/**
+	 * Automatically define our constructor which will set our data cache
+	 * @param array $data An array of data to pass to the view
+	 */
+	public function __construct( $data = array() ) {
+		$this->data_cache = $data;
+	}
 
 	/**
 	 * Triggered when invoking inaccessible methods in an object context
@@ -70,9 +77,9 @@ abstract class Helper_Abstract_View extends Helper_Abstract_Model {
 	 */
 	final public function __call( $name, $arguments ) {
 		/* check if we have any arguments */
-		$vars = $this->data;
+		$vars = $this->data_cache;
 		if ( isset($arguments[0]) && is_array( $arguments[0] ) ) {
-			$vars = array_merge( $arguments[0], $this->data );
+			$vars = array_merge( $arguments[0], $vars );
 		}
 
 		/* load the about page view */

--- a/src/views/View_Actions.php
+++ b/src/views/View_Actions.php
@@ -51,10 +51,6 @@ class View_Actions extends Helper_Abstract_View
 	 */
 	protected $ViewType = 'Actions';
 
-	public function __construct( $data = array() ) {
-		$this->data = $data;
-	}
-
 	/**
 	 * Add our primary button and an opt-our dismissal button
 	 * @param  String $type        The action ID

--- a/src/views/View_Form_Settings.php
+++ b/src/views/View_Form_Settings.php
@@ -47,15 +47,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class View_Form_Settings extends Helper_Abstract_View
 {
-
 	/**
 	 * Set the view's name
 	 * @var string
 	 * @since 4.0
 	 */
 	protected $ViewType = 'FormSettings';
-
-	public function __construct( $data = array() ) {
-		$this->data = $data;
-	}
 }

--- a/src/views/View_PDF.php
+++ b/src/views/View_PDF.php
@@ -102,7 +102,7 @@ class View_PDF extends Helper_Abstract_View
 	 * @var Object
 	 * @since 4.0
 	 */
-	protected $plugin_data;
+	protected $data;
 
 	/**
 	 * Holds our Helper_Misc object
@@ -113,18 +113,26 @@ class View_PDF extends Helper_Abstract_View
 	protected $misc;
 
 	/**
-	 * [__construct description]
-	 * @param array $data [description]
+	 * Setup our view with the needed data and classes
+	 * @param array                $data_cache  An array of data to pass to the view
+	 * @param Helper_Abstract_Form $form        Our abstracted Gravity Forms helper functions
+	 * @param LoggerInterface      $log         Our logger class
+	 * @param Helper_Options       $options     Our options class which allows us to access any settings
+	 * @param Helper_Data          $data Our plugin data store
+	 * @param Helper_Misc          $misc        Our miscellanious methods
+	 * @since 4.0
 	 */
-	public function __construct( $data = array(), Helper_Abstract_Form $form, LoggerInterface $log, Helper_Options $options, Helper_Data $plugin_data, Helper_Misc $misc ) {
-		$this->data = $data;
+	public function __construct( $data_cache = array(), Helper_Abstract_Form $form, LoggerInterface $log, Helper_Options $options, Helper_Data $data, Helper_Misc $misc ) {
+
+		/* Call our parent constructor */
+		parent::__construct( $data_cache );
 
 		/* Assign our internal variables */
-		$this->form        = $form;
-		$this->log         = $log;
-		$this->options     = $options;
-		$this->plugin_data = $plugin_data;
-		$this->misc        = $misc;
+		$this->form    = $form;
+		$this->log     = $log;
+		$this->options = $options;
+		$this->data    = $data;
+		$this->misc    = $misc;
 	}
 
 	/**
@@ -161,7 +169,7 @@ class View_PDF extends Helper_Abstract_View
 		/**
 		 * Set out our PDF abstraction class
 		 */
-		$pdf = new Helper_PDF( $entry, $settings, $this->form, $this->plugin_data );
+		$pdf = new Helper_PDF( $entry, $settings, $this->form, $this->data );
 		$pdf->set_filename( $model->get_pdf_name( $settings, $entry ) );
 
 		try {

--- a/src/views/View_Settings.php
+++ b/src/views/View_Settings.php
@@ -90,7 +90,7 @@ class View_Settings extends Helper_Abstract_View
 	 * @var Object
 	 * @since 4.0
 	 */
-	protected $plugin_data;
+	protected $data;
 
 	/**
 	 * Holds our Helper_Misc object
@@ -100,21 +100,27 @@ class View_Settings extends Helper_Abstract_View
 	 */
 	protected $misc;
 
-
-
 	/**
-	 * [__construct description]
-	 * @param array $data [description]
+	 * Setup our view with the needed data and classes
+	 * @param array                $data_cache  An array of data to pass to the view
+	 * @param Helper_Abstract_Form $form        Our abstracted Gravity Forms helper functions
+	 * @param LoggerInterface      $log         Our logger class
+	 * @param Helper_Options       $options     Our options class which allows us to access any settings
+	 * @param Helper_Data          $data Our plugin data store
+	 * @param Helper_Misc          $misc        Our miscellanious methods
+	 * @since 4.0
 	 */
-	public function __construct( $data = array(), Helper_Abstract_Form $form, LoggerInterface $log, Helper_Options $options, Helper_Data $plugin_data, Helper_Misc $misc ) {
-		$this->data = $data;
+	public function __construct( $data_cache = array(), Helper_Abstract_Form $form, LoggerInterface $log, Helper_Options $options, Helper_Data $data, Helper_Misc $misc ) {
+
+		/* Call our parent constructor */
+		parent::__construct( $data_cache );
 
 		/* Assign our internal variables */
-		$this->form        = $form;
-		$this->log         = $log;
-		$this->options     = $options;
-		$this->plugin_data = $plugin_data;
-		$this->misc        = $misc;
+		$this->form    = $form;
+		$this->log     = $log;
+		$this->options = $options;
+		$this->data    = $data;
+		$this->misc    = $misc;
 	}
 
 	/**
@@ -130,10 +136,8 @@ class View_Settings extends Helper_Abstract_View
 		$vars = array(
 			'selected' => isset( $_GET['tab'] ) ? $_GET['tab'] : 'general',
 			'tabs'     => $this->get_avaliable_tabs(),
-			'data'     => $this->plugin_data,
+			'data'     => $this->data,
 		);
-
-		$vars = array_merge( $vars, $this->data );
 
 		/* load the tabs view */
 		$this->load( 'tabs', $vars );
@@ -185,13 +189,11 @@ class View_Settings extends Helper_Abstract_View
 		$status = new GFPDF_Major_Compatibility_Checks();
 
 		$vars = array(
-			'memory'      => $status->get_ram( $this->plugin_data->memory_limit ),
+			'memory'      => $status->get_ram( $this->data->memory_limit ),
 			'wp'          => $wp_version,
 			'php'         => phpversion(),
 			'gf'          => $this->form->get_version(),
 		);
-
-		$vars = array_merge( $vars, $this->data );
 
 		$this->log->addNotice( 'System Status', array( 'status' => $vars ) );
 
@@ -209,8 +211,6 @@ class View_Settings extends Helper_Abstract_View
 		$vars = array(
 			'edit_cap' => $this->form->has_capability( 'gravityforms_edit_settings' ),
 		);
-
-		$vars = array_merge( $vars, $this->data );
 
 		/* load the system status view */
 		$this->load( 'general', $vars );
@@ -230,15 +230,13 @@ class View_Settings extends Helper_Abstract_View
 			wp_die( __( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
 		}
 
-		$template_directory = ( is_multisite() ) ? $this->plugin_data->multisite_template_location : $this->plugin_data->template_location;
+		$template_directory = ( is_multisite() ) ? $this->data->multisite_template_location : $this->data->template_location;
 
 		$vars = array(
 			'template_directory'            => $this->misc->relative_path( $template_directory, '/' ),
 			'template_files'                => $this->options->get_plugin_pdf_templates(),
 			'custom_template_setup_warning' => $this->options->get_option( 'custom_pdf_template_files_installed' ),
 		);
-
-		$vars = array_merge( $vars, $this->data );
 
 		/* load the system status view */
 		$this->load( 'tools', $vars );

--- a/src/views/View_Shortcodes.php
+++ b/src/views/View_Shortcodes.php
@@ -51,11 +51,6 @@ class View_Shortcodes extends Helper_Abstract_View
 	 */
 	protected $ViewType = 'Shortcodes';
 
-
-	public function __construct( $data = array() ) {
-		$this->data = $data;
-	}
-
 	/**
 	 * Shortcode Error: Entry ID not passed through the shortcode - directly or through the URL.
 	 * @return String The error message

--- a/src/views/View_Welcome_Screen.php
+++ b/src/views/View_Welcome_Screen.php
@@ -63,11 +63,18 @@ class View_Welcome_Screen extends Helper_Abstract_View
 	 */
 	protected $form;
 
-	public function __construct( $data = array(), Helper_Abstract_Form $form ) {
-		$this->data = $data;
+	/**
+	 * Setup our view with the needed data and classes
+	 * @param array                $data_cache  An array of data to pass to the view
+	 * @param Helper_Abstract_Form $form        Our abstracted Gravity Forms helper functions
+	 */
+	public function __construct( $data_cache = array(), Helper_Abstract_Form $form ) {
+
+		/* Call our parent constructor */
+		parent::__construct( $data_cache );
 
 		/* Assign our internal variables */
-		$this->form        = $form;
+		$this->form = $form;
 	}
 
 	/**
@@ -80,8 +87,6 @@ class View_Welcome_Screen extends Helper_Abstract_View
 		$args = array(
 			'selected' => isset( $_GET['page'] ) ? $_GET['page'] : 'gfpdf-getting-started',
 		);
-
-		$args = array_merge( $args, $this->data );
 
 		/* load the tabs view */
 		$this->load( 'tabs', $args );
@@ -97,8 +102,6 @@ class View_Welcome_Screen extends Helper_Abstract_View
 		$args = array(
 			'forms' => $this->form->get_forms(),
 		);
-
-		$args = array_merge( $args, $this->data );
 
 		/* Render our view */
 		$this->load( 'welcome', $args );


### PR DESCRIPTION
While reviewing issue #50 we found there was unnessisary __construct() calls in the classes that extended `Helper_Abstract_View`. A general clean up of this behaviour was done, as well as rectifying the naming conflict mentioned in #50.

Fixes #50