### PR TITLE
Fix for Tier 2 add-on attachments

### DIFF
--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -147,9 +147,9 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Add save PDF filter */
 		add_action( 'gform_after_submission', array( $this->model, 'maybe_save_pdf' ), 10, 2 );
-		add_action( 'gform_after_submission', array( $this->model, 'cleanup_pdf' ), 9999, 2 );
 
-		/* Setup clean-up cron */
+		/* Clean-up actions */
+		add_action( 'gform_after_submission', array( $this->model, 'cleanup_pdf' ), 9999, 2 );
 		add_action( 'gfpdf_cleanup_tmp_dir', array( $this->model, 'cleanup_tmp_dir' ) );
 	}
 
@@ -194,6 +194,9 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		/* Pre-process our template arguments and automatically render them in PDF */
 		add_filter( 'gfpdf_template_args', array( $this->model, 'preprocess_template_arguments' ) );
 		add_filter( 'gfpdf_pdf_html_output', array( $this->view, 'autoprocess_core_template_options' ), 5, 4 );
+
+		/* Cleanup filters */
+		add_filter( 'gform_before_resend_notifications', array( $this->model, 'resend_notification_pdf_cleanup' ), 10, 2 );
 	}
 
 	/**

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -967,4 +967,52 @@ class Helper_Misc {
 		return $fields;
 	}
 
+	/**
+	 * Converts the 4.x settings array into a compatible 3.x settings array
+	 *
+	 * @param  array $settings The 4.x settings to be converted
+	 *
+	 * @return array           The 3.x compatible settings
+	 *
+	 * @since 4.0
+	 */
+	public function backwards_compat_conversion( $settings ) {
+
+		$compat                   = array();
+		$compat['premium']        = ( isset( $settings['advanced_template'] ) && $settings['advanced_template'] == 'Yes' ) ? true : false;
+		$compat['rtl']            = ( isset( $settings['rtl'] ) && $settings['rtl'] == 'Yes' ) ? true : false;
+		$compat['dpi']            = ( isset( $settings['image_dpi'] ) ) ? (int) $settings['image_dpi'] : 96;
+		$compat['security']       = ( isset( $settings['security'] ) && $settings['security'] == 'Yes' ) ? true : false;
+		$compat['pdf_password']   = ( isset( $settings['password'] ) ) ? $settings['password'] : '';
+		$compat['pdf_privileges'] = ( isset( $settings['privileges'] ) ) ? $settings['privileges'] : '';
+		$compat['pdfa1b']         = ( isset( $settings['format'] ) && $settings['format'] == 'PDFA1B' ) ? true : false;
+		$compat['pdfx1a']         = ( isset( $settings['format'] ) && $settings['format'] == 'PDFX1A' ) ? true : false;
+
+		return $compat;
+	}
+
+	/**
+	 * Converts the 4.x output to into a compatible 3.x type
+	 *
+	 * @param  string $type
+	 *
+	 * @return string
+	 *
+	 * @since 4.0
+	 */
+	public function backwards_compat_output( $type = '' ) {
+		switch ( strtolower( $type ) ) {
+			case 'display':
+				return 'view';
+			break;
+
+			case 'download':
+				return 'download';
+			break;
+
+			default:
+				return 'save';
+			break;
+		}
+	}
 }

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -188,21 +188,36 @@ class View_PDF extends Helper_Abstract_View {
 		$pdf->set_filename( $model->get_pdf_name( $settings, $entry ) );
 
 		try {
-			$pdf->init();
 
-			/* set display type */
+			/* Initialise our PDF helper class */
+			$pdf->init();
+			$pdf->set_template();
+
+			/* Increment our rudimentary PDF counter */
+			$this->options->increment_pdf_count();
+
+			/* Set display type and allow user to override the behaviour */
 			$settings['pdf_action'] = apply_filters( 'gfpdfe_pdf_output_type', $settings['pdf_action'] ); /* Backwards compat */
 			if ( $settings['pdf_action'] == 'download' ) {
 				$pdf->set_output_type( 'download' );
 			}
 
-			/* determine if we should show the print dialog box */
+			/* Add Backwards compatibility support for our v3 Tier 2 Add-on */
+			if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) == 'yes' ) {
+
+				/* Check if we should process this document using our legacy system */
+				if ( $model->handle_legacy_tier_2_processing( $pdf, $entry, $settings, $args ) ) {
+					return true;
+				}
+			}
+
+			/* Determine if we should show the print dialog box */
 			if ( isset( $_GET['print'] ) ) {
 				$pdf->set_print_dialog( true );
 			}
 
+			/* Render the PDF template HTML */
 			$pdf->render_html( $args );
