### PR TITLE
Refine the template markup

### DIFF
--- a/initialisation/template.css
+++ b/initialisation/template.css
@@ -57,7 +57,8 @@ h2.default, h3 {
 .no-style h3,
 .no-style .entry-view-html-value,
 .no-style .entry-view-section-break-content,
-.no-style .gfpdf-section-description {
+.no-style .gfpdf-section-description,
+.no-style .even {
     background: none;
     border: none;
 }

--- a/src/templates/blank-slate.php
+++ b/src/templates/blank-slate.php
@@ -20,242 +20,221 @@ if ( ! class_exists( 'GFForms' ) ) {
  *
  * $form (The current Gravity Form array)
  * $entry (The raw entry data)
- * $lead (alias of $entry)
  * $form_data (The processed entry data stored in an array)
  * $settings (the current PDF configuration)
  * $gfpdf (the main Gravity PDF object containing all our helper classes)
  * $args (contains an array of all variables - the ones being described right now - passed to the template)
- *
- * The following variables are avaliable for backwards compatibility purposes:
- *
- * $form_id (the current form ID)
- * $lead_ids (an array of the selected entries)
- * $lead_id (the current entry ID)
- *
- * To see the variable structure add "var_dump($variable); exit;" to your PDF template and view in your browser
  */
 
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
+<!-- Include styles needed for the PDF -->
+<style>
 
-    <style>
+    /* Handle Gravity Forms CSS Ready Classes */
+    .row-separator {
+        clear: both;
+        padding: 1.25mm 0;
+    }
 
-        /* Handle Gravity Forms CSS Ready Classes */
-        .row-separator {
-            clear: both;
-            padding: 1.25mm 0;
-        }
+    .gf_left_half,
+    .gf_left_third, .gf_middle_third,
+    .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
+        float: left;
+    }
 
-        .gf_left_half,
-        .gf_left_third, .gf_middle_third,
-        .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
-            float: left;
-        }
+    .gf_right_half,
+    .gf_right_third {
+        float: right;
+    }
 
-        .gf_right_half,
-        .gf_right_third {
-            float: right;
-        }
+    .gf_left_half, .gf_right_half,
+    .gf_list_2col li {
+        width: 49%;
+    }
 
-        .gf_left_half, .gf_right_half,
-        .gf_list_2col li {
-            width: 49%;
-        }
+    .gf_left_third, .gf_middle_third, .gf_right_third,
+    .gf_list_3col li {
+        width: 32.3%;
+    }
 
-        .gf_left_third, .gf_middle_third, .gf_right_third,
-        .gf_list_3col li {
-            width: 32.3%;
-        }
+    .gf_list_4col li {
+        width: 24%;
+    }
 
-        .gf_list_4col li {
-            width: 24%;
-        }
+    .gf_list_5col li {
+        width: 19%;
+    }
 
-        .gf_list_5col li {
-            width: 19%;
-        }
+    .gf_left_half, .gf_right_half {
+        padding-right: 1%;
+    }
 
-        .gf_left_half, .gf_right_half {
-            padding-right: 1%;
-        }
+    .gf_left_third, .gf_middle_third, .gf_right_third {
+        padding-right: 1.505%;
+    }
 
-        .gf_left_third, .gf_middle_third, .gf_right_third {
-            padding-right: 1.505%;
-        }
+    .gf_right_half, .gf_right_third {
+        padding-right: 0;
+    }
 
-        .gf_right_half, .gf_right_third {
-            padding-right: 0;
-        }
+    /* Don't double float the list items if already floated (mPDF does not support this ) */
+    .gf_left_half li, .gf_right_half li,
+    .gf_left_third li, .gf_middle_third li, .gf_right_third li {
+        width: 100% !important;
+        float: none !important;
+    }
 
-        /* Don't double float the list items if already floated (mPDF does not support this ) */
-        .gf_left_half li, .gf_right_half li,
-        .gf_left_third li, .gf_middle_third li, .gf_right_third li {
-            width: 100% !important;
-            float: none !important;
-        }
+    /**
+     * Headings
+     */
+    h3 {
+        margin: 1.5mm 0 0.5mm;
+        padding: 0;
+    }
 
-        /**
-         * Headings
-         */
-        h3 {
-            margin: 1.5mm 0 0.5mm;
-            padding: 0;
-        }
+    /**
+     * Quiz Style Support
+     */
+    .gquiz-field {
+        color: #666;
+    }
 
-        /**
-         * Quiz Style Support
-         */
-        .gquiz-field {
-            color: #666;
-        }
+    .gquiz-correct-choice {
+        font-weight: bold;
+        color: black;
+    }
 
-        .gquiz-correct-choice {
-            font-weight: bold;
-            color: black;
-        }
+    .gf-quiz-img {
+        padding-left: 5px !important;
+        vertical-align: middle;
+    }
 
-        .gf-quiz-img {
-            padding-left: 5px !important;
-            vertical-align: middle;
-        }
+    /**
+     * Survey Style Support
+     */
+    .gsurvey-likert-choice-label {
+        padding: 4px;
+    }
 
-        /**
-         * Survey Style Support
-         */
-        .gsurvey-likert-choice-label {
-            padding: 4px;
-        }
+    .gsurvey-likert-choice, .gsurvey-likert-choice-label {
+        text-align: center;
+    }
 
-        .gsurvey-likert-choice, .gsurvey-likert-choice-label {
-            text-align: center;
-        }
+    /**
+     * Table Support
+     */
+    th, td {
+        font-size: 9pt;
+    }
 
-        /**
-         * Table Support
-         */
-        th, td {
-            font-size: 9pt;
-        }
+    /**
+     * List Support
+     */
+    ul, ol {
+        margin: 0;
+        padding-left: 1mm;
+        padding-right: 1mm;
+    }
 
-        /**
-         * List Support
-         */
-        ul, ol {
-            margin: 0;
-            padding-left: 1mm;
-            padding-right: 1mm;
-        }
+    li {
+        margin: 0;
+        padding: 0;
+        list-style-position: inside;
+    }
 
-        li {
-            margin: 0;
-            padding: 0;
-            list-style-position: inside;
-        }
+    /**
+     * Header / Footer
+     */
+    .alignleft {
+        float: left;
+    }
 
-        /**
-         * Header / Footer
-         */
-        .alignleft {
-            float: left;
-        }
+    .alignright {
+        float: right;
+    }
 
-        .alignright {
-            float: right;
-        }
+    .aligncenter {
+        text-align: center;
+    }
 
-        .aligncenter {
-            text-align: center;
-        }
+    p.alignleft {
+        text-align: left;
+        float: none;
+    }
 
-        p.alignleft {
-            text-align: left;
-            float: none;
-        }
+    p.alignright {
+        text-align: right;
+        float: none;
+    }
 
-        p.alignright {
-            text-align: right;
-            float: none;
-        }
+    /**
+     * Independant Template Styles
+     */
+    .row-separator .gfpdf-field {
+        margin-bottom: 10px;
+    }
 
-        /**
-         * Independant Template Styles
-         */
-        .row-separator .gfpdf-field {
-            margin-bottom: 10px;
-        }
+    #form_title {
+        margin: 0;
+        font-size: 150%;
+    }
 
