### PR TITLE
Consolidate the multisite path and url into a method in misc

### DIFF
--- a/src/depreciated.php
+++ b/src/depreciated.php
@@ -107,13 +107,11 @@ class GFPDF_Core extends GFPDF_Depreciated_Abstract {
 		}
 
 		if ( ! defined( 'PDF_TEMPLATE_LOCATION' ) ) {
-			$destination_path = ( is_multisite() ) ? $gfpdf->data->multisite_template_location : $gfpdf->data->template_location;
-			define( 'PDF_TEMPLATE_LOCATION', $destination_path );
+			define( 'PDF_TEMPLATE_LOCATION', $gfpdf->misc->get_template_path() );
 		}
 
 		if ( ! defined( 'PDF_TEMPLATE_URL_LOCATION' ) ) {
-			$destination_url = ( is_multisite() ) ? $gfpdf->data->multisite_template_location_url : $gfpdf->data->template_location_url;
-			define( 'PDF_TEMPLATE_URL_LOCATION', $destination_url );
+			define( 'PDF_TEMPLATE_URL_LOCATION', $gfpdf->misc->get_template_url() );
 		}
 	}
 
@@ -127,7 +125,7 @@ class GFPDF_Core extends GFPDF_Depreciated_Abstract {
 
 		$gfpdfe_data = $gfpdf->data;
 
-		$gfpdf->data->template_site_location = $gfpdf->data->template_location_url;
+		$gfpdf->data->template_site_location = $gfpdf->misc->get_template_url();
 		$gfpdf->data->template_save_location = $gfpdf->data->template_tmp_location;
 	}
 }

