### PR TITLE
Add Singleton-style helper class to allow access to original objects

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -125,6 +125,16 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	public $misc;
 
 	/**
+	 * Makes our MVC classes sudo-singletons by allowing easy access to the original objects
+	 * through `$singleton->get_class();`
+	 *
+	 * @var \GFPDF\Helper\Helper_Singleton
+	 *
+	 * @since 4.0
+	 */
+	public $singleton;
+
+	/**
 	 * Add user depreciation notice for any methods not included in current object
 	 *
 	 * @param string $name The function name to be called
@@ -175,6 +185,9 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		/* Set up our options object - this is initialised on admin_init but other classes need to access its methods before this */
 		$this->options = new Helper\Helper_Options_Fields( $this->log, $this->form, $this->data, $this->misc, $this->notices );
+
+		/* Setup our Singleton object */
+		$this->singleton = new Helper\Helper_Singleton();
 
 		/* Load modules */
 		$this->installer();
@@ -679,6 +692,10 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		/* set up required data */
 		$class->setup_defaults();
+
+		/* Add to our singleton controller */
+		$this->singleton->add_class( $class );
+		$this->singleton->add_class( $model );
 	}
 
 	/**
@@ -697,6 +714,11 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		$class = new Controller\Controller_Welcome_Screen( $model, $view, $this->log, $this->data, $this->options );
 		$class->init();
+
+		/* Add to our singleton controller */
+		$this->singleton->add_class( $class );
+		$this->singleton->add_class( $model );
+		$this->singleton->add_class( $view );
 	}
 
 	/**
@@ -713,6 +735,11 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		$class = new Controller\Controller_Settings( $model, $view, $this->form, $this->log, $this->notices, $this->data, $this->misc );
 		$class->init();
+
+		/* Add to our singleton controller */
+		$this->singleton->add_class( $class );
+		$this->singleton->add_class( $model );
+		$this->singleton->add_class( $view );
 	}
 
 	/**
@@ -729,6 +756,11 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		$class = new Controller\Controller_Form_Settings( $model, $view, $this->data, $this->options, $this->misc );
 		$class->init();
+
+		/* Add to our singleton controller */
+		$this->singleton->add_class( $class );
+		$this->singleton->add_class( $model );
+		$this->singleton->add_class( $view );
 	}
 
 	/**
@@ -745,6 +777,11 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		$class = new Controller\Controller_PDF( $model, $view, $this->form, $this->log, $this->misc );
 		$class->init();
+
+		/* Add to our singleton controller */
+		$this->singleton->add_class( $class );
+		$this->singleton->add_class( $model );
+		$this->singleton->add_class( $view );
 	}
 
 	/**
@@ -761,6 +798,11 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		$class = new Controller\Controller_Shortcodes( $model, $view, $this->log );
 		$class->init();
+
+		/* Add to our singleton controller */
+		$this->singleton->add_class( $class );
+		$this->singleton->add_class( $model );
+		$this->singleton->add_class( $view );
 	}
 
 	/**
@@ -777,6 +819,11 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		$class = new Controller\Controller_Actions( $model, $view, $this->form, $this->log, $this->notices );
 		$class->init();
+
+		/* Add to our singleton controller */
+		$this->singleton->add_class( $class );
+		$this->singleton->add_class( $model );
+		$this->singleton->add_class( $view );
 	}
 
 	/**

--- a/src/helper/Helper_Singleton.php
+++ b/src/helper/Helper_Singleton.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace GFPDF\Helper;
+
+	/**
+	 * A Sudo-Singleton Helper Class designed to hold our MVC classes
+	 * The main benefit is it more easily allows users to remove filters/actions Gravity PDF sets
+	 *
+	 * This isn't considered an actual `Singleton` pattern as we're not modifying our classes in any way (no static methods / disabling of the __construct), but it has the same objectives
+	 *
+	 * @package     Gravity PDF
+	 * @copyright   Copyright (c) 2015, Blue Liquid Designs
+	 * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+	 * @since       4.0
+	 */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF Copyright (C) 2015 Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * @since 4.0
+ */
+class Helper_Singleton {
+
+	/**
+	 * Location for the classes
+	 *
+	 * @var array
+	 *
+	 * @since 4.0
+	 */
+	private $classes = array();
+
+	/**
+	 * Get the class name without the namespace
+	 *
+	 * @param object $class
+	 *
+	 * @return string
+	 *
+	 * @since 4.0
+	 */
+	private function get_class_name( $class ) {
+		$class_name = get_class( $class );
+
+		if ( $pos = strrpos( $class_name, '\\' ) ) {
+			return substr( $class_name, $pos + 1 );
+		}
+
+		return $class_name;
+	}
+
+	/**
+	 * Add the already-initialised class to our singleton data store for later use
+	 *
+	 * @param object $class
+	 *
+	 * @since 4.0
+	 */
+	public function add_class( $class ) {
+		$class_name = $this->get_class_name( $class );
+
+		$this->classes[ $class_name ] = $class;
+	}
+
+	/**
+	 * Retreive the desired class
+	 *
+	 * @param string $name
+	 *
+	 * @return object|bool
+	 *
+	 * @since 4.0
+	 *
+	 */
+	public function get_class( $name ) {
+		if ( isset( $this->classes[ $name ] ) ) {
+			return $this->classes[ $name ];
+		}
+
+		return false;
+	}
+}