-        #form_title {
-            margin: 0;
-            font-size: 150%;
-        }
+    .product-field-title {
+        margin: 0;
+    }
 
-        .product-field-title {
-            margin: 0;
-        }
+    .gfpdf-field .label {
+       padding-bottom: 5px;
+    }
 
-        .gfpdf-field .label {
-           padding-bottom: 5px;
-        }
+    .gfpdf-field .value {
 
-        .gfpdf-field .value {
+    }
 
-        }
+    .gfield_list th, table.entry-products td.emptycell, table.entry-products th {
+        background: none;
+    }
 
-        .gfield_list th, table.entry-products td.emptycell, table.entry-products th {
-            background: none;
-        }
+</style>
 
-    </style>
+<!-- Output our HTML markup -->
+<?php
 
-</head>
-    <body>
+    /**
+     * Load our core-specific styles from our PDF settings which will be passed to the PDF template $config array
+     */
+    $show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] == 'Yes' )            ? true : false;
+    $show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' )            ? true : false;
+    $show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] == 'Yes' )                        ? true : false;
+    $show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' )  ? true : false;
+    $enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] == 'Yes' )      ? true : false;
+    $show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' )                      ? true : false;
 
-        <?php
+    /**
+     * Set up our configuration array to control what is and is not shown in the generated PDF
+     *
+     * @var array
+     */
+    $config = array(
+        'settings'  => $settings,
+        'meta'      => array(
+            'echo'                => true, /* whether to output the HTML or return it */
+            'exclude'             => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
+            'empty'               => $show_empty, /* whether to show empty fields or not. Default is false */
+            'conditional'         => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
+            'show_title'          => $show_form_title, /* whether we should show the form title. Default to true */
+            'section_content'     => $show_section_content, /* whether we should include a section breaks content. Default to false */
+            'page_names'          => $show_page_names, /* whether we should show the form's page names. Default to false */
+            'html_field'          => $show_html, /* whether we should show the form's html fields. Default to false */
+            'individual_products' => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        ),
+    );
 
-            /**
-             * Load our core-specific styles we'll pass to our $config array below which will control the display of certain fields in our Gravity Form
-             */
-            $show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] == 'Yes' )            ? true : false;
-            $show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' )            ? true : false;
-            $show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] == 'Yes' )                        ? true : false;
-            $show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' )  ? true : false;
-            $enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] == 'Yes' )      ? true : false;
-            $show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' )                      ? true : false;
-
-            /**
-             * Set up our configuration array to control what is and is not generated
-             * @var array
-             */
-            $config = array(
-                'settings'  => $settings,
-                'meta'      => array(
-                    'echo'                => true, /* whether to output the HTML or return it */
-                    'exclude'             => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
-                    'empty'               => $show_empty, /* whether to show empty fields or not. Default is false */
-                    'conditional'         => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
-                    'show_title'          => $show_form_title, /* whether we should show the form title. Default to true */
-                    'section_content'     => $show_section_content, /* whether we should include a section breaks content. Default to false */
-                    'page_names'          => $show_page_names, /* whether we should show the form's page names. Default to false */
-                    'html_field'          => $show_html, /* whether we should show the form's html fields. Default to false */
-                    'individual_products' => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
-                ),
-            );
-
-            /**
-             * Generate our HTML markup
-             *
-             * Gravity PDF uses PHP Namespaces to structure its codebase.
-             *
-             * To keep it simplier for users the PDF template files are in PHP's global namespace, which means you have easy access to all PHP and WordPress' core classes.
-             *
-             * You can access Gravity PDFs common functions and classes through our API wrapper class "GPDFAPI", or use the full namespaces to references classes (GFPDF\View\View_PDF or GFPDF\Model\Model_PDF)
-             */
-            $pdf = GPDFAPI::get_pdf_class();
-            $pdf->process_html_structure( $entry, GPDFAPI::get_pdf_class( 'model' ), $config );
-
-        ?>
-    </body>
-</html>
+    /**
+     * Generate our HTML markup
+     *
+     * You can access Gravity PDFs common functions and classes through our API wrapper class "GPDFAPI"
+     */
+    $pdf = GPDFAPI::get_pdf_class();
+    $pdf->process_html_structure( $entry, GPDFAPI::get_pdf_class( 'model' ), $config );

