### PR TITLE
Add "Download PDF" text when global setting is 'download' on entry list

### DIFF
--- a/src/views/html/PDF/entry_list_pdf_multiple.php
+++ b/src/views/html/PDF/entry_list_pdf_multiple.php
@@ -37,7 +37,7 @@ if (! defined('ABSPATH')) {
 ?>
 
 <span class="gf_form_toolbar_settings gf_form_action_has_submenu gfpdf_form_action_has_submenu">
-   | <a href="#" title="View PDFs" onclick="return false" class=""><?php _e('View PDFs', 'gravity-forms-pdf-extended' ); ?></a>
+   | <a href="#" title="View PDFs" onclick="return false" class=""><?php echo ( $args['view'] == 'download' ) ? __('Download PDFs', 'gravity-forms-pdf-extended') : __('View PDFs', 'gravity-forms-pdf-extended' ); ?></a>
 
     <div class="gf_submenu gfpdf_submenu">
         <ul>

--- a/src/views/html/PDF/entry_list_pdf_single.php
+++ b/src/views/html/PDF/entry_list_pdf_single.php
@@ -37,5 +37,5 @@ if (! defined('ABSPATH')) {
 ?>
 
 | <a href="<?php echo ( $args['view'] == 'download' ) ? $args['pdf']['download'] : $args['pdf']['view']; ?>" target="_blank">
-    <?php _e('View PDF', 'gravity-forms-pdf-extended' ); ?>
+    <?php echo ( $args['view'] == 'download' ) ? __('Download PDF', 'gravity-forms-pdf-extended') : __('View PDF', 'gravity-forms-pdf-extended' ); ?>
 </a>


### PR DESCRIPTION
The PDF text on the entry list page has always been "View PDF" or "View PDFs". Now there's the option to change the default behaviour to 'download' a PDF we've added appropriate text "Download PDF" and "Download PDFs" to account for this.

Fixes #24.