### PR TITLE
Include our default template styles with our in-browser HTML viewer.

### DIFF
--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -192,6 +192,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		/* Pre-process our template arguments and automatically render them in PDF */
 		add_filter( 'gfpdf_template_args', array( $this->model, 'preprocess_template_arguments' ) );
 		add_filter( 'gfpdf_mpdf_init_class', array( $this->view, 'autoprocess_core_template_options' ), 10, 3 );
+		add_filter( 'gfpdf_pre_html_browser_output', array( $this->view, 'show_core_html_template_on_display' ), 10, 2 );
 	}
 
 	/**

--- a/src/helper/Helper_PDF.php
+++ b/src/helper/Helper_PDF.php
@@ -722,7 +722,7 @@ class Helper_PDF {
 	/**
 	 * Allow site admins to view the RAW HTML if needed
 	 *
-	 * @param  string $html The HTML that should be output to the browser
+	 * @param string $html The HTML that should be output to the browser
 	 *
 	 * @return void
 	 *
@@ -731,7 +731,7 @@ class Helper_PDF {
 	protected function maybe_display_raw_html( $html ) {
 
 		if ( $this->output !== 'SAVE' && rgget( 'html' ) && $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
-			echo $html;
+			echo apply_filters( 'gfpdf_pre_html_browser_output', $html, $this->settings );
 			exit;
 		}
 	}

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -515,9 +515,36 @@ class View_PDF extends Helper_Abstract_View {
 			return $mpdf;
 		}
 
-		$html = $this->load( 'core_template_styles', array( 'settings' => $settings ), false );
+		$html = $this->load_core_template_styles( $settings );
 		$mpdf->WriteHTML( $html );
 
 		return $mpdf;
+	}
+
+	/**
+	 * Load our core PDF template settings
+	 *
+	 * @param $settings
+	 *
+	 * @return string|\WP_Error
+	 *
+	 * @since 4.0
+	 */
+	public function load_core_template_styles( $settings ) {
+		return $this->load( 'core_template_styles', array( 'settings' => $settings ), false );
+	}
+
+	/**
+	 * @param string $html The current HTML
+	 * @param array $settings The current PDF settings
+	 *
+	 * @return string
+	 *
+	 * @since 4.0
+	 */
+	public function show_core_html_template_on_display( $html, $settings ) {
+		$core_template_html = $this->load_core_template_styles( $settings );
+
+		return $html . $core_template_html;
 	}
 }

--- a/src/view/html/PDF/core_template_styles.php
+++ b/src/view/html/PDF/core_template_styles.php
@@ -163,26 +163,34 @@ $include_product_styles     = apply_filters( 'gfpdf_include_product_styles', tru
 
 </style>
 
-<htmlpageheader name="TemplateFirstHeader">
-	<div id="first_header">
-		<?php echo $first_header; ?>
-	</div>
-</htmlpageheader>
+<?php if ( ! empty($first_header) ) : ?>
+	<htmlpageheader name="TemplateFirstHeader">
+		<div id="first_header">
+			<?php echo $first_header; ?>
+		</div>
+	</htmlpageheader>
+<?php endif; ?>
 
-<htmlpageheader name="TemplateHeader">
-	<div id="header">
-		<?php echo $header; ?>
-	</div>
-</htmlpageheader>
+<?php if ( ! empty($header) ) : ?>
+	<htmlpageheader name="TemplateHeader">
+		<div id="header">
+			<?php echo $header; ?>
+		</div>
+	</htmlpageheader>
+<?php endif; ?>
 
-<htmlpagefooter name="TemplateFirstFooter">
-	<div id="first_footer">
-		<?php echo $first_footer; ?>
-	</div>
-</htmlpagefooter>
+<?php if ( ! empty($first_footer) ) : ?>
+	<htmlpagefooter name="TemplateFirstFooter">
+		<div id="first_footer">
+			<?php echo $first_footer; ?>
+		</div>
+	</htmlpagefooter>
+<?php endif; ?>
 
-<htmlpagefooter name="TemplateFooter">
-	<div class="footer">
-		<?php echo $footer; ?>
-	</div>
-</htmlpagefooter>
+<?php if ( ! empty($footer) ) : ?>
+	<htmlpagefooter name="TemplateFooter">
+		<div class="footer">
+			<?php echo $footer; ?>
+		</div>
+	</htmlpagefooter>
+<?php endif; ?>


### PR DESCRIPTION
Currently the template HTML and the default styles just returned together (after the closing `</html>` tag) but in future it would be good to insert it after the opening `<body>` tag (need to replace querypath library first though - probably use Symphony).

Fixes #147 