--- a/src/templates/focus-gravity.php
+++ b/src/templates/focus-gravity.php
@@ -20,19 +20,10 @@ if ( ! class_exists('GFForms')) {
  *
  * $form (The current Gravity Form array)
  * $entry (The raw entry data)
- * $lead (alias of $entry)
  * $form_data (The processed entry data stored in an array)
  * $settings (the current PDF configuration)
  * $gfpdf (the main Gravity PDF object containing all our helper classes)
  * $args (contains an array of all variables - the ones being described right now - passed to the template)
- *
- * The following variables are avaliable for backwards compatibility purposes:
- *
- * $form_id (the current form ID)
- * $lead_ids (an array of the selected entries)
- * $lead_id (the current entry ID)
- *
- * To see the variable structure add "var_dump($variable); exit;" to your PDF template and view in your browser
  */
 
 /**
@@ -47,224 +38,219 @@ $label_format              = ( ! empty($settings['focusgravity_label_format'])) 
 
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
+<!-- Include styles needed for the PDF -->
+<style>
 
-    <style>
+    /* Handle Gravity Forms CSS Ready Classes */
+    .row-separator {
+        clear: both;
+    }
 
-        /* Handle Gravity Forms CSS Ready Classes */
-        .row-separator {
-            clear: both;
-        }
+    .gf_left_half,
+    .gf_left_third, .gf_middle_third,
+    .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
+        float: left;
+    }
 
-        .gf_left_half,
-        .gf_left_third, .gf_middle_third,
-        .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
-            float: left;
-        }
+    .gf_right_half,
+    .gf_right_third {
+        float: right;
+    }
 
-        .gf_right_half,
-        .gf_right_third {
-            float: right;
-        }
+    .gf_left_half, .gf_right_half,
+    .gf_list_2col li {
+        width: 49%;
+    }
 
-        .gf_left_half, .gf_right_half,
-        .gf_list_2col li {
-            width: 49%;
-        }
+    .gf_left_third, .gf_middle_third, .gf_right_third,
+    .gf_list_3col li {
+        width: 32.3%;
+    }
 
-        .gf_left_third, .gf_middle_third, .gf_right_third,
-        .gf_list_3col li {
-            width: 32.3%;
-        }
+    .gf_list_4col li {
+        width: 24%;
+    }
 
-        .gf_list_4col li {
-            width: 24%;
-        }
+    .gf_list_5col li {
+        width: 19%;
+    }
 
-        .gf_list_5col li {
-            width: 19%;
-        }
+    .gf_left_half, .gf_right_half {
+        padding-right: 1%;
+    }
 
-        .gf_left_half, .gf_right_half {
-            padding-right: 1%;
-        }
+    .gf_left_third, .gf_middle_third, .gf_right_third {
+        padding-right: 1.505%;
+    }
 
-        .gf_left_third, .gf_middle_third, .gf_right_third {
-            padding-right: 1.505%;
-        }
+    .gf_right_half, .gf_right_third {
+        padding-right: 0;
+    }
 
-        .gf_right_half, .gf_right_third {
-            padding-right: 0;
-        }
+    /* Don't double float the list items if already floated (mPDF does not support this ) */
+    .gf_left_half li, .gf_right_half li,
+    .gf_left_third li, .gf_middle_third li, .gf_right_third li {
+        width: 100% !important;
+        float: none !important;
+    }
 
-        /* Don't double float the list items if already floated (mPDF does not support this ) */
-        .gf_left_half li, .gf_right_half li,
-        .gf_left_third li, .gf_middle_third li, .gf_right_third li {
-            width: 100% !important;
-            float: none !important;
-        }
+    /**
+     * Headings
+     */
+    h3 {
+        margin: 1.5mm 0 0.5mm;
+        padding: 0;
+    }
 
-        /**
-         * Headings
-         */
-        h3 {
-            margin: 1.5mm 0 0.5mm;
-            padding: 0;
-        }
+    /**
+     * Quiz Style Support
+     */
+    .gquiz-field {
+        color: #666;
+    }
 
-        /**
-         * Quiz Style Support
-         */
-        .gquiz-field {
-            color: #666;
-        }
+    .gquiz-correct-choice {
+        font-weight: bold;
+        color: black;
+    }
 
-        .gquiz-correct-choice {
-            font-weight: bold;
-            color: black;
-        }
+    .gf-quiz-img {
+        padding-left: 5px !important;
+        vertical-align: middle;
+    }
 
-        .gf-quiz-img {
-            padding-left: 5px !important;
-            vertical-align: middle;
-        }
+    /**
+     * Survey Style Support
+     */
+    .gsurvey-likert-choice-label {
+        padding: 4px;
+    }
 
-        /**
-         * Survey Style Support
-         */
-        .gsurvey-likert-choice-label {
-            padding: 4px;
-        }
+    .gsurvey-likert-choice, .gsurvey-likert-choice-label {
+        text-align: center;
+    }
 
-        .gsurvey-likert-choice, .gsurvey-likert-choice-label {
-            text-align: center;
-        }
+    /**
+     * Table Support
+     */
+    th, td {
+        font-size: 95%;
+    }
 
-        /**
-         * Table Support
-         */
-        th, td {
-            font-size: 95%;
-        }
+    /**
+     * List Support
+     */
+    ul, ol {
+        margin: 0;
+        padding-left: 1mm;
+        padding-right: 1mm;
+    }
 
-        /**
-         * List Support
-         */
-        ul, ol {
-            margin: 0;
-            padding-left: 1mm;
-            padding-right: 1mm;
-        }
+    li {
+        margin: 0;
+        padding: 0;
+        list-style-position: inside;
+    }
 
