### PR TITLE
Load core plugin on `after_setup_theme` instead of `plugins_loaded`

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -6,6 +6,7 @@ use GFPDF\Controller;
 use GFPDF\Model;
 use GFPDF\View;
 use GFPDF\Helper;
+
 use GFPDF_Core;
 
 use Monolog\Formatter\LineFormatter;
@@ -159,8 +160,30 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	}
 
 	/**
+	 * Fired on the `after_setup_theme` action to initialise our plugin
+	 *
+	 * We do this on this hook instead of plugins_loaded so that users can tap into all our actions and filters
+	 * directly from their theme (usually the functions.php file).
+	 *
+	 * @since 4.0
+	 */
+	public static function initialise_plugin() {
+
+		global $gfpdf;
+
+		/* Initialise our Router class */
+		$gfpdf = new Router();
+		$gfpdf->init();
+
+		/* Add backwards compatibility support */
+		$depreciated = new GFPDF_Core();
+		$depreciated->setup_constants();
+		$depreciated->setup_depreciated_paths();
+	}
+
+	/**
 	 * Setup our plugin functionality
-	 * Note: Fires on WordPress' init hook
+	 * Note: This method runs during the `after_setup_theme` action
 	 *
 	 * @since 4.0
 	 */
@@ -883,5 +906,9 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 /**
  * Execute our bootstrap class
+ *
+ * We were forced to forgo initialising the plugin using an anonymous function call due to
+ * our AJAX calls in our unit testing suite failing (boo)
  */
-new GFPDF_Core();
+add_action( 'after_setup_theme', '\GFPDF\Router::initialise_plugin' );
+

--- a/src/depreciated.php
+++ b/src/depreciated.php
@@ -78,19 +78,6 @@ abstract class GFPDF_Depreciated_Abstract {
 class GFPDF_Core extends GFPDF_Depreciated_Abstract {
 
 	/**
-	 * Initialise our Gravity PDF Router and initialise
-	 */
-	public function __construct() {
-		global $gfpdf;
-
-		$gfpdf = new Router();
-
-		$gfpdf->init();
-		$this->setup_constants();
-		$this->setup_depreciated_paths();
-	}
-
-	/**
 	 * Setup our v3 template location constants
 	 *
 	 * @since 4.0

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -65,7 +65,7 @@ class GravityPDF_Unit_Tests_Bootstrap {
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load' ) );
 
 		/* load Gravity PDF objects */
-		tests_add_filter( 'plugins_loaded', array( $this, 'create_stubs' ), 20 );
+		tests_add_filter( 'after_setup_theme', array( $this, 'create_stubs' ), 20 );
 
 		/* load the WP testing environment */
 		require_once( $this->wp_tests_dir . '/includes/bootstrap.php' );

--- a/tests/phpunit/unit-tests/test-depreciated.php
+++ b/tests/phpunit/unit-tests/test-depreciated.php
@@ -2,7 +2,6 @@
 
 namespace GFPDF\Tests;
 
-use GFPDF_Core;
 use PDFRender;
 use PDF_Common;
 
@@ -76,31 +75,6 @@ class Test_Depreciated extends WP_UnitTestCase {
 			array( 'GFPDFEntryDetail' ),
 			array( 'PDF_Generator' ),
 		);
-	}
-
-	/**
-	 * Check our global $gfpdf variable gets setup correctly
-	 *
-	 * @since 4.0
-	 */
-	public function test_setup() {
-
-		/* Backup our class object and remove */
-		$backup = $GLOBALS['gfpdf'];
-		unset( $GLOBALS['gfpdf'] );
-
-		/* Test it was removed */
-		$this->assertNull( $GLOBALS['gfpdf'] );
-
-		/* Verify out object is set up correctly */
-		new GFPDF_Core();
-
-		$this->assertNotNull( $GLOBALS['gfpdf'] );
-		$this->assertEquals( 'GFPDF\Router', get_class( $GLOBALS['gfpdf'] ) );
-
-		/* Reset the object */
-		unset( $GLOBALS['gfpdf'] );
-		$GLOBALS['gfpdf'] = $backup;
 	}
 
 	/**


### PR DESCRIPTION
Load the plugin on the `after_setup_theme` action instead of`plugins_loaded` to allow themes to tap into all our actions / filters via their theme.

Ensure our unit testing stubs aren't created until after Gravity PDF loads.