### PR TITLE
Fix header/footer manual display issue

### DIFF
--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -193,8 +193,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Pre-process our template arguments and automatically render them in PDF */
 		add_filter( 'gfpdf_template_args', array( $this->model, 'preprocess_template_arguments' ) );
-		add_filter( 'gfpdf_mpdf_init_class', array( $this->view, 'autoprocess_core_template_options' ), 10, 3 );
-		add_filter( 'gfpdf_pre_html_browser_output', array( $this->view, 'show_core_html_template_on_display' ), 10, 3 );
+		add_filter( 'gfpdf_pdf_html_output', array( $this->view, 'autoprocess_core_template_options' ), 5, 4 );
 	}
 
 	/**

--- a/src/helper/Helper_PDF.php
+++ b/src/helper/Helper_PDF.php
@@ -517,7 +517,10 @@ class Helper_PDF {
 	protected function begin_pdf() {
 		$this->mpdf = new mPDF( '', $this->paper_size, 0, '', 15, 15, 16, 16, 9, 9, $this->orientation );
 
-		/* allow $mpdf object class to be modified */
+		/**
+		 * Allow $mpdf object class to be modified
+		 * Note: in some circumstances using WriteHTML() during this filter will break headers/footers
+		 */
 		$this->mpdf = apply_filters( 'gfpdf_mpdf_init_class', $this->mpdf, $this->entry, $this->settings, $this );
 	}
 

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -515,24 +515,18 @@ class View_PDF extends Helper_Abstract_View {
 	}
 
 	/**
-	 * Automatically render our core PDF fields, a styles in templates to simplify there usage for users
+	 * Automatically render our core PDF fields and add styles in templates to simplify there usage for users
 	 *
-	 * @param  \mPDF $mpdf     The mPDF object
-	 * @param  array $entry    The Gravity Form entry being processed
-	 * @param  array $settings The current PDF settings
+	 * @param  string $html The current HTML template being processed
+	 * @param  array  $form
+	 * @param  array  $entry
+	 * @param  array  $settings
 	 *
-	 * @return \mPDF
-	 *
+	 * @return string
 	 * @since 4.0
 	 */
-	public function autoprocess_core_template_options( $mpdf, $entry, $settings ) {
-		if ( ! $mpdf instanceof mPDF ) {
-			return $mpdf;
-		}
-
-		$mpdf->WriteHTML( $this->get_core_template_styles( $settings, $entry ) );
-
-		return $mpdf;
+	public function autoprocess_core_template_options( $html, $form, $entry, $settings ) {
+		return $this->get_core_template_styles( $settings, $entry ) . $html;
 	}
 
 	/**
@@ -574,22 +568,5 @@ class View_PDF extends Helper_Abstract_View {
 		$settings = $args['settings'];
 
 		return $this->load( 'core_template_styles', array( 'settings' => $settings ), false );
-	}
-
-	/**
-	 * Ensures our autoloaded core HTML gets displayed with the template HTML
-	 *
-	 * @param string $html     The current HTML
-	 * @param array  $settings The current PDF settings
-	 * @param array  $entry    The Gravity Form entry
-	 *
-	 * @return string
-	 *
-	 * @since 4.0
-	 */
-	public function show_core_html_template_on_display( $html, $settings, $entry ) {
-		$core_template_html = $this->get_core_template_styles( $settings, $entry );
-
-		return $html . $core_template_html;
 	}
 }

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -193,7 +193,7 @@ class Test_PDF extends WP_UnitTestCase {
 			$this->model,
 			'preprocess_template_arguments',
 		) ) );
-		$this->assertSame( 10, has_filter( 'gfpdf_mpdf_init_class', array(
+		$this->assertSame( 5, has_filter( 'gfpdf_pdf_html_output', array(
 			$this->view,
 			'autoprocess_core_template_options',
 		) ) );


### PR DESCRIPTION
This issue was caused because we were writing our core styles (which includes header/footer details) to the PDF before our template. This caused the software to create a new page (with no header/footer). The solution was to write the styles at the same time.

This may create a regression with v3 templates and we'll need to get a close eye for any issues.

Fixes #206