-        li {
-            margin: 0;
-            padding: 0;
-            list-style-position: inside;
-        }
+    /**
+     * Header / Footer
+     */
+    .alignleft {
+        float: left;
+    }
 
-        /**
-         * Header / Footer
-         */
-        .alignleft {
-            float: left;
-        }
+    .alignright {
+        float: right;
+    }
 
-        .alignright {
-            float: right;
-        }
+    .aligncenter {
+        text-align: center;
+    }
 
-        .aligncenter {
-            text-align: center;
-        }
+    p.alignleft {
+        text-align: left;
+        float: none;
+    }
 
-        p.alignleft {
-            text-align: left;
-            float: none;
-        }
+    p.alignright {
+        text-align: right;
+        float: none;
+    }
 
-        p.alignright {
-            text-align: right;
-            float: none;
-        }
+    /**
+     * Independant Template Styles
+     */
+    #container {
+        border-radius: 5px;
+        border: 1px solid <?php echo $accent_colour; ?>;
+    }
 
-        /**
-         * Independant Template Styles
-         */
-        #container {
-            border-radius: 5px;
-            border: 1px solid <?php echo $accent_colour; ?>;
-        }
+    #form_title {
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
+    }
 
-        #form_title {
-            border-top-left-radius: 3px;
-            border-top-right-radius: 3px;
-        }
+    h3 {
+        background: <?php echo $accent_colour; ?>;
+        color: <?php echo $accent_contrast_colour; ?>;
+        margin: 0;
+    }
 
-        h3 {
-            background: <?php echo $accent_colour; ?>;
-            color: <?php echo $accent_contrast_colour; ?>;
-            margin: 0;
-        }
+    .gfpdf-page {
+        border-top: 1px solid #FFF;
+    }
 
-        .gfpdf-page {
-            border-top: 1px solid #FFF;
-        }
+    .gfpdf-field .label {
+        font-weight: bold;
+        border-bottom: 1px solid <?php echo $accent_colour; ?>;
+        background: <?php echo $secondary_colour; ?>;
+        color: <?php echo $secondary_contrast_colour; ?>;
+    }
 
+    .gfpdf-field .value, .gfpdf-section-description, .gfpdf-field .label, h3 {
+        padding: 7px 6px 7px 10px;
+    }
+
+    .gfpdf-html {
+        border-top: 5px solid <?php echo $secondary_colour; ?>;
+    }
+
+    table.gfield_list th {
+        background: <?php echo $accent_colour; ?>;
+        color: <?php echo $accent_contrast_colour; ?>;
+    }
+
+    table.entry-products th, table.entry-products td.emptycell {
+        background: none;
+    }
+
+    <?php if( $label_format == 'combined_label' ): ?>
         .gfpdf-field .label {
-            font-weight: bold;
-            border-bottom: 1px solid <?php echo $accent_colour; ?>;
-            background: <?php echo $secondary_colour; ?>;
-            color: <?php echo $secondary_contrast_colour; ?>;
-        }
-
-        .gfpdf-field .value, .gfpdf-section-description, .gfpdf-field .label, h3 {
-            padding: 7px 6px 7px 10px;
-        }
-
-        .gfpdf-html {
-            border-top: 5px solid <?php echo $secondary_colour; ?>;
-        }
-
-        table.gfield_list th {
-            background: <?php echo $accent_colour; ?>;
-            color: <?php echo $accent_contrast_colour; ?>;
-        }
-
-        table.entry-products th, table.entry-products td.emptycell {
             background: none;
+            border: none;
+            padding-bottom: 0;
         }
 
-        <?php if( $label_format == 'combined_label' ): ?>
-            .gfpdf-field .label {
-                background: none;
-                border: none;
-                padding-bottom: 0;
-            }
+        .gfpdf-field .value {
+            padding-top: 0;
+        }
 
-            .gfpdf-field .value {
-                padding-top: 0;
-            }
+        .even {
+            background: <?php echo $secondary_colour; ?>;
+        }
+    <?php else: ?>
+        .gfpdf-html .value {
+            border-top: 1px solid <?php echo $accent_colour; ?>;
+        }
+    <?php endif; ?>
 
-            .even {
-                background: <?php echo $secondary_colour; ?>;
-            }
-        <?php else: ?>
-            .gfpdf-html .value {
-                border-top: 1px solid <?php echo $accent_colour; ?>;
-            }
-        <?php endif; ?>
+</style>
 
-    </style>
-
-</head>
-<body>
-
+<!-- Output our HTML markup -->
 <?php
 
 /**
- * Load our core-specific styles we'll pass to our $config array below which will control the display of certain fields in our Gravity Form
+ * Load our core-specific styles from our PDF settings which will be passed to the PDF template $config array
  */
 $show_form_title      = ( ! empty($settings['show_form_title']) && $settings['show_form_title'] == 'Yes') ? true : false;
 $show_page_names      = ( ! empty($settings['show_page_names']) && $settings['show_page_names'] == 'Yes') ? true : false;
