### PR TITLE
Prevent Appearance defaults loading on legacy Tier 2 templates

### DIFF
--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -212,7 +212,8 @@
 				this.handleSecurityConditionals();
 				this.handlePDFConditionalLogic();
 				this.handleOwnerRestriction();
-				this.toggleFontAppearance( $('#gfpdf_settings\\[template\\]').data('template_group') ); /* Show/Hide the
+				this.toggleFontAppearance( $('#gfpdf_settings\\[template\\]').data('template_group') );
+				this.toggleAppearanceTab();
 
 				/*
 				 * Workaround for Firefix TinyMCE Editor Bug NS_ERROR_UNEXPECTED (http://www.tinymce.com/develop/bugtracker_view.php?id=3152) when loading wp_editor via AJAX
@@ -723,6 +724,24 @@
 				} else { /* Ensure the fields are showing */
 					$rows.show();
 				}
+			}
+
+			/**
+			 * Check if the current PDF template selection uses the legacy Enable Advanced Templating option
+			 * and hide the Appearance tab altogether
+			 * @since 4.0
+			 */
+			this.toggleAppearanceTab = function() {
+
+				$('input[name="gfpdf_settings[advanced_template]"]').change(function() {
+					if($(this).val() == 'Yes') {
+						$('#gfpdf-appearance-nav').hide();
+					} else {
+						$('#gfpdf-appearance-nav').show();
+					}
+				});
+
+				$('input[name="gfpdf_settings[advanced_template]"]:checked').trigger('change');
 			}
 
 			/**

--- a/src/helper/Helper_Options_Fields.php
+++ b/src/helper/Helper_Options_Fields.php
@@ -538,7 +538,11 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 	}
 
 	/**
-	 * Enable advanced templating field if the user has enabled it with a filter, or our premium plugin has been installed
+	 * Enable advanced templating field if the user has our legacy premium plugin installed
+	 *
+	 * Dev notice: We're going to rewrite and rename the Tier 2 premium add-on and utilise template headers to automatically handle
+	 * advanced templates without the need for user intervention, which is why this method doesn't have a filter to manually
+	 * enable it.
 	 *
 	 * @param  array $settings The 'form_settings_advanced' array
 	 *
@@ -546,13 +550,10 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 	 *
 	 * @since 4.0
 	 *
-	 * @todo  Document this method
 	 */
 	public function get_advanced_template_field( $settings ) {
 
-		$enabled = apply_filters( 'gfpdf_enable_advanced_template_field', false );
-
-		if ( $enabled !== true && ! class_exists( 'gfpdfe_business_plus' ) ) {
+		if ( ! class_exists( 'gfpdfe_business_plus' ) ) {
 			return $settings;
 		}
 

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -502,8 +502,8 @@ class View_PDF extends Helper_Abstract_View {
 	 * @since 4.0
 	 */
 	public function autoprocess_core_template_options( $html, $form, $entry, $settings ) {
-		/* Prevent core styles loading if a v3 template */
-		if ( $this->options->get_template_group( $settings['template'] ) !== 'legacy' ) {
+		/* Prevent core styles loading if a v3 template or using our legacy Tier 2 add-on */
+		if ( 'legacy' !== $this->options->get_template_group( $settings['template'] ) && ( empty( $settings['advanced_template'] ) || 'Yes' !== $settings['advanced_template'] )  ) {
 			$html = $this->get_core_template_styles( $settings, $entry ) . $html;
 		}
 

--- a/src/view/html/FormSettings/add_edit.php
+++ b/src/view/html/FormSettings/add_edit.php
@@ -71,11 +71,11 @@ global $wp_settings_fields;
 
 	<div class="wp-filter gfpdf-tab-wrapper">
 		<ul class="filter-links">
-			<li>
+			<li id="gfpdf-general-nav">
 				<a href="#gfpdf-general-options" class="current"><i class="fa fa-cog"></i> General</a>
 			</li>
 
-			<li>
+			<li id="gfpdf-appearance-nav">
 				<a href="#gfpdf-appearance-options"><i class="fa fa-adjust"></i> Appearance</a>
 			</li>
 
@@ -83,7 +83,7 @@ global $wp_settings_fields;
 				<a href="#gfpdf-custom-appearance-options"><i class="fa fa-file-text-o"></i> Template</a>
 			</li>
 
-			<li>
+			<li id="gfpdf-advanced-nav">
 				<a href="#gfpdf-advanced-pdf-options"><i class="fa fa-cogs"></i> Advanced</a>
 			</li>
 		</ul>


### PR DESCRIPTION
- Hide the appearance tab when using a Tier 2 template
- Prevent the loading of the core template styles when usign a Tier 2 template
- Remove the filter "gfpdf_enable_advanced_template_field" because we want to automate this much more