### PR TITLE
Housekeeping for our PDF generator code

### DIFF
--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -162,13 +162,13 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	 */
 	public function add_filters() {
 		/* PDF authentication middleware */
-		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_public_access' ), 5, 3 );
-		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ), 10, 3 );
-		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ), 10, 3 );
-		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_owner_restriction' ), 20, 3 );
-		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_timeout' ), 30, 3 );
-		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_auth_logged_out_user' ), 40, 3 );
-		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ), 50, 3 );
+		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_public_access' ), 10, 3 );
+		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ), 20, 3 );
+		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ), 30, 3 );
+		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_owner_restriction' ), 40, 3 );
+		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_timeout' ), 50, 3 );
+		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_auth_logged_out_user' ), 60, 3 );
+		add_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ), 70, 3 );
 
 		/* Tap into GF notifications */
 		add_filter( 'gform_notification', array( $this->model, 'notifications', ), 9999, 3 ); /* ensure Gravity PDF is one of the last filters to be applied */

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -436,16 +436,15 @@ class View_PDF extends Helper_Abstract_View {
 	 * @since 4.0
 	 */
 	public function show_form_title( $show_title, $form ) {
-		ob_start();
-
 		/* Show the form title, if needed */
-		if ( $show_title !== false ) : ?>
-			<div class="row-separator">
-				<h3 id="form_title"><?php echo $form['title'] ?></h3>
-			</div>
-		<?php endif;
+		if ( $show_title !== false ) {
 
-		echo apply_filters( 'gfpdf_pdf_form_title_html', ob_get_clean(), $form );
+			/* Load our HTML */
+			$html = $this->load( 'form_title', array( 'form' => $form ), false );
+
+			/* Run it through a filter and output */
+			echo apply_filters( 'gfpdf_pdf_form_title_html', $html, $form );
+		}
 	}
 
 	/**
@@ -468,17 +467,11 @@ class View_PDF extends Helper_Abstract_View {
 			/* correctly close / cleanup the HTML container if needed */
 			$container->close();
 
-			ob_start();
+			/* Load our HTML */
+			$html = $this->load( 'page_title', array( 'form' => $form, 'page' => $page ), false );
 
-			?>
-			<div class="row-separator">
-				<h3 class="gfpdf-page gfpdf-field">
-					<?php echo $form['pagination']['pages'][ $page ]; ?>
-				</h3>
-			</div>
-			<?php
-
-			echo apply_filters( 'gfpdf_field_page_name_html', ob_get_clean(), $page, $form );
+			/* Run it through a filter and output */
+			echo apply_filters( 'gfpdf_field_page_name_html', $html, $page, $form );
 		}
 	}
 

--- a/src/view/html/PDF/core_template_styles.php
+++ b/src/view/html/PDF/core_template_styles.php
@@ -14,6 +14,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF Copyright (C) 2015 Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
 $font                       = ( ! empty( $settings['font'] ) ) ? $settings['font'] : 'DejavuSansCondensed';
 $font_colour                = ( ! empty( $settings['font_colour'] ) ) ? $settings['font_colour'] : '#333';
 $font_size                  = ( ! empty( $settings['font_size'] ) ) ? $settings['font_size'] : '9';

--- a/src/view/html/PDF/form_title.php
+++ b/src/view/html/PDF/form_title.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * The HTML mark-up needed to display our core PDF title
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2015, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF Copyright (C) 2015 Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+?>
+
+<div class="row-separator">
+	<h3 id="form_title"><?php echo $form['title'] ?></h3>
+</div>

--- a/src/view/html/PDF/page_title.php
+++ b/src/view/html/PDF/page_title.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * The HTML mark-up to display our core PDF page
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2015, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF Copyright (C) 2015 Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+?>
+
+<div class="row-separator">
+	<h3 class="gfpdf-page gfpdf-field">
+		<?php echo $form['pagination']['pages'][ $page ]; ?>
+	</h3>
+</div>

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -155,22 +155,13 @@ class Test_PDF extends WP_UnitTestCase {
 	public function test_filters() {
 		global $gfpdf;
 
-		$this->assertSame( 5, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_public_access' ) ) );
-		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
-		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
-		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', array(
-			$this->model,
-			'middle_owner_restriction',
-		) ) );
-		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', array(
-			$this->model,
-			'middle_logged_out_timeout',
-		) ) );
-		$this->assertSame( 40, has_filter( 'gfpdf_pdf_middleware', array(
-			$this->model,
-			'middle_auth_logged_out_user',
-		) ) );
-		$this->assertSame( 50, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ) ) );
+		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_public_access' ) ) );
+		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
+		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
+		$this->assertSame( 40, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_owner_restriction' ) ) );
+		$this->assertSame( 50, has_filter( 'gfpdf_pdf_middleware', array( $this->model,	'middle_logged_out_timeout' ) ) );
+		$this->assertSame( 60, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_auth_logged_out_user' ) ) );
+		$this->assertSame( 70, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ) ) );
 
 		$this->assertSame( 9999, has_filter( 'gform_notification', array( $this->model, 'notifications' ), 9999 ) );
 
@@ -338,37 +329,22 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->model->middle_public_access( '', '', $settings );
 
 		/* Run our Tests */
-		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
-		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
-		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', array(
-			$this->model,
-			'middle_owner_restriction',
-		) ) );
-		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', array(
-			$this->model,
-			'middle_logged_out_timeout',
-		) ) );
-		$this->assertSame( 40, has_filter( 'gfpdf_pdf_middleware', array(
-			$this->model,
-			'middle_auth_logged_out_user',
-		) ) );
-		$this->assertSame( 50, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ) ) );
+		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
+		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
+		$this->assertSame( 40, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_owner_restriction' ) ) );
+		$this->assertSame( 50, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_timeout' ) ) );
+		$this->assertSame( 60, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_auth_logged_out_user' ) ) );
+		$this->assertSame( 70, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ) ) );
 
 		/* Check if setting passes */
 		$settings['public_access'] = 'Yes';
 		$this->model->middle_public_access( '', '', $settings );
 
-		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
-		$this->assertSame( 10, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
-		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array(
-			$this->model,
-			'middle_owner_restriction',
-		) ) );
+		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
+		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
+		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_owner_restriction' ) ) );
 		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_timeout' ) ) );
-		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array(
-			$this->model,
-			'middle_auth_logged_out_user',
-		) ) );
+		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_auth_logged_out_user' ) ) );
 		$this->assertFalse( has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ) ) );
 
 	}


### PR DESCRIPTION
- Change the middleware filter order
- Include missing middleware from comments
- Create separate HTML files for our title and page mark-up
- Include GPL notice in core_template_styles.php
- Reorder the variables in our gfpdf_post_save_pdf hook and include the $filename.
- Change $pdf to $settings to be more accurate
- Change $pdf to $settings to be more accurate
- Fix up bug when enabling public access
- Ensure unit tests pass