@@ -274,7 +260,7 @@ $enable_conditional   = ( ! empty($settings['enable_conditional']) && $settings[
 $show_empty           = ( ! empty($settings['show_empty']) && $settings['show_empty'] == 'Yes') ? true : false;
 
 /**
- * Set up our configuration array to control what is and is not generated
+ * Set up our configuration array to control what is and is not shown in the generated PDF
  *
  * @var array
  */
@@ -296,15 +282,8 @@ $config = array(
 /**
  * Generate our HTML markup
  *
- * Gravity PDF uses PHP Namespaces to structure its codebase.
- *
- * To keep it simplier for users the PDF template files are in PHP's global namespace, which means you have easy access to all PHP and WordPress' core classes.
- *
- * You can access Gravity PDFs common functions and classes through our API wrapper class "GPDFAPI", or use the full namespaces to references classes (GFPDF\View\View_PDF or GFPDF\Model\Model_PDF)
+ * You can access Gravity PDFs common functions and classes through our API wrapper class "GPDFAPI"
  */
 $pdf = GPDFAPI::get_pdf_class();
 $pdf->process_html_structure($entry, GPDFAPI::get_pdf_class('model'), $config);
 
-?>
-</body>
-</html>

--- a/src/templates/rubix.php
+++ b/src/templates/rubix.php
@@ -20,19 +20,10 @@ if ( ! class_exists('GFForms')) {
  *
  * $form (The current Gravity Form array)
  * $entry (The raw entry data)
- * $lead (alias of $entry)
  * $form_data (The processed entry data stored in an array)
  * $settings (the current PDF configuration)
  * $gfpdf (the main Gravity PDF object containing all our helper classes)
  * $args (contains an array of all variables - the ones being described right now - passed to the template)
- *
- * The following variables are avaliable for backwards compatibility purposes:
- *
- * $form_id (the current form ID)
- * $lead_ids (an array of the selected entries)
- * $lead_id (the current entry ID)
- *
- * To see the variable structure add "var_dump($variable); exit;" to your PDF template and view in your browser
  */
 
 /**
@@ -45,217 +36,212 @@ $contrast = $gfpdf->misc->get_background_and_border_contrast( $container_backgro
 
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
+<!-- Include styles needed for the PDF -->
+<style>
 
-    <style>
+    /* Handle Gravity Forms CSS Ready Classes */
+    .row-separator {
+        clear: both;
+    }
 
-        /* Handle Gravity Forms CSS Ready Classes */
-        .row-separator {
-            clear: both;
-        }
+    .gf_left_half,
+    .gf_left_third, .gf_middle_third,
+    .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
+        float: left;
+    }
 
-        .gf_left_half,
-        .gf_left_third, .gf_middle_third,
-        .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
-            float: left;
-        }
+    .gf_right_half,
+    .gf_right_third {
+        float: right;
+    }
 
-        .gf_right_half,
-        .gf_right_third {
-            float: right;
-        }
+    .gf_left_half, .gf_right_half,
+    .gf_list_2col li {
+        width: 49%;
+    }
 
-        .gf_left_half, .gf_right_half,
-        .gf_list_2col li {
-            width: 49%;
-        }
+    .gf_left_third, .gf_middle_third, .gf_right_third,
+    .gf_list_3col li {
+        width: 32.3%;
+    }
 
-        .gf_left_third, .gf_middle_third, .gf_right_third,
-        .gf_list_3col li {
-            width: 32.3%;
-        }
+    .gf_list_4col li {
+        width: 24%;
+    }
 
-        .gf_list_4col li {
-            width: 24%;
-        }
+    .gf_list_5col li {
+        width: 19%;
+    }
 
-        .gf_list_5col li {
-            width: 19%;
-        }
+    .gf_left_half, .gf_right_half {
+        padding-right: 1%;
+    }
 
-        .gf_left_half, .gf_right_half {
-            padding-right: 1%;
-        }
+    .gf_left_third, .gf_middle_third, .gf_right_third {
+        padding-right: 1.505%;
+    }
 
-        .gf_left_third, .gf_middle_third, .gf_right_third {
-            padding-right: 1.505%;
-        }
+    .gf_right_half, .gf_right_third {
+        padding-right: 0;
+    }
 
-        .gf_right_half, .gf_right_third {
-            padding-right: 0;
-        }
+    /* Don't double float the list items if already floated (mPDF does not support this ) */
+    .gf_left_half li, .gf_right_half li,
+    .gf_left_third li, .gf_middle_third li, .gf_right_third li {
+        width: 100% !important;
+        float: none !important;
+    }
 
-        /* Don't double float the list items if already floated (mPDF does not support this ) */
-        .gf_left_half li, .gf_right_half li,
-        .gf_left_third li, .gf_middle_third li, .gf_right_third li {
-            width: 100% !important;
-            float: none !important;
-        }
+    /**
+     * Headings
+     */
+    h3 {
+        margin: 1.5mm 0 0.5mm;
+        padding: 0;
+    }
 
-        /**
-         * Headings
-         */
-        h3 {
-            margin: 1.5mm 0 0.5mm;
-            padding: 0;
-        }
+    /**
+     * Quiz Style Support
+     */
+    .gquiz-field {
+        color: #666;
+    }
 
-        /**
-         * Quiz Style Support
-         */
-        .gquiz-field {
-            color: #666;
-        }
+    .gquiz-correct-choice {
+        font-weight: bold;
+        color: black;
+    }
 
-        .gquiz-correct-choice {
-            font-weight: bold;
-            color: black;
-        }
+    .gf-quiz-img {
+        padding-left: 5px !important;
+        vertical-align: middle;
+    }
 
-        .gf-quiz-img {
-            padding-left: 5px !important;
-            vertical-align: middle;
-        }
+    /**
+     * Survey Style Support
+     */
+    .gsurvey-likert-choice-label {
+        padding: 4px;
+    }
 
-        /**
-         * Survey Style Support
-         */
-        .gsurvey-likert-choice-label {
-            padding: 4px;
-        }
+    .gsurvey-likert-choice, .gsurvey-likert-choice-label {
+        text-align: center;
+    }
 
-        .gsurvey-likert-choice, .gsurvey-likert-choice-label {
-            text-align: center;
-        }
+    /**
+     * Table Support
+     */
+    th, td {
+        font-size: 95%;
+    }
 
-        /**
-         * Table Support
-         */
-        th, td {
-            font-size: 95%;
-        }
+    /**
+     * List Support
+     */
+    ul, ol {
+        margin: 0;
+        padding-left: 1mm;
+        padding-right: 1mm;
+    }
 
-        /**
-         * List Support
-         */
-        ul, ol {
-            margin: 0;
-            padding-left: 1mm;
-            padding-right: 1mm;
-        }
+    li {
+        margin: 0;
+        padding: 0;
+        list-style-position: inside;
+    }
 
-        li {
-            margin: 0;
-            padding: 0;
-            list-style-position: inside;
-        }
+    /**
+     * Header / Footer
+     */
+    .alignleft {
+        float: left;
+    }
 
-        /**
-         * Header / Footer
-         */
-        .alignleft {
-            float: left;
-        }
+    .alignright {
+        float: right;
+    }
 
-        .alignright {
-            float: right;
-        }
+    .aligncenter {
+        text-align: center;
+    }
 
-        .aligncenter {
-            text-align: center;
-        }
+    p.alignleft {
+        text-align: left;
+        float: none;
+    }
 
-        p.alignleft {
-            text-align: left;
-            float: none;
-        }
+    p.alignright {
+        text-align: right;
+        float: none;
+    }
 
-        p.alignright {
-            text-align: right;
-            float: none;
-        }
+    /**
+     * Independant Template Styles
+     */
+    #form_title {
+        text-align: center;
+        text-transform: uppercase;
+        font-size: 22px;
+    }
 
-        /**
-         * Independant Template Styles
-         */
-        #form_title {
-            text-align: center;
-            text-transform: uppercase;
-            font-size: 22px;
-        }
+    .row-separator {
+        margin-bottom: 15px;
+    }
 
