### PR TITLE
Create markup closer to our v3 style when using depreciated methods

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -824,6 +824,19 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	}
 
 	/**
+	 * Backwards compatibility with our early v3 templates
+	 *
+	 * @param $form_id
+	 *
+	 * @return array
+	 *
+	 * @since 4.0
+	 */
+	public function get_config_data( $form_id ) {
+		return $this->get_default_config_data( $form_id );
+	}
+
+	/**
 	 * Add backwards compatbility with v3.x.x default PDF template files
 	 * This function will now pull the PDF configuration details from our query variables / or our backwards compatible URL params method
 	 *

--- a/src/helper/fields/Field_Products.php
+++ b/src/helper/fields/Field_Products.php
@@ -84,6 +84,7 @@ class Field_Products extends Helper_Abstract_Fields {
 		?>
 
 		<div class="row-separator products-title-container">
+			<!-- <h2>Backwards Compatible</h2> -->
 			<h3 class="product-field-title gfpdf-field">
 				<?php
 				$label = apply_filters( 'gform_order_label', __( 'Order', 'gravityforms' ), $form_id );

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -441,45 +441,6 @@ class View_PDF extends Helper_Abstract_View {
 		echo apply_filters( 'gfpdf_pdf_form_title_html', ob_get_clean(), $form );
 	}
 
-
-	/**
-	 * Our default template used a number of legacy classes.
-	 * To keep backwards compatible, we will manually assign when needed.
-	 *
-	 * @param  GF_Field $field The Gravity Form Fields
-	 *
-	 * @return void (classes are passed by reference)
-	 *
-	 * @since 4.0
-	 */
-	public function load_legacy_css( GF_Field $field ) {
-		static $counter = 1;
-
-		/* Because multiple PDFs can be processed at the same time and will share the same field classes we'll only update the css once */
-		if ( strpos( $field->cssClass, 'gfpdf-field-processed' ) !== false ) {
-			return;
-		}
-
-		/* Add odd / even rows */
-		$field->cssClass = ( $counter++ % 2 ) ? $field->cssClass . ' odd' : ' even';
-
-		switch ( $field->type ) {
-			case 'html':
-				$field->cssClass .= ' entry-view-html-value';
-			break;
-
-			case 'section':
-				$field->cssClass .= ' entry-view-section-break-content';
-			break;
-
-			default:
-				$field->cssClass .= ' entry-view-field-value';
-			break;
-		}
-
-		$field->cssClass .= ' gfpdf-field-processed';
-	}
-
 	/**
 	 * Output the current page name HTML
 	 *

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -1346,16 +1346,6 @@ class Test_PDF extends WP_UnitTestCase {
 		$html = ob_get_clean();
 
 		$this->assertNotFalse( strpos( $html, '<div class="value">&nbsp;</div>' ) );
-
-		/* Enable legacy css */
-		$config['meta']['legacy_css'] = true;
-
-		ob_start();
-		$this->view->process_field( $field, $entry, $form, $config, $products, new Helper_Field_Container(), $this->model );
-		$html = ob_get_clean();
-
-		$this->assertNotFalse( strpos( $html, 'entry-view-field-value' ) );
-
 	}
 
 	/**
@@ -1380,32 +1370,6 @@ class Test_PDF extends WP_UnitTestCase {
 		$html = ob_get_clean();
 
 		$this->assertNotFalse( strpos( $html, '<h3 id="form_title">' ) );
-	}
-
-	/**
-	 * Check our legacy (v3) classes are loaded correctly
-	 *
-	 * @since 4.0
-	 */
-	public function test_load_legacy_css() {
-
-		/* Create standard field objects */
-		$text       = new GF_Field();
-		$text->type = 'text';
-
-		$html       = new GF_Field();
-		$html->type = 'html';
-
-		$section       = new GF_Field();
-		$section->type = 'section';
-
-		$this->view->load_legacy_css( $text );
-		$this->view->load_legacy_css( $html );
-		$this->view->load_legacy_css( $section );
-
-		$this->assertNotFalse( strpos( $text->cssClass, 'entry-view-field-value' ) );
-		$this->assertNotFalse( strpos( $html->cssClass, 'entry-view-html-value' ) );
-		$this->assertNotFalse( strpos( $section->cssClass, 'entry-view-section-break-content' ) );
 	}
 
 	/**


### PR DESCRIPTION
Our premium v3 templates accepts the returned markup as an array and parses it to create columns. The way we had it set up in v4 was just to return the entire string.

To get around this issue we moved a stripped down version of the field output to depreciated.php.

Fixes #227

Add additional backwards compatible tweaks to ensure a smoother transition for more users