### PR TITLE
Pass in the current template's initialised config class

### DIFF
--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -8,6 +8,7 @@ use Psr\Log\LoggerInterface;
 
 use GFCommon;
 use GFMultiCurrency;
+use GPDFAPI;
 
 use WP_Error;
 use RecursiveDirectoryIterator;
@@ -666,8 +667,9 @@ class Helper_Misc {
 		/* Disable the field encryption checks which can slow down our entry queries */
 		add_filter( 'gform_is_encrypted_field', '__return_false' );
 
-		$form = $this->form->get_form( $entry['form_id'] );
-		$pdf  = new Model_PDF( $this->form, $this->log, $gfpdf->options, $this->data, $this, $gfpdf->notices );
+		$form          = $this->form->get_form( $entry['form_id'] );
+		$pdf           = GPDFAPI::get_mvc_class( 'Model_PDF' );
+		$form_settings = GPDFAPI::get_mvc_class( 'Model_Form_Settings' );
 
 		return apply_filters( 'gfpdf_template_args', array(
 
@@ -680,6 +682,7 @@ class Helper_Misc {
 			'lead'      => $entry,
 			'form_data' => $pdf->get_form_data( $entry ),
 			'fields'    => $this->get_fields_sorted_by_id( $form['id'] ),
+			'config'    => $form_settings->get_template_configuration( $settings['template'] ),
 
 			'settings' => $settings,
 
@@ -962,4 +965,5 @@ class Helper_Misc {
 
 		return $fields;
 	}
+
 }

--- a/src/model/Model_Form_Settings.php
+++ b/src/model/Model_Form_Settings.php
@@ -15,6 +15,10 @@ use Psr\Log\LoggerInterface;
 
 use _WP_Editors;
 
+use stdClass;
+
+
+
 /**
  * Settings Model
  *
@@ -681,6 +685,11 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		if ( in_array( $template, $legacy_templates ) ) {
 			$class = $this->load_template_configuration( PDF_PLUGIN_DIR . 'src/templates/config/legacy.php' );
+		}
+
+		/* If there is still no class loaded we'll pass along a new empty class */
+		if( empty( $class ) ) {
+			$class = new stdClass();
 		}
 
 		return $class;

--- a/src/templates/blank-slate.php
+++ b/src/templates/blank-slate.php
@@ -23,6 +23,7 @@ if ( ! class_exists( 'GFForms' ) ) {
  * $form_data (The processed entry data stored in an array)
  * $settings (the current PDF configuration)
  * $fields (an array of Gravity Form fields which can be accessed with their ID number)
+ * $config (The initialised template config class – /config/blank-slate.php)
  * $gfpdf (the main Gravity PDF object containing all our helper classes)
  * $args (contains an array of all variables - the ones being described right now - passed to the template)
  */

--- a/src/templates/focus-gravity.php
+++ b/src/templates/focus-gravity.php
@@ -23,6 +23,7 @@ if ( ! class_exists('GFForms')) {
  * $form_data (The processed entry data stored in an array)
  * $settings (the current PDF configuration)
  * $fields (an array of Gravity Form fields which can be accessed with their ID number)
+ * $config (The initialised template config class – /config/focus-gravity.php)
  * $gfpdf (the main Gravity PDF object containing all our helper classes)
  * $args (contains an array of all variables - the ones being described right now - passed to the template)
  */

--- a/src/templates/rubix.php
+++ b/src/templates/rubix.php
@@ -23,6 +23,7 @@ if ( ! class_exists('GFForms')) {
  * $form_data (The processed entry data stored in an array)
  * $settings (the current PDF configuration)
  * $fields (an array of Gravity Form fields which can be accessed with their ID number)
+ * $config (The initialised template config class – /config/rubix.php)
  * $gfpdf (the main Gravity PDF object containing all our helper classes)
  * $args (contains an array of all variables - the ones being described right now - passed to the template)
  */

--- a/src/templates/zadani.php
+++ b/src/templates/zadani.php
@@ -23,6 +23,7 @@ if ( ! class_exists( 'GFForms' ) ) {
  * $form_data (The processed entry data stored in an array)
  * $settings (the current PDF configuration)
  * $fields (an array of Gravity Form fields which can be accessed with their ID number)
+ * $config (The initialised template config class – /config/zadani.php)
  * $gfpdf (the main Gravity PDF object containing all our helper classes)
  * $args (contains an array of all variables - the ones being described right now - passed to the template)
  */

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -581,7 +581,7 @@ class Test_Form_Settings extends WP_UnitTestCase {
 	public function test_get_template_configuration() {
 
 		/* Test failure first */
-		$this->assertFalse( $this->model->get_template_configuration( 'test' ) );
+		$this->assertEquals( 'stdClass', get_class( $this->model->get_template_configuration( 'test' ) ) );
 
 		/* Test default template */
 		$this->assertEquals( 'GFPDF\Templates\Config\Zadani', get_class( $this->model->get_template_configuration( 'zadani' ) ) );

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -353,6 +353,8 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'lead', $data );
 		$this->assertArrayHasKey( 'form_data', $data );
 		$this->assertArrayHasKey( 'settings', $data );
+		$this->assertArrayHasKey( 'fields', $data );
+		$this->assertArrayHasKey( 'config', $data );
 		$this->assertArrayHasKey( 'gfpdf', $data );
 
 		/* Sniff that our keys have the correct details */
@@ -366,6 +368,9 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 		$this->assertEquals( $data['entry'], $data['lead'] );
 		$this->assertEquals( $pdf, $data['settings'] );
 		$this->assertEquals( 'GFPDF\Router', get_class( $data['gfpdf'] ) );
+		$this->assertTrue( is_array( $data['fields'] ) );
+		$this->assertEquals( 'GF_Field_Checkbox', get_class( $data['fields'][47] ) );
+		$this->assertEquals( 'GFPDF\Templates\Config\Zadani', get_class( $data['config'] ) );
 	}
 
 	/**


### PR DESCRIPTION
This allows devs to move their core template logic into reusable code blocks with ease.

Fixes #259