### PR TITLE
Bump PHP minimum version up to 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -14,11 +13,11 @@ env:
 
 matrix:
   include:
-  - php: 5.3
+  - php: 5.4
     env: WP_VERSION=latest WP_MULTISITE=1
-  - php: 5.3
+  - php: 5.4
     env: WP_VERSION=4.3 WP_MULTISITE=0
-  - php: 5.3
+  - php: 5.4
     env: WP_VERSION=4.2 WP_MULTISITE=0
 
 before_script:

--- a/pdf.php
+++ b/pdf.php
@@ -107,13 +107,18 @@ class GFPDF_Major_Compatibility_Checks {
 
 	/**
 	 * The plugin's required PHP version
-	 * We've made the call to drop PHP5.2 support
+	 *
+	 * Gravity PDF 4.0 is such a major release that we can afford to also bump up the version requirements.
+	 * We really wanted to bump this up to an actively supported version of PHP (http://php.net/supported-versions.php)
+	 * but with WordPress supporting PHP5.2+ (and making no moves to increase this) we had to strike a balance.
+	 *
+	 * The initial release will require PHP 5.4 which will strike a better balance.
 	 *
 	 * @var string
 	 *
 	 * @since 4.0
 	 */
-	public $required_php_version = '5.3';
+	public $required_php_version = '5.4';
 
 	/**
 	 * Set our required variables for a fallback and attempt to initialise


### PR DESCRIPTION
Gravity PDF 4.0 is such a major release that we can afford to also bump up the version requirements.
We really wanted to bump this up to an actively supported version of PHP (http://php.net/supported-versions.php) but with WordPress supporting PHP5.2+ (and making no moves to increase this) we had to strike a balance.

The initial release will require PHP 5.4 which will strike a better balance.