### PR TITLE
Make the API create_pdf() method easier for developers to use

### DIFF
--- a/api.php
+++ b/api.php
@@ -384,27 +384,35 @@ class GPDFAPI {
 	}
 
 	/**
-	 * Provided the Gravity Form entry and PDF settings, this method will correctly generate the PDF, save it to disk
-	 * and return the absolute path to the PDF.
+	 * When provided the Gravity Form entry ID and PDF ID, this method will correctly generate the PDF, save it to disk,
+	 * trigger appropriate actions and return the absolute path to the PDF.
 	 *
-	 * @param  array $entry   The Gravity Form entry array – eg. GFAPI::get_entry( $id )
-	 * @param  array $setting The PDF configuration settings for the particular entry / form being processed – eg. GPDFAPI::get_pdf( $form_id, $pdf_id )
+	 * @param  integer $entry_id The Gravity Form entry ID
+	 * @param  string  $pdf_id   The Gravity PDF ID number (the pid number in the URL when viewing a setting in the admin area)
 	 *
 	 * @return mixed            Return the full path to the PDF, or a WP_Error on failure
 	 *
 	 * @since 4.0
 	 */
-	public static function create_pdf( $entry, $setting ) {
+	public static function create_pdf( $entry_id, $pdf_id ) {
 
-		if ( ! is_array( $entry ) || empty( $entry['id'] ) ) {
-			return new WP_Error( 'invalid_entry', 'The $entry value is not a valid Gravity Forms Entry object. Use "GFAPI::get_entry( $id )" to get the object.' );
+		$form_class = self::get_form_class();
+
+		/* Get our entry */
+		$entry = $form_class->get_entry( $entry_id );
+
+		if ( is_wp_error( $entry ) ) {
+			return new WP_Error( 'invalid_entry', 'Make sure to pass in a valid Gravity Forms Entry ID' );
 		}
 
-		if ( ! is_array( $setting ) || empty( $setting['id'] ) ) {
-			return new WP_Error( 'invalid_pdf_setting', 'The $setting value is not a valid Gravity PDF Setting object. Use "GPDFAPI::get_pdf( $form_id, $pdf_id )" to get the object.' );
+		/* Get our settings */
+		$setting = self::get_pdf( $entry['form_id'], $pdf_id );
+
+		if ( is_wp_error( $setting ) ) {
+			return new WP_Error( 'invalid_pdf_setting', 'Could not located the PDF Settings. Ensure you pass in a valid PDF ID.' );
 		}
 
-		$pdf = self::get_pdf_class( 'model' );
+		$pdf = self::get_mvc_class( 'Model_PDF' );
 
 		return $pdf->generate_and_save_pdf( $entry, $setting );
 	}

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -350,20 +350,21 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 		$fid     = $results['form']['id'];
 		$pid     = '555ad84787d7e';
 
-		/* Get our PDF */
-		$settings             = $gfpdf->options->get_pdf( $fid, $pid );
-		$settings['template'] = 'zadani';
-
 		/* Check for $entry error first */
-		$pdf = GPDFAPI::create_pdf( '', $settings );
+		$pdf = GPDFAPI::create_pdf( '', '' );
 		$this->assertEquals( 'invalid_entry', $pdf->get_error_code() );
 
 		/* Check for $settings error */
-		$pdf = GPDFAPI::create_pdf( $entry, '' );
+		$pdf = GPDFAPI::create_pdf( $entry['id'], '' );
 		$this->assertEquals( 'invalid_pdf_setting', $pdf->get_error_code() );
 
 		/* Create the PDF and test it was correctly generated */
-		$filename = GPDFAPI::create_pdf( $entry, $settings );
+		add_filter( 'gfpdf_pdf_config', function( $settings ) {
+			$settings['template'] = 'zadani';
+			return $settings;
+		} );
+
+		$filename = GPDFAPI::create_pdf( $entry['id'], $pid );
 
 		$this->assertTrue( is_file( $filename ) );
 


### PR DESCRIPTION
Instead of requiring the Entry and PDF Settings objects you can now just pass in the entry ID and PDF ID and get a PDF generated.

Resolves #236