-			$this->options->increment_pdf_count();
 
 			/* Generate PDF */
 			$pdf->generate();

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -7,7 +7,7 @@ use GFPDF\Helper\Helper_Misc;
 use WP_UnitTestCase;
 
 /**
- * Test Gravity PDF Hlper Misc Functionality
+ * Test Gravity PDF Helper Misc Functionality
  *
  * @package     Gravity PDF
  * @copyright   Copyright (c) 2015, Blue Liquid Designs
@@ -462,11 +462,11 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 	 * Ensure we correctly return an appropriate class name based on the file path given
 	 *
 	 * @param string $expected The expected value
-	 * @param string $file The test path
+	 * @param string $file     The test path
 	 *
 	 * @dataProvider provider_get_config_class_name
 	 *
-	 * @since 4.0
+	 * @since        4.0
 	 */
 	public function test_get_config_class_name( $expected, $file ) {
 		$this->assertEquals( $expected, $this->misc->get_config_class_name( $file ) );
@@ -497,7 +497,7 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 	 *
 	 * @dataProvider provider_get_background_and_border_contrast
 	 *
-	 * @since 4.0
+	 * @since        4.0
 	 */
 	public function test_get_background_and_border_contrast( $expected, $hex ) {
 		$contrast = $this->misc->get_background_and_border_contrast( $hex );
@@ -535,12 +535,65 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 		$this->assertSame( 0, sizeof( $this->misc->get_fields_sorted_by_id( 0 ) ) );
 
 		/* Check for real form and verify the results */
-		$form  = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+		$form = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
 
 		$fields = $this->misc->get_fields_sorted_by_id( $form['id'] );
 
 		$this->assertEquals( 54, sizeof( $fields ) );
 		$this->assertEquals( 'Section Break', $fields[10]->label );
+	}
 
+	/**
+	 * Check if our backwards compatible settings conversion works correctly
+	 */
+	public function test_backwards_compat_conversion() {
+		$settings = array(
+			'irrelivant' => 'Yes',
+		);
+
+		/* Check all the defaults work as expected */
+		$compat = $this->misc->backwards_compat_conversion( $settings );
+
+		$this->assertEquals( 8, sizeof( $compat ) );
+		$this->assertFalse( isset( $compat['irrelivant'] ) );
+		$this->assertFalse( $compat['premium'] );
+		$this->assertFalse( $compat['rtl'] );
+		$this->assertFalse( $compat['security'] );
+		$this->assertFalse( $compat['pdfa1b'] );
+		$this->assertFalse( $compat['pdfx1a'] );
+		$this->assertEquals( '', $compat['password'] );
+		$this->assertEquals( '', $compat['pdf_privileges'] );
+		$this->assertEquals( 96, $compat['dpi'] );
+
+		/* Check all the settings get correctly converted */
+		$settings = array(
+			'advanced_template' => 'Yes',
+			'rtl'               => 'Yes',
+			'image_dpi'         => 300,
+			'security'          => 'Yes',
+			'password'          => 'password',
+			'privileges'        => 'privileges',
+			'format'            => 'PDFX1A',
+		);
+
+		$compat = $this->misc->backwards_compat_conversion( $settings );
+
+		$this->assertTrue( $compat['premium'] );
+		$this->assertTrue( $compat['rtl'] );
+		$this->assertTrue( $compat['security'] );
+		$this->assertFalse( $compat['pdfa1b'] );
+		$this->assertTrue( $compat['pdfx1a'] );
+		$this->assertEquals( 'password', $compat['pdf_password'] );
+		$this->assertEquals( 'privileges', $compat['pdf_privileges'] );
+		$this->assertEquals( 300, $compat['dpi'] );
+	}
+
+	/**
+	 * Check if our backwards compatible output functions work correctly
+	 */
+	public function test_backwards_compat_output() {
+		$this->assertEquals( 'save', $this->misc->backwards_compat_output() );
+		$this->assertEquals( 'view', $this->misc->backwards_compat_output( 'display' ) );
+		$this->assertEquals( 'download', $this->misc->backwards_compat_output( 'download' ) );
 	}
 }

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -131,16 +131,10 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_actions() {
-		$this->assertSame( 10, has_action( 'parse_request', array(
-			$this->controller,
-			'process_legacy_pdf_endpoint',
-		) ) );
+		$this->assertSame( 10, has_action( 'parse_request', array( $this->controller, 'process_legacy_pdf_endpoint' ) ) );
 		$this->assertSame( 10, has_action( 'parse_request', array( $this->controller, 'process_pdf_endpoint' ) ) );
 
-		$this->assertSame( 10, has_action( 'gform_entries_first_column_actions', array(
-			$this->model,
-			'view_pdf_entry_list',
-		) ) );
+		$this->assertSame( 10, has_action( 'gform_entries_first_column_actions', array( $this->model, 'view_pdf_entry_list' ) ) );
 		$this->assertSame( 10, has_action( 'gform_entry_info', array( $this->model, 'view_pdf_entry_detail' ) ) );
 		$this->assertSame( 10, has_action( 'gform_after_submission', array( $this->model, 'maybe_save_pdf' ) ) );
 		$this->assertSame( 9999, has_action( 'gform_after_submission', array( $this->model, 'cleanup_pdf' ) ) );
@@ -159,7 +153,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertSame( 20, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_active' ) ) );
 		$this->assertSame( 30, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_conditional' ) ) );
 		$this->assertSame( 40, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_owner_restriction' ) ) );
-		$this->assertSame( 50, has_filter( 'gfpdf_pdf_middleware', array( $this->model,	'middle_logged_out_timeout' ) ) );
+		$this->assertSame( 50, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_logged_out_timeout' ) ) );
 		$this->assertSame( 60, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_auth_logged_out_user' ) ) );
 		$this->assertSame( 70, has_filter( 'gfpdf_pdf_middleware', array( $this->model, 'middle_user_capability' ) ) );
 
@@ -168,29 +162,18 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertSame( 10, has_filter( 'mpdf_tmp_path', array( $this->model, 'mpdf_tmp_path' ) ) );
 		$this->assertSame( 10, has_filter( 'mpdf_fontdata_path', array( $this->model, 'mpdf_tmp_font_path' ) ) );
 		$this->assertSame( 10, has_filter( 'mpdf_current_font_path', array( $this->model, 'set_current_pdf_font' ) ) );
-		$this->assertSame( 10, has_filter( 'mpdf_font_data', array(
-			$this->model,
-			'register_custom_font_data_with_mPDF',
-		) ) );
-		$this->assertSame( 20, has_filter( 'mpdf_font_data', array(
-			$this->model,
-			'add_unregistered_fonts_to_mPDF',
-		) ) );
+		$this->assertSame( 10, has_filter( 'mpdf_font_data', array( $this->model, 'register_custom_font_data_with_mPDF' ) ) );
+		$this->assertSame( 20, has_filter( 'mpdf_font_data', array( $this->model, 'add_unregistered_fonts_to_mPDF' ) ) );
 
 		$this->assertSame( 10, has_filter( 'gfpdf_pdf_html_output', array( $gfpdf->misc, 'do_mergetags' ) ) );
 		$this->assertSame( 10, has_filter( 'gfpdf_pdf_html_output', 'do_shortcode' ) );
 
-		$this->assertSame( 10, has_filter( 'gfpdf_template_args', array(
-			$this->model,
-			'preprocess_template_arguments',
-		) ) );
-		$this->assertSame( 5, has_filter( 'gfpdf_pdf_html_output', array(
-			$this->view,
-			'autoprocess_core_template_options',
-		) ) );
+		$this->assertSame( 10, has_filter( 'gfpdf_template_args', array( $this->model, 'preprocess_template_arguments' ) ) );
+		$this->assertSame( 5, has_filter( 'gfpdf_pdf_html_output', array( $this->view, 'autoprocess_core_template_options' ) ) );
 
 		/* Backwards compatiblity */
 		$this->assertSame( 1, has_filter( 'gfpdfe_pre_load_template', array( 'PDFRender', 'prepare_ids' ) ) );
+		$this->assertSame( 10, has_filter( 'gform_before_resend_notifications', array( $this->model, 'resend_notification_pdf_cleanup' ) ) );
 	}
 
 	/**
@@ -927,6 +910,94 @@ class Test_PDF extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the PDF output setting is correct
+	 *
+	 * @since 4.0
+	 */
+	public function test_get_output_type() {
+		global $gfpdf;
+
+		$pdf = new Helper_PDF( '', '', $gfpdf->form, $gfpdf->data );
+
+		$pdf->set_output_type( 'display' );
+		$this->assertEquals( 'DISPLAY', $pdf->get_output_type() );
+
+		$pdf->set_output_type( 'download' );
+		$this->assertEquals( 'DOWNLOAD', $pdf->get_output_type() );
+
+		$pdf->set_output_type( 'save' );
+		$this->assertEquals( 'SAVE', $pdf->get_output_type() );
+	}
+
+	/**
+	 * Ensure the correct template path is returned
+	 *
+	 * @since 4.0
+	 */
+	public function test_get_template_path() {
+		global $gfpdf;
+
+		$pdf = new Helper_PDF( '', array( 'template' => 'zadani' ), $gfpdf->form, $gfpdf->data );
+
+		/* Cleanup any previous tests */
+		@unlink( $gfpdf->data->template_location . 'zadani.php' );
+
+		/* Set our current PDF template */
+		$pdf->set_template();
+
+		/* Check our basic struction is correct */
+		$this->assertEquals( PDF_PLUGIN_DIR . 'src/templates/zadani.php', $pdf->get_template_path() );
+
+		/* Copy the template to our PDF_EXTENDED_TEMPLATES directory and recheck the path */
+		copy( PDF_PLUGIN_DIR . 'src/templates/zadani.php', $gfpdf->data->template_location . 'zadani.php' );
+
+		/* Set our current PDF template */
+		$pdf->set_template();
+
+		/* Run our new test */
+		$this->assertEquals( $gfpdf->data->template_location . 'zadani.php', $pdf->get_template_path() );
+		@unlink( $gfpdf->data->template_location . 'zadani.php' );
+
+		/* Check the multisite option */
+		if ( is_multisite() ) {
+			/* Copy the template to our multisite PDF_EXTENDED_TEMPLATES directory and recheck the path */
+			copy( PDF_PLUGIN_DIR . 'src/templates/zadani.php', $gfpdf->data->multisite_template_location . 'zadani.php' );
+
+			/* Set our current PDF template */
+			$pdf->set_template();
+
+			/* Run our new test */
+			$this->assertEquals( $gfpdf->data->multisite_template_location . 'zadani.php', $pdf->get_template_path() );
+			@unlink( $gfpdf->data->multisite_template_location . 'zadani.php' );
+		}
+
+		/* Check for errors */
+		$pdf = new Helper_PDF( '', array( 'template' => 'non-existant' ), $gfpdf->form, $gfpdf->data );
+
+		try {
+			/* Set our current PDF template */
+			$pdf->set_template();
+		} catch ( Exception $e ) {
+			$this->assertEquals( 'Could not find the template: non-existant.php', $e->getMessage() );
+		}
+
+		/* Check for incorrect version requirements */
+		$template = file_get_contents( PDF_PLUGIN_DIR . 'src/templates/zadani.php' );
+		$template = str_replace( 'Required PDF Version: 4.0-alpha', 'Required PDF Version: 10', $template );
+		file_put_contents( $gfpdf->data->template_location . 'zadani.php', $template );
+
+		$pdf = new Helper_PDF( '', array( 'template' => 'zadani' ), $gfpdf->form, $gfpdf->data );
+
+		try {
+			$pdf->set_template();
+		} catch ( Exception $e ) {
+			$this->assertEquals( sprintf( 'The PDF Template %s requires Gravity PDF version %s. Upgrade to the latest version.', '<em>zadani.php</em>', '<em>10</em>' ), $e->getMessage() );
+		}
+
+		@unlink( $gfpdf->data->template_location . 'zadani.php' );
+	}
+
+	/**
 	 * Check our tmp directory is being cleaned up correctly
 	 *
 	 * @since 4.0
@@ -1535,5 +1606,31 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertNotFalse( strpos( $results, 'background-image-resize: 4;' ) );
 
 		$this->assertNotFalse( strpos( $results, 'background-color: red;' ) );
+	}
+
+	/**
+	 * Check that our backwards compatible Tier 2 add-on works as expected
+	 *
+	 * @since 4.0
+	 */
+	public function test_handle_legacy_tier_2_processing() {
+		global $gfpdf;
+
+		$settings = array( 'template' => 'zadani' );
+		$entry    = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$args     = $gfpdf->misc->get_template_args( $entry, $settings );
+
+		$pdf = new Helper_PDF( '', $settings, $gfpdf->form, $gfpdf->data );
+		$pdf->set_template();
+		$pdf->set_output_type( 'save' );
+
+		$this->assertFalse( $this->model->handle_legacy_tier_2_processing( $pdf, $entry, $settings, $args ) );
+
+		/* Set a filter and ensure the test passes */
+		add_filter( 'gfpdfe_pre_load_template', function( $form_id ) {
+			return true;
+		} );
+
+		$this->assertTrue( $this->model->handle_legacy_tier_2_processing( $pdf, $entry, $settings, $args ) );
 	}
 }

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -329,7 +329,7 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 		}
 
 		/* Trigger an error */
-		$error = $this->model->generate_and_save_pdf( '', '' );
+		$error = $this->model->generate_and_save_pdf( array(), '' );
 
 		$this->assertTrue( is_wp_error( $error ) );
 	}


### PR DESCRIPTION
There was a major issue with the way we were parsing the legacy Tier 2 add-on. It appeared to work correctly when only one Tier 2 template was being run but once you started using multiples it fell to pieces.

This patch reimagines how the legacy Tier 2 compatibility should function in Gravity PDF 4.0. Instead of handling it inside our Helper_PDF class, we are instead bypassing that functionality and doing the checks before hand in our Model_PDF and View_PDF functions (one for saving and one for viewing).

We also fixed a clean-up issue when resending PDFs via the admin area.

Add unit tests and optimise code

Resolves #289