--- a/tests/phpunit/unit-tests/test-singleton.php
+++ b/tests/phpunit/unit-tests/test-singleton.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace GFPDF\Tests;
+
+use GFPDF\Helper\Helper_Singleton;
+use GFPDF\Helper\Helper_Data;
+
+use WP_UnitTestCase;
+
+/**
+ * Test Gravity PDF Singleton Helper class
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2015, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.0
+ */
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF Copyright (C) 2015 Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * @since 4.0
+ * @group singleton
+ */
+class Test_Singleton_Helper extends WP_UnitTestCase {
+
+	/**
+	 * Our Gravity PDF Data object
+	 *
+	 * @var \GFPDF\Helper\Helper_Singleton
+	 *
+	 * @since 4.0
+	 */
+	public $singleton;
+
+	/**
+	 * The WP Unit Test Set up function
+	 *
+	 * @since 4.0
+	 */
+	public function setUp() {
+
+		/* run parent method */
+		parent::setUp();
+
+		/* Setup out loader class */
+		$this->singleton = new Helper_Singleton();
+	}
+
+	/**
+	 * Check our add_class() and get_class() methods functions correctly
+	 *
+	 * @since 4.0
+	 */
+	public function test_singleton() {
+		/* create a test class */
+		$data          = new Helper_Data();
+		$data->working = 'yes';
+
+		/* Add our class to the singleton */
+		$this->singleton->add_class( $data );
+
+		/* Do other stuff with original object */
+		$data->stuff = 'completed';
+
+		/* Get our stored class and verify the results */
+		$singleton_data = $this->singleton->get_class( 'Helper_Data' );
+
+		/* Run our tests */
+		$this->assertNotFalse( $singleton_data );
+		$this->assertEquals( 'GFPDF\Helper\Helper_Data', get_class( $singleton_data ) );
+		$this->assertEquals( 'yes', $singleton_data->working );
+		$this->assertEquals( 'completed', $singleton_data->stuff );
+
+		/* Check for class that doens't exist */
+		$this->assertFalse( $this->singleton->get_class( 'non_existant' ) );
+	}
+
+	/**
+	 * Ensure Gravity PDF correctly registers all our MVC classes
+	 *
+	 * @since 4.0
+	 * @dataProvider provider_registered_classes
+	 */
+	public function test_registered_classes( $expected, $class ) {
+		global $gfpdf;
+
+		$singleton = $gfpdf->singleton;
+
+		$this->assertEquals( $expected, get_class( $singleton->get_class( $class ) ) );
+
+	}
+
+	/**
+	 * A data provider for our test_registered_classes() method
+	 *
+	 * @return array
+	 *
+	 * @since 4.0
+	 */
+	public function provider_registered_classes() {
+		return array(
+			array( 'GFPDF\Controller\Controller_Actions', 'Controller_Actions' ),
+			array( 'GFPDF\Controller\Controller_Form_Settings', 'Controller_Form_Settings' ),
+			array( 'GFPDF\Controller\Controller_Install', 'Controller_Install' ),
+			array( 'GFPDF\Controller\Controller_PDF', 'Controller_PDF' ),
+			array( 'GFPDF\Controller\Controller_Settings', 'Controller_Settings' ),
+			array( 'GFPDF\Controller\Controller_Shortcodes', 'Controller_Shortcodes' ),
+			array( 'GFPDF\Controller\Controller_Welcome_Screen', 'Controller_Welcome_Screen' ),
+			array( 'GFPDF\Model\Model_Actions', 'Model_Actions' ),
+			array( 'GFPDF\Model\Model_Form_Settings', 'Model_Form_Settings' ),
+			array( 'GFPDF\Model\Model_Install', 'Model_Install' ),
+			array( 'GFPDF\Model\Model_PDF', 'Model_PDF' ),
+			array( 'GFPDF\Model\Model_Settings', 'Model_Settings' ),
+			array( 'GFPDF\Model\Model_Shortcodes', 'Model_Shortcodes' ),
+			array( 'GFPDF\Model\Model_Welcome_Screen', 'Model_Welcome_Screen' ),
+			array( 'GFPDF\View\View_Actions', 'View_Actions' ),
+			array( 'GFPDF\View\View_Form_Settings', 'View_Form_Settings' ),
+			array( 'GFPDF\View\View_PDF', 'View_PDF' ),
+			array( 'GFPDF\View\View_Settings', 'View_Settings' ),
+			array( 'GFPDF\View\View_Shortcodes', 'View_Shortcodes' ),
+			array( 'GFPDF\View\View_Welcome_Screen', 'View_Welcome_Screen' ),
+		);
+	}
+
+	/**
+	 * Check that we can correctly remove actions / filters using the singleton classes
+	 *
+	 * @since 4.0
+	 */
+	public function test_remove_actions_filters() {
+		global $gfpdf;
+
+		$singleton = $gfpdf->singleton;
+
+		$actions = $singleton->get_class( 'Controller_Actions' );
+
+		/* Verify action exists */
+		$this->assertEquals( 10, has_action( 'admin_init', array( $actions, 'route' ) ) );
+
+		/* Remove the action */
+		remove_action( 'admin_init', array( $actions, 'route' ) );
+
+		$this->assertFalse( has_action( 'admin_init', array( $actions, 'route' ) ) );
+	}
+}


### PR DESCRIPTION
We decided against making our MVC classes singletons themselves due to the problems this presented when doing so in an abstract way (http://stackoverflow.com/questions/8907460/php-5-3-abstract-singleton-class-and-childrens). 

Since we just need to provide access to the original objects we build a helper class that can be used to store and retrieve the classes when needed. This allowed an easier way for developers to interact with the original classes – the main reason is to allow the manipulation of actions/filters.

This PR effectively resolves #102 and #21.