### PR TITLE
Add warning system about insecure tmp directory

### DIFF
--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -167,6 +167,9 @@
 				/* Ensure the Gravity Forms settings navigation (Form Settings / Notifications / Confirmation) has the 'tab' URI stripped from it */
 				this.cleanupGFNavigation();
 
+				/* Run our direct PDF status check */
+				this.runPDFAccessCheck();
+
 				/* Run the appropriate settings page */
 				switch (this.getCurrentSettingsPage()) {
 					case 'General':
@@ -860,6 +863,46 @@
 					$(this).attr('href', href.replace(regex, ''));
 				});
 			};
+
+			/**
+			 * Do an AJAX call to verify a user is protected
+			 * @return void
+			 * @since 4.0
+			 */
+			this.runPDFAccessCheck = function() {
+				var $status = $('#gfpdf-direct-pdf-protection-check');
+
+				if( $status.length > 0 ) {
+					/* Do our AJAX call */
+
+					/* Add spinner */
+					var $spinner = $('<img alt="' + GFPDF.spinnerAlt + '" src="' + GFPDF.spinnerUrl + '" class="gfpdf-spinner" />');
+
+					/* Add our spinner */
+					$status.append($spinner);
+
+					/* Set up ajax data */
+					var data = {
+						'action': 'gfpdf_has_pdf_protection',
+						'nonce': $status.data('nonce'),
+					};
+
+					/* Do ajax call */
+					this.ajax(data, function(response) {
+
+						/* Remove our loading spinner */
+						$spinner.remove();
+
+						if( response === true ) {
+							/* enable our protected message */
+							$status.find('#gfpdf-direct-pdf-check-protected').show();
+						} else {
+							/* enable our unprotected message */
+							$status.find('#gfpdf-direct-pdf-check-unprotected').show();
+						}
+					} );
+				}
+			}
 
 			/**
 			 * Enable dynamic required fields on the Gravity Forms PDF Settings page

--- a/src/controller/Controller_Settings.php
+++ b/src/controller/Controller_Settings.php
@@ -195,6 +195,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		 */
 		add_action( 'wp_ajax_gfpdf_font_save', array( $this->model, 'save_font' ) );
 		add_action( 'wp_ajax_gfpdf_font_delete', array( $this->model, 'delete_font' ) );
+		add_action( 'wp_ajax_gfpdf_has_pdf_protection', array( $this->model, 'check_tmp_pdf_security' ) );
 
 	}
 

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -457,7 +457,7 @@ class Helper_Misc {
 	 *
 	 * @param  string $url The Url to convert
 	 *
-	 * @return string|object      Path on success or WP_Error on failure
+	 * @return string|boolean      Path on success or false on failure
 	 *
 	 * @since  4.0
 	 */
@@ -506,8 +506,64 @@ class Helper_Misc {
 		}
 
 		/* If we are here we couldn't locate the file */
+		return false;
+	}
 