-        .row-separator {
-            margin-bottom: 15px;
-        }
+    .gfpdf-page, .product-field-title {
+        margin-bottom: -13px;
+        margin-left: 10px;
+    }
 
-        .gfpdf-page, .product-field-title {
-            margin-bottom: -13px;
-            margin-left: 10px;
-        }
+    .gfpdf-field .inner-container {
+        background: <?php echo $container_background_color; ?>;
+        border-radius: 10px;
+    }
 
-        .gfpdf-field .inner-container {
-            background: <?php echo $container_background_color; ?>;
-            border-radius: 10px;
-        }
+    .gfpdf-field .label {
+        padding: 5px 10px 0;
+    }
 
-        .gfpdf-field .label {
-            padding: 5px 10px 0;
-        }
+    .gfpdf-field .value {
+        padding: 0 10px 5px;
+    }
 
-        .gfpdf-field .value {
-            padding: 0 10px 5px;
-        }
+    .gfpdf-products .inner-container,
+    div.gfpdf-html .value {
+        padding: 5px 10px;
+    }
 
-        .gfpdf-products .inner-container,
-        div.gfpdf-html .value {
-            padding: 5px 10px;
-        }
+    div.gfpdf-section-description .inner-container {
+        background: none;
+        border-radius: 0;
+    }
 
-        div.gfpdf-section-description .inner-container {
-            background: none;
-            border-radius: 0;
-        }
+    .gfpdf-section-title {
+        padding-left: 10px;
+    }
 
-        .gfpdf-section-title {
-            padding-left: 10px;
-        }
+    .gfpdf-section-title h3 {
+        margin-top: 0;
+        padding-top: 0;
+    }
 
-        .gfpdf-section-title h3 {
-            margin-top: 0;
-            padding-top: 0;
-        }
+    .gfield_list th,
+    table.entry-products th, table.entry-products td.emptycell {
+        background-color: <?php echo $contrast['background']; ?>;
+    }
 
-        .gfield_list th,
-        table.entry-products th, table.entry-products td.emptycell {
-            background-color: <?php echo $contrast['background']; ?>;
-        }
+    .gfield_list th, .gfield_list td,
+    table.entry-products th, table.entry-products td {
+        border: 1px solid <?php echo $contrast['border']; ?>;
+    }
 
-        .gfield_list th, .gfield_list td,
-        table.entry-products th, table.entry-products td {
-            border: 1px solid <?php echo $contrast['border']; ?>;
-        }
+</style>
 
-    </style>
-
-</head>
-<body>
-
+<!-- Output our HTML markup -->
 <?php
 
 /**
- * Load our core-specific styles we'll pass to our $config array below which will control the display of certain fields in our Gravity Form
+ * Load our core-specific styles from our PDF settings which will be passed to the PDF template $config array
  */
 $show_form_title      = ( ! empty($settings['show_form_title']) && $settings['show_form_title'] == 'Yes') ? true : false;
 $show_page_names      = ( ! empty($settings['show_page_names']) && $settings['show_page_names'] == 'Yes') ? true : false;