--- a/src/helper/Helper_Migration.php
+++ b/src/helper/Helper_Migration.php
@@ -177,13 +177,11 @@ class Helper_Migration {
 	 */
 	private function load_old_configuration() {
 
+		$path = $this->misc->get_template_path();
+
 		/* Import our configuration files */
-		if ( ! is_multisite() && is_file( $this->data->template_location . 'configuration.php' ) ) {
-			require_once( $this->data->template_location . 'configuration.php' );
-
-		} elseif ( is_multisite() && is_file( $this->data->multisite_template_location . 'configuration.php' ) ) {
-			require_once( $this->data->multisite_template_location . 'configuration.php' );
-
+		if ( is_file( $path . 'configuration.php' ) ) {
+			require_once( $path . 'configuration.php' );
 		} else {
 			throw new Exception( 'Could not locate v3 configuration file.' );
 		}
@@ -559,13 +557,10 @@ class Helper_Migration {
 	 * @since 4.0
 	 */
 	private function archive_v3_configuration() {
-		if ( ! is_multisite() && is_file( $this->data->template_location . 'configuration.php' ) ) {
-			@rename( $this->data->template_location . 'configuration.php', $this->data->template_location . 'configuration.archive.php' );
-		}
+		$path = $this->misc->get_template_path();
 
-		/* Check multisite installation */
-		if ( is_multisite() && is_file( $this->data->multisite_template_location . 'configuration.php' ) ) {
-			@rename( $this->data->multisite_template_location . 'configuration.php', $this->data->multisite_template_location . 'configuration.archive.php' );
+		if ( is_file( $path . 'configuration.php' ) ) {
+			@rename( $path . 'configuration.php', $path . 'configuration.archive.php' );
 		}
 	}
 
@@ -577,7 +572,7 @@ class Helper_Migration {
 	 * @since 4.0
 	 */
 	private function cleanup_output_directory() {
-		$output_dir = $this->data->template_location . 'output';
+		$output_dir = $this->misc->get_template_path() . 'output';
 
 		if ( is_dir( $output_dir ) ) {
 			return $this->misc->rmdir( $output_dir );

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -705,7 +705,6 @@ class Helper_Misc {
 		$default_template_path = PDF_PLUGIN_DIR . $relative_image_path;
 		$default_template_url  = PDF_PLUGIN_URL . $relative_image_path;
 
-
 		/* Multisite Location */
 		if ( is_multisite() && is_file( $this->data->multisite_template_location . 'images/' . $template ) ) {
 			return $this->data->multisite_template_location_url . 'images/' . $template;
@@ -909,5 +908,35 @@ class Helper_Misc {
 		}
 
 		return $evaluation;
+	}
+
+	/**
+	 * Check if running single or multisite and return the working directory path
+	 *
+	 * @return string Path to working directory
+	 *
+	 * @since 4.0
+	 */
+	public function get_template_path() {
+		if( is_multisite() ) {
+			return $this->data->multisite_template_location;
+		}
+
+		return $this->data->template_location;
+	}
+
+	/**
+	 * Check if running single or multisite and return the working directory URL
+	 *
+	 * @return string URL to working directory
+	 *
+	 * @since 4.0
+	 */
+	public function get_template_url() {
+		if( is_multisite() ) {
+			return $this->data->multisite_template_location_url;
+		}
+
+		return $this->data->template_location_url;
 	}
 }

--- a/src/helper/abstract/Helper_Abstract_Options.php
+++ b/src/helper/abstract/Helper_Abstract_Options.php
@@ -880,11 +880,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		/**
 		 * Load the user's templates
 		 */
-		$discovered_user_templates = glob( $this->data->template_location . '*.php' );
-
-		if ( is_multisite() ) {
-			$discovered_user_templates = array_merge( $discovered_user_templates, glob( $this->data->multisite_template_location . '*.php' ) );
-		}
+		$discovered_user_templates = glob( $this->misc->get_template_path() . '*.php' );
 
 		foreach ( $discovered_user_templates as $filename ) {
 
@@ -963,10 +959,15 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	 */
 	public function get_template_information( $name ) {
 
-		if ( is_file( $this->data->template_location . $name . '.php' ) ) {
-			$template          = $this->get_template_headers( $this->data->template_location . $name . '.php' );
-			$template['group'] = __( 'User Templates: ', 'gravity-forms-pdf-extended' ) . $template['group'];
+		/* Check if we can find the template and load the data */
+		if( is_multisite() && is_file( $this->data->multisite_template_location . $name . '.php' ) ) {
+			$template = $this->get_template_headers( $this->data->multisite_template_location . $name . '.php' );
+		} elseif ( is_file( $this->data->template_location . $name . '.php' ) ) {
+			$template = $this->get_template_headers( $this->data->template_location . $name . '.php' );
+		}
 
+		if( isset( $template ) ) {
+			$template['group'] = __( 'User Templates: ', 'gravity-forms-pdf-extended' ) . $template['group'];
 			return $template;
 		}
 

--- a/src/model/Model_Settings.php
+++ b/src/model/Model_Settings.php
@@ -226,7 +226,7 @@ class Model_Settings extends Helper_Abstract_Model {
 	 */
 	public function install_templates() {
 
-		$destination = ( is_multisite() ) ? $this->data->multisite_template_location : $this->data->template_location;
+		$destination = $this->misc->get_template_path();
 		$copy        = $this->misc->copyr( PDF_PLUGIN_DIR . 'src/templates/', $destination );
 		if ( is_wp_error( $copy ) ) {
 			$this->log->addError( 'Template Installation Error.' );

--- a/src/view/View_Settings.php
+++ b/src/view/View_Settings.php
@@ -253,7 +253,7 @@ class View_Settings extends Helper_Abstract_View {
 			wp_die( __( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
 		}
 
-		$template_directory = ( is_multisite() ) ? $this->data->multisite_template_location : $this->data->template_location;
+		$template_directory = $this->misc->get_template_path();
 
 		$vars = array(
 			'template_directory'            => $this->misc->relative_path( $template_directory, '/' ),

--- a/tests/phpunit/unit-tests/test-migration.php
+++ b/tests/phpunit/unit-tests/test-migration.php
@@ -373,19 +373,19 @@ class Test_Migration extends WP_UnitTestCase {
 		touch( $configuration_path . 'configuration.php' );
 
 		/* Setup an output directory and fill it with files */
-		mkdir( $gfpdf->data->template_location . 'output' );
-		mkdir( $gfpdf->data->template_location . 'output/123/' );
-		touch( $gfpdf->data->template_location . 'output/file' );
-		touch( $gfpdf->data->template_location . 'output/123/file' );
+		mkdir( $configuration_path . 'output' );
+		mkdir( $configuration_path . 'output/123/' );
+		touch( $configuration_path . 'output/file' );
+		touch( $configuration_path . 'output/123/file' );
 
 		/* Verify the output folder exists */
-		$this->assertTrue( is_dir( $gfpdf->data->template_location . 'output' ) );
+		$this->assertTrue( is_dir( $configuration_path . 'output' ) );
 
 		/* Run the migration */
 		$this->assertTrue( $this->migration->begin_migration() );
 
 		/* Verify our output folder no longer exists */
-		$this->assertFalse( is_dir( $gfpdf->data->template_location . 'output' ) );
+		$this->assertFalse( is_dir( $configuration_path . 'output' ) );
 		$this->assertTrue( is_dir( $gfpdf->data->template_location ) );
 
 		/* Verify our config file was archived and clean up */


### PR DESCRIPTION
Update any single references to the path or url. We left a lot of the template/config/image paths untouched as it checks multisite, then the single site directory before looking in the plugin folder.

Fixes #222