-		return $url;
+	/**
+	 * Attempt to convert the current path to a URL
+	 *
+	 * @param  string $path The path to convert
+	 *
+	 * @return string|boolean      Url on success or false
+	 *
+	 * @since  4.0
+	 */
+	public function convert_path_to_url( $path ) {
+
+		/* If $url is empty we'll return early */
+		if ( trim( $path ) == false ) {
+			return $path;
+		}
+
+		/* Mostly we'll be accessing files in the upload directory, so attempt that first */
+		$upload = wp_upload_dir();
+
+		$try_url = str_replace( $upload['basedir'], $upload['baseurl'], $path );
+
+		if ( $try_url !== $path ) {
+			return $try_url;
+		}
+
+		/* If WP_CONTENT_DIR and WP_CONTENT_URL are set we'll try them */
+		if ( defined( 'WP_CONTENT_DIR' ) && defined( 'WP_CONTENT_URL' ) ) {
+			$try_url = str_replace( WP_CONTENT_DIR, WP_CONTENT_URL, $path );
+
+			if ( $try_url !== $path ) {
+				return $try_url;
+			}
+		}
+
+		/* Include our get_home_path functionality */
+		if ( ! function_exists( 'get_home_path' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		/* If that didn't work let's try use home_url() and get_home_path() */
+		$try_url = str_replace( get_home_path(), home_url(), $path );
+
+		if ( $try_url !== $path ) {
+			return $try_url;
+		}
+
+		/* If that didn't work let's try use site_url() and ABSPATH */
+		$try_url = str_replace( ABSPATH, site_url(), $path );
+
+		if ( $try_url !== $path ) {
+			return $try_url;
+		}
+
+		/* If we are here we couldn't locate the file */
+		return false;
 	}
 
 	/**

--- a/src/views/View_Settings.php
+++ b/src/views/View_Settings.php
@@ -277,6 +277,7 @@ class View_Settings extends Helper_Abstract_View {
 	public function add_tooltips( $tooltips ) {
 
 		$tooltips['pdf_status_wp_memory'] = '<h6>' . __( 'WP Memory Available', 'gravity-forms-pdf-extended' ) . '</h6>' . sprintf( __( 'Producing PDF documents is hard work and Gravity PDF requires more resources than most plugins. We strongly recommend you have at least 128MB, but you may need more.', 'gravity-forms-pdf-extended' ) );
+		$tooltips['pdf_protection']       = '<h6>' . __( 'Direct PDF Protection', 'gravity-forms-pdf-extended' ) . '</h6>' . sprintf( __( 'Apache and Litespeed servers automatically disable public access to the Gravity PDF temporary directory using a %s.htaccess%s file, but other web servers like Nginx do not support this feature. We will check if your PDFs are automatically protected, and let you know what you can do to protect your data if they are not.', 'gravity-forms-pdf-extended' ), '<code>', '</code>', '<code>', '</code>' );
 
 		return apply_filters( 'gravitypdf_registered_tooltips', $tooltips );
 	}

--- a/src/views/html/Settings/system_status.php
+++ b/src/views/html/Settings/system_status.php
@@ -7,6 +7,8 @@
  * @copyright   Copyright (c) 2015, Blue Liquid Designs
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since       4.0
+ *
+ * @todo Include correct link to the documentation about the tmp directory filter
  */
 
 /* Exit if accessed directly */
@@ -103,6 +105,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<td>
 			<?php echo $args['php']; ?>
+		</td>
+	</tr>
+
+	<tr>
+		<th scope="row">
+			<?php _e( 'Direct PDF Protection', 'gravity-forms-pdf-extended' ); ?> <?php gform_tooltip( 'pdf_protection' ); ?>
+		</th>
+
+		<td>
+
+			<!-- A placeholder for our JS which will do the check for us, thereby preventing any load time by checking in PHP directly -->
+			<div id="gfpdf-direct-pdf-protection-check" data-nonce="<?php echo wp_create_nonce( 'gfpdf-direct-pdf-protection' ); ?>">
+				<noscript><?php _e( 'You need JavaScript enabled to perform this check.', 'gravity-forms-pdf-extended' ); ?></noscript>
+
+				<div id="gfpdf-direct-pdf-check-protected" style="display: none">
+					Protected <span class="fa fa-check-circle"></span>
+				</div>
+
+				<div id="gfpdf-direct-pdf-check-unprotected" style="display: none">
+					<strong>Unprotected</strong> <span class="fa fa-times-circle"></span>
+
+					<span class="gf_settings_description">
+						We've detected the PDFs saved in Gravity PDF's <code>tmp</code> directory can be publically accessed.<br>
+						We recommend you use our <code>gfpdf_tmp_location</code> filter to <a href="#">move the directory outside your public website directory</a>.
+					</span>
+				</div>
+			</div>
 		</td>
 	</tr>
 

--- a/tests/phpunit/unit-tests/test-ajax.php
+++ b/tests/phpunit/unit-tests/test-ajax.php
@@ -434,4 +434,55 @@ class Test_PDF_Ajax extends WP_Ajax_UnitTestCase {
 
 		$this->assertEquals( 'Could not delete Gravity PDF font correctly. Please try again.', $response['error'] );
 	}
+
+	/**
+	 * Test our security has been implimented correctly
+	 *
+	 * @class Model_Settings
+	 *
+	 * @since 4.0
+	 */
+	public function test_check_tmp_pdf_security() {
+
+		/**
+		 * Check for authentication failure
+		 */
+		try {
+			$this->_handleAjax( 'gfpdf_has_pdf_protection' );
+		} catch ( WPAjaxDieStopException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$this->assertEquals( '401', $e->getMessage() );
+
+		/* set up our role */
+		$this->_setRole( 'administrator' );
+
+		/**
+		 * Check for nonce failure
+		 */
+		try {
+			$this->_handleAjax( 'gfpdf_has_pdf_protection' );
+		} catch ( WPAjaxDieStopException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$this->assertEquals( '401', $e->getMessage() );
+
+		/*
+		 * Do successful test
+		 */
+		$_POST['nonce'] = wp_create_nonce( 'gfpdf-direct-pdf-protection' );
+
+		try {
+			$this->_handleAjax( 'gfpdf_has_pdf_protection' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		unset( $this->_last_response );
+
+		$this->assertTrue( $response );
+	}
 }


### PR DESCRIPTION
Non Apache systems aren't protected because they don't support .htaccess. Add a notice about it in the system status when this is detected and link to our documentation on how to move the tmp directory to a non-public directory. Used AJAX to prevent page loading problems.

Resolves #97 
Resolves #28 