@@ -265,7 +251,7 @@ $enable_conditional   = ( ! empty($settings['enable_conditional']) && $settings[
 $show_empty           = ( ! empty($settings['show_empty']) && $settings['show_empty'] == 'Yes') ? true : false;
 
 /**
- * Set up our configuration array to control what is and is not generated
+ * Set up our configuration array to control what is and is not shown in the generated PDF
  *
  * @var array
  */
@@ -287,15 +273,7 @@ $config = array(
 /**
  * Generate our HTML markup
  *
- * Gravity PDF uses PHP Namespaces to structure its codebase.
- *
- * To keep it simplier for users the PDF template files are in PHP's global namespace, which means you have easy access to all PHP and WordPress' core classes.
- *
- * You can access Gravity PDFs common functions and classes through our API wrapper class "GPDFAPI", or use the full namespaces to references classes (GFPDF\View\View_PDF or GFPDF\Model\Model_PDF)
+ * You can access Gravity PDFs common functions and classes through our API wrapper class "GPDFAPI"
  */
 $pdf = GPDFAPI::get_pdf_class();
 $pdf->process_html_structure($entry, GPDFAPI::get_pdf_class('model'), $config);
-
-?>
-</body>
-</html>

--- a/src/templates/zadani.php
+++ b/src/templates/zadani.php
@@ -20,19 +20,10 @@ if ( ! class_exists( 'GFForms' ) ) {
  *
  * $form (The current Gravity Form array)
  * $entry (The raw entry data)
- * $lead (alias of $entry)
  * $form_data (The processed entry data stored in an array)
  * $settings (the current PDF configuration)
  * $gfpdf (the main Gravity PDF object containing all our helper classes)
  * $args (contains an array of all variables - the ones being described right now - passed to the template)
- *
- * The following variables are avaliable for backwards compatibility purposes:
- *
- * $form_id (the current form ID)
- * $lead_ids (an array of the selected entries)
- * $lead_id (the current entry ID)
- *
- * To see the variable structure add "var_dump($variable); exit;" to your PDF template and view in your browser
  */
 
 /**
@@ -42,218 +33,206 @@ $value_border_colour  = ( ! empty( $settings['zadani_border_colour']) ) ? $setti
 
 ?>
 
-<!DOCTYPE html>
-<html>
-<head>
+<!-- Include styles needed for the PDF -->
+<style>
 
-    <style>
+    /* Handle Gravity Forms CSS Ready Classes */
+    .row-separator {
+        clear: both;
+        padding: 1.25mm 0;
+    }
 
-        /* Handle Gravity Forms CSS Ready Classes */
-        .row-separator {
-            clear: both;
-            padding: 1.25mm 0;
-        }
+    .gf_left_half,
+    .gf_left_third, .gf_middle_third,
+    .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
+        float: left;
+    }
 
-        .gf_left_half,
-        .gf_left_third, .gf_middle_third,
-        .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
-            float: left;
-        }
+    .gf_right_half,
+    .gf_right_third {
+        float: right;
+    }
 
-        .gf_right_half,
-        .gf_right_third {
-            float: right;
-        }
+    .gf_left_half, .gf_right_half,
+    .gf_list_2col li {
+        width: 49%;
+    }
 
-        .gf_left_half, .gf_right_half,
-        .gf_list_2col li {
-            width: 49%;
-        }
+    .gf_left_third, .gf_middle_third, .gf_right_third,
+    .gf_list_3col li {
+        width: 32.3%;
+    }
 
-        .gf_left_third, .gf_middle_third, .gf_right_third,
-        .gf_list_3col li {
-            width: 32.3%;
-        }
+    .gf_list_4col li {
+        width: 24%;
+    }
 
-        .gf_list_4col li {
-            width: 24%;
-        }
+    .gf_list_5col li {
+        width: 19%;
+    }
 
-        .gf_list_5col li {
-            width: 19%;
-        }
+    .gf_left_half, .gf_right_half {
+        padding-right: 1%;
+    }
 
-        .gf_left_half, .gf_right_half {
-            padding-right: 1%;
-        }
+    .gf_left_third, .gf_middle_third, .gf_right_third {
+        padding-right: 1.505%;
+    }
 
-        .gf_left_third, .gf_middle_third, .gf_right_third {
-            padding-right: 1.505%;
-        }
+    .gf_right_half, .gf_right_third {
+        padding-right: 0;
+    }
 
-        .gf_right_half, .gf_right_third {
-            padding-right: 0;
-        }
+    /* Don't double float the list items if already floated (mPDF does not support this ) */
+    .gf_left_half li, .gf_right_half li,
+    .gf_left_third li, .gf_middle_third li, .gf_right_third li {
+        width: 100% !important;
+        float: none !important;
+    }
 
-        /* Don't double float the list items if already floated (mPDF does not support this ) */
-        .gf_left_half li, .gf_right_half li,
-        .gf_left_third li, .gf_middle_third li, .gf_right_third li {
-            width: 100% !important;
-            float: none !important;
-        }
+    /**
+     * Headings
+     */
+    h3 {
+        margin: 1.5mm 0 0.5mm;
+        padding: 0;
+    }
 
-        /**
-         * Headings
-         */
-        h3 {
-            margin: 1.5mm 0 0.5mm;
-            padding: 0;
-        }
+    /**
+     * Quiz Style Support
+     */
+    .gquiz-field {
+        color: #666;
+    }
 
-        /**
-         * Quiz Style Support
-         */
-        .gquiz-field {
-            color: #666;
-        }
+    .gquiz-correct-choice {
+        font-weight: bold;
+        color: black;
+    }
 
-        .gquiz-correct-choice {
-            font-weight: bold;
-            color: black;
-        }
+    .gf-quiz-img {
+        padding-left: 5px !important;
+        vertical-align: middle;
+    }
 
-        .gf-quiz-img {
-            padding-left: 5px !important;
-            vertical-align: middle;
-        }
+    /**
+     * Survey Style Support
+     */
+    .gsurvey-likert-choice-label {
+        padding: 4px;
+    }
 
-        /**
-         * Survey Style Support
-         */
-        .gsurvey-likert-choice-label {
-            padding: 4px;
-        }
+    .gsurvey-likert-choice, .gsurvey-likert-choice-label {
+        text-align: center;
+    }
 
-        .gsurvey-likert-choice, .gsurvey-likert-choice-label {
-            text-align: center;
-        }
+    /**
+     * Table Support
+     */
+    th, td {
+        font-size: 9pt;
+    }
 
-        /**
-         * Table Support
-         */
-        th, td {
-            font-size: 9pt;
-        }
+    /**
+     * List Support
+     */
+    ul, ol {
+        margin: 0;
+        padding-left: 1mm;
+        padding-right: 1mm;
+    }
 
-        /**
-         * List Support
-         */
-        ul, ol {
-            margin: 0;
-            padding-left: 1mm;
-            padding-right: 1mm;
-        }
+    li {
+        margin: 0;
+        padding: 0;
+        list-style-position: inside;
+    }
 
-        li {
-            margin: 0;
-            padding: 0;
-            list-style-position: inside;
-        }
+    /**
+     * Header / Footer
+     */
+    .alignleft {
+        float: left;
+    }
 
-        /**
-         * Header / Footer
-         */
-        .alignleft {
-            float: left;
-        }
+    .alignright {
+        float: right;
+    }
 
-        .alignright {
-            float: right;
-        }
+    .aligncenter {
+        text-align: center;
+    }
 
-        .aligncenter {
-            text-align: center;
-        }
+    p.alignleft {
+        text-align: left;
+        float: none;
+    }
 
-        p.alignleft {
-            text-align: left;
-            float: none;
-        }
+    p.alignright {
+        text-align: right;
+        float: none;
+    }
 
-        p.alignright {
-            text-align: right;
-            float: none;
-        }
+    /**
+     * Independant Template Styles
+     */
+    .gfpdf-field .label {
+        text-transform: uppercase;
+        font-size: 8pt;
+    }
 
-        /**
-         * Independant Template Styles
-         */
-        .gfpdf-field .label {
-            text-transform: uppercase;
-            font-size: 8pt;
-        }
+    .gfpdf-field .value {
+        border: 1px solid <?php echo $value_border_colour; ?>;
+        padding: 1.5mm 2mm;
+    }
 
-        .gfpdf-field .value {
-            border: 1px solid <?php echo $value_border_colour; ?>;
-            padding: 1.5mm 2mm;
-        }
+    .products-title-container, .products-container {
+        padding: 0;
+    }
 
-        .products-title-container, .products-container {
-            padding: 0;
-        }
+    .products-title-container h3 {
+        margin-bottom: -0.5mm;
+    }
 
-        .products-title-container h3 {
-            margin-bottom: -0.5mm;
-        }
+</style>
 
-    </style>
+<!-- Output our HTML markup -->
+<?php
 
-</head>
-    <body>
+    /**
+     * Load our core-specific styles from our PDF settings which will be passed to the PDF template $config array
+     */
+    $show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] == 'Yes' )            ? true : false;
+    $show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' )            ? true : false;
+    $show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] == 'Yes' )                        ? true : false;
+    $show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' )  ? true : false;
+    $enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] == 'Yes' )      ? true : false;
+    $show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' )                      ? true : false;
 
