### PR TITLE
Remove the custom appearance HTML from the form when not supported

### DIFF
--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -686,8 +686,9 @@
 		      				self.doMergetags();
 
 		      			} else {
-							/* Hide our template nav item as there are no fields */
+							/* Hide our template nav item as there are no fields and clear our the HTML */
 		      				$('#gfpdf-custom-appearance-nav').hide();
+							$('#pdf-custom-appearance').html('');
 		      			}
 
 		      			/* Update our template example preview and display it */


### PR DESCRIPTION
This prevents issues saving the old PDF template settings.

Fixes #210