### PR TITLE
Fix Public Access bug and enable the field by default

### DIFF
--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -150,6 +150,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	 */
 	public function add_filters() {
 		/* PDF authentication middleware */
+		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_public_access'), 5, 3 );
 		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ), 10, 3 );
 		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ), 10, 3 );
 		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_restriction' ), 20, 3 );

--- a/src/helper/Helper_Options_Fields.php
+++ b/src/helper/Helper_Options_Fields.php
@@ -50,7 +50,6 @@ class Helper_Options_Fields extends Helper_Options implements Helper_Interface_F
 	public function add_filters() {
 
 		/* Conditionally enable specific fields */
-		add_filter( 'gfpdf_form_settings_advanced', array( $this, 'get_public_access_field' ) );
 		add_filter( 'gfpdf_form_settings_advanced', array( $this, 'get_advanced_template_field' ) );
 
 		parent::add_filters();
@@ -495,40 +494,23 @@ class Helper_Options_Fields extends Helper_Options implements Helper_Interface_F
 						'tooltip' => '<h6>' . __( 'Save PDF', 'gravity-forms-pdf-extended' ) . '</h6>' . sprintf( __( "By default, PDFs are not automatically saved to disk. Enable this option to force the PDF to be generated and saved. Useful when using the %sgfpdf_post_pdf_save%s hook to copy the PDF to an alternate location.", 'gravity-forms-pdf-extended' ), '<code>' , '</code>' ),
 					),
 
-				)
-			),
-		);
-
-		return apply_filters( 'gfpdf_registered_fields', $gfpdf_settings );
-	}
-
-	/**
-	 * Enable public access field if the user has enabled it with a filter
-	 * @param  Array $settings The 'form_settings_advanced' array
-	 * @return Array
-	 * @since 4.0
-	 */
-	public function get_public_access_field( $settings ) {
-
-		$enabled = apply_filters( 'gfpdf_enable_public_access_field', false );
-
-		if( $enabled !== true ) {
-			return $settings;
-		}
-
-		$settings['public_access'] = array(
+					'public_access' => array(
 						'id'    => 'public_access',
 						'name'  => __( 'Enable Public Acccess', 'gravity-forms-pdf-extended' ),
-						'desc'  => sprintf( __( 'Allow ANYONE to access the PDFs. %sWarning: This disables all security protocols.%s', 'gravity-forms-pdf-extended' ), '<strong>', '</strong>' ),
+						'desc'  => sprintf( __( 'Allow %sanyone%s with a direct link to access the PDF. %sThis disables all %ssecurity protocols%s for this PDF.%s ', 'gravity-forms-pdf-extended' ), '<strong>', '</strong>', '<em>', '<a href="#">', '</a>', '</em>' ),
 						'type'  => 'radio',
 						'options' => array(
 							'Yes' => __( 'Yes', 'gravity-forms-pdf-extended' ),
 							'No'  => __( 'No', 'gravity-forms-pdf-extended' ),
 						),
 						'std'   => __( 'No', 'gravity-forms-pdf-extended' ),
+						'tooltip' => '<h6>' . __( 'Public Access', 'gravity-forms-pdf-extended' ) . '</h6>' . __( "When public access is on all security protocols are disabled and anyone worldwide can view the PDF document for ALL your form's entries. For most users the standard security measures will be adequate and public access should remain disabled.", 'gravity-forms-pdf-extended' ),
+					),
+				)
+			),
 		);
 
-		return $settings;
+		return apply_filters( 'gfpdf_registered_fields', $gfpdf_settings );
 	}
 
 	/**

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -251,6 +251,26 @@ class Model_PDF extends Helper_Abstract_Model {
 	}
 
 	/**
+	 * Check if the current PDF trying to be viewed has public access enabled
+	 * If it does, we'll remove some of our middleware filters to allow this feature
+	 * @param  Boolean / Object $action
+	 * @param  Array            $entry    The Gravity Forms Entry
+	 * @param  Array            $settings The Gravity Form PDF Settings
+	 * @return Boolean / Object
+	 * @since 4.0
+	 */
+	public function middle_public_access( $action, $entry, $settings ) {
+		if( isset( $settings['public_access'] ) && 'Yes' === $settings['public_access'] ) {
+			remove_filter( 'gfpdf_pdf_middleware', array( $this, 'middle_logged_out_restriction'), 20 );
+			remove_filter( 'gfpdf_pdf_middleware', array( $this, 'middle_logged_out_timeout'), 30 );
+			remove_filter( 'gfpdf_pdf_middleware', array( $this, 'middle_auth_logged_out_user'), 40 );
+			remove_filter( 'gfpdf_pdf_middleware', array( $this, 'middle_user_capability'), 50 );
+		}
+
+		return $action;
+	}
+
+	/**
 	 * Check if the current PDF trying to be viewed is active
 	 * @param  Boolean / Object $action
 	 * @param  Array            $entry    The Gravity Forms Entry

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -139,6 +139,7 @@ class Test_PDF extends WP_UnitTestCase
 	public function test_filters() {
 		global $gfpdf;
 
+		$this->assertSame( 5,  has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_public_access' ) ) );
 		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
 		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
 		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_restriction' ) ) );
@@ -279,6 +280,37 @@ class Test_PDF extends WP_UnitTestCase
 		$this->assertEquals( 'Other', $e->getMessage() );
 
 		wp_set_current_user(0);
+
+	}
+
+	/**
+	 * Test if our public access middleware works as expected
+	 * @since 4.0
+	 */
+	public function test_middle_public_access() {
+
+		/* Check if error correctly triggered */
+		$settings['public_access'] = 'No';
+		$this->model->middle_public_access( '', '', $settings );
+
+		/* Run our Tests */
+		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
+		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
+		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_restriction' ) ) );
+		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_timeout' ) ) );
+		$this->assertSame( 40, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_auth_logged_out_user' ) ) );
+		$this->assertSame( 50, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ) ) );
+
+		/* Check if setting passes */
+		$settings['public_access'] = 'Yes';
+		$this->model->middle_public_access( '', '', $settings );
+
+		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
+		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
+		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_restriction' ) ) );
+		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_timeout' ) ) );
+		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_auth_logged_out_user' ) ) );
+		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ) ) );
 
 	}
 


### PR DESCRIPTION
While reviewing issue #19 we realised that the PDF public_access logic wasn't configured correctly. This was correctly fixed using a filter and the new function was unit tested. Along with this, the public_access field was enabled by default (not by a filter) and adequate warnings were included for the user.

Resolves #19.