-        <?php
+    /**
+     * Set up our configuration array to control what is and is not shown in the generated PDF
+     *
+     * @var array
+     */
+    $config = array(
+        'settings'  => $settings,
+        'meta'      => array(
+            'echo'                => true, /* whether to output the HTML or return it */
+            'exclude'             => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
+            'empty'               => $show_empty, /* whether to show empty fields or not. Default is false */
+            'conditional'         => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
+            'show_title'          => $show_form_title, /* whether we should show the form title. Default to true */
+            'section_content'     => $show_section_content, /* whether we should include a section breaks content. Default to false */
+            'page_names'          => $show_page_names, /* whether we should show the form's page names. Default to false */
+            'html_field'          => $show_html, /* whether we should show the form's html fields. Default to false */
+            'individual_products' => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        ),
+    );
 
-            /**
-             * Load our core-specific styles we'll pass to our $config array below which will control the display of certain fields in our Gravity Form
-             */
-            $show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] == 'Yes' )            ? true : false;
-            $show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' )            ? true : false;
-            $show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] == 'Yes' )                        ? true : false;
-            $show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' )  ? true : false;
-            $enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] == 'Yes' )      ? true : false;
-            $show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' )                      ? true : false;
-
-            /**
-             * Set up our configuration array to control what is and is not generated
-             * @var array
-             */
-            $config = array(
-                'settings'  => $settings,
-                'meta'      => array(
-                    'echo'                => true, /* whether to output the HTML or return it */
-                    'exclude'             => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
-                    'empty'               => $show_empty, /* whether to show empty fields or not. Default is false */
-                    'conditional'         => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
-                    'show_title'          => $show_form_title, /* whether we should show the form title. Default to true */
-                    'section_content'     => $show_section_content, /* whether we should include a section breaks content. Default to false */
-                    'page_names'          => $show_page_names, /* whether we should show the form's page names. Default to false */
-                    'html_field'          => $show_html, /* whether we should show the form's html fields. Default to false */
-                    'individual_products' => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
-                ),
-            );
-
-            /**
-             * Generate our HTML markup
-             *
-             * Gravity PDF uses PHP Namespaces to structure its codebase.
-             *
-             * To keep it simplier for users the PDF template files are in PHP's global namespace, which means you have easy access to all PHP and WordPress' core classes.
-             *
-             * You can access Gravity PDFs common functions and classes through our API wrapper class "GPDFAPI", or use the full namespaces to references classes (GFPDF\View\View_PDF or GFPDF\Model\Model_PDF)
-             */
-            $pdf = GPDFAPI::get_pdf_class();
-            $pdf->process_html_structure( $entry, GPDFAPI::get_pdf_class( 'model' ), $config );
-
-        ?>
-    </body>
-</html>
+    /**
+     * Generate our HTML markup
+     *
+     * You can access Gravity PDFs common functions and classes through our API wrapper class "GPDFAPI"
+     */
+    $pdf = GPDFAPI::get_pdf_class();
+    $pdf->process_html_structure( $entry, GPDFAPI::get_pdf_class( 'model' ), $config );


### PR DESCRIPTION
We've stripped out all unnecessary markup from the PDF templates. We didn't need <body> or </html> tags (it just gets confusing for the end user). We also refined some of the comments.

Resolves #209

Remove note about backwards compatible variables