### PR TITLE
Prevent saving of tools form fields in our global PDF settings

### DIFF
--- a/src/helper/abstract/Helper_Abstract_Options.php
+++ b/src/helper/abstract/Helper_Abstract_Options.php
@@ -1258,7 +1258,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 
 		$all_settings = $this->get_registered_fields();
 		$tab          = isset( $referrer['tab'] ) ? $referrer['tab'] : 'general';
-		$settings     = ( ! empty( $all_settings[ $tab ] ) ) ? $all_settings[ $tab ] : array();
+		$settings     = ( ! empty( $all_settings[ $tab ] ) && $tab !== 'tools' ) ? $all_settings[ $tab ] : array();
 
 		/*
          * Get all setting types
@@ -1330,7 +1330,6 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			set_transient( 'gfpdf_settings_user_data', array_merge( $gfpdf_options, $input ), 30 );
 
 			/* return nothing */
-
 			return array();
 		}
 

--- a/src/view/html/Settings/tools.php
+++ b/src/view/html/Settings/tools.php
@@ -49,6 +49,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<form method="post">
 
+		<?php settings_fields( 'gfpdf_settings' ); ?>
+
 		<table id="pdf-tools" class="widefat gfpdfe_table">
 			<thead>
 				<tr>


### PR DESCRIPTION
- Include settings fields on tools tab so our sanitization method runs correctly
- Prevent the saving of any registered fields on the tools tab (it's just for actions).

Resolves #280