### PR TITLE
Refer to our abstract GF API as $gform instead of $form

### DIFF
--- a/api.php
+++ b/api.php
@@ -152,7 +152,7 @@ final class GPDFAPI {
 	 *
 	 * Usage:
 	 *
-	 * $form->get_form( $form_id );
+	 * $gform->get_form( $form_id );
 	 *
 	 * @return \GFPDF\Helper\Helper_Form
 	 *
@@ -161,7 +161,7 @@ final class GPDFAPI {
 	public static function get_form_class() {
 		global $gfpdf;
 
-		return $gfpdf->form;
+		return $gfpdf->gform;
 	}
 
 	/**
@@ -430,7 +430,7 @@ final class GPDFAPI {
 	public static function product_table( $entry, $return = false ) {
 		global $gfpdf;
 
-		$products = new GFPDF\Helper\Fields\Field_Products( new GF_Field(), $entry, $gfpdf->form, $gfpdf->misc );
+		$products = new GFPDF\Helper\Fields\Field_Products( new GF_Field(), $entry, $gfpdf->gform, $gfpdf->misc );
 
 		if ( $return ) {
 			return $products->html();
@@ -456,7 +456,7 @@ final class GPDFAPI {
 		global $gfpdf;
 
 		/* Get our form */
-		$form = $gfpdf->form->get_form( $entry['form_id'] );
+		$form = $gfpdf->gform->get_form( $entry['form_id'] );
 
 		/* Check for errors */
 		if ( is_wp_error( $form ) ) {
@@ -469,7 +469,7 @@ final class GPDFAPI {
 			if ( $field->id == $field_id && $field->inputType == 'likert' ) {
 
 				/* Output our likert */
-				$likert = new GFPDF\Helper\Fields\Field_Likert( $field, $entry, $gfpdf->form, $gfpdf->misc );
+				$likert = new GFPDF\Helper\Fields\Field_Likert( $field, $entry, $gfpdf->gform, $gfpdf->misc );
 
 				if ( $return ) {
 					return $likert->html();

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -77,13 +77,13 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	public $log;
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	public $form;
+	public $gform;
 
 	/**
 	 * Holds our Helper_Notices object
@@ -193,21 +193,21 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$this->setup_logger();
 
 		/* Set up our form object */
-		$this->form = new Helper\Helper_Form();
+		$this->gform = new Helper\Helper_Form();
 
 		/* Set up our data access layer */
 		$this->data = new Helper\Helper_Data();
 		$this->data->init();
 
 		/* Set up our misc object */
-		$this->misc = new Helper\Helper_Misc( $this->log, $this->form, $this->data );
+		$this->misc = new Helper\Helper_Misc( $this->log, $this->gform, $this->data );
 
 		/* Set up our notices */
 		$this->notices = new Helper\Helper_Notices();
 		$this->notices->init();
 
 		/* Set up our options object - this is initialised on admin_init but other classes need to access its methods before this */
-		$this->options = new Helper\Helper_Options_Fields( $this->log, $this->form, $this->data, $this->misc, $this->notices );
+		$this->options = new Helper\Helper_Options_Fields( $this->log, $this->gform, $this->data, $this->misc, $this->notices );
 
 		/* Setup our Singleton object */
 		$this->singleton = new Helper\Helper_Singleton();
@@ -532,7 +532,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		/*
         * Localise admin script
         */
-		wp_localize_script( 'gfpdf_js_settings', 'GFPDF', $this->data->get_localised_script_data( $this->options, $this->form ) );
+		wp_localize_script( 'gfpdf_js_settings', 'GFPDF', $this->data->get_localised_script_data( $this->options, $this->gform ) );
 	}
 
 
@@ -710,8 +710,8 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 * @return void
 	 */
 	public function installer() {
-		$model = new Model\Model_Install( $this->form, $this->log, $this->data, $this->misc, $this->notices );
-		$class = new Controller\Controller_Install( $model, $this->form, $this->log, $this->notices, $this->data, $this->misc );
+		$model = new Model\Model_Install( $this->gform, $this->log, $this->data, $this->misc, $this->notices );
+		$class = new Controller\Controller_Install( $model, $this->gform, $this->log, $this->notices, $this->data, $this->misc );
 		$class->init();
 
 		/* set up required data */
@@ -734,7 +734,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$model = new Model\Model_Welcome_Screen( $this->log );
 		$view  = new View\View_Welcome_Screen( array(
 			'display_version' => PDF_EXTENDED_VERSION,
-		), $this->form );
+		), $this->gform );
 
 		$class = new Controller\Controller_Welcome_Screen( $model, $view, $this->log, $this->data, $this->options );
 		$class->init();
@@ -754,10 +754,10 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function gf_settings() {
 
-		$model = new Model\Model_Settings( $this->form, $this->log, $this->notices, $this->options, $this->data, $this->misc );
-		$view  = new View\View_Settings( array(), $this->form, $this->log, $this->options, $this->data, $this->misc );
+		$model = new Model\Model_Settings( $this->gform, $this->log, $this->notices, $this->options, $this->data, $this->misc );
+		$view  = new View\View_Settings( array(), $this->gform, $this->log, $this->options, $this->data, $this->misc );
 
-		$class = new Controller\Controller_Settings( $model, $view, $this->form, $this->log, $this->notices, $this->data, $this->misc );
+		$class = new Controller\Controller_Settings( $model, $view, $this->gform, $this->log, $this->notices, $this->data, $this->misc );
 		$class->init();
 
 		/* Add to our singleton controller */
@@ -775,7 +775,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function gf_form_settings() {
 
-		$model = new Model\Model_Form_Settings( $this->form, $this->log, $this->data, $this->options, $this->misc, $this->notices );
+		$model = new Model\Model_Form_Settings( $this->gform, $this->log, $this->data, $this->options, $this->misc, $this->notices );
 		$view  = new View\View_Form_Settings( array() );
 
 		$class = new Controller\Controller_Form_Settings( $model, $view, $this->data, $this->options, $this->misc );
@@ -796,10 +796,10 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function pdf() {
 
-		$model = new Model\Model_PDF( $this->form, $this->log, $this->options, $this->data, $this->misc, $this->notices );
-		$view  = new View\View_PDF( array(), $this->form, $this->log, $this->options, $this->data, $this->misc );
+		$model = new Model\Model_PDF( $this->gform, $this->log, $this->options, $this->data, $this->misc, $this->notices );
+		$view  = new View\View_PDF( array(), $this->gform, $this->log, $this->options, $this->data, $this->misc );
 
-		$class = new Controller\Controller_PDF( $model, $view, $this->form, $this->log, $this->misc );
+		$class = new Controller\Controller_PDF( $model, $view, $this->gform, $this->log, $this->misc );
 		$class->init();
 
 		/* Add to our singleton controller */
@@ -817,7 +817,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function shortcodes() {
 
-		$model = new Model\Model_Shortcodes( $this->form, $this->log, $this->options, $this->misc );
+		$model = new Model\Model_Shortcodes( $this->gform, $this->log, $this->options, $this->misc );
 		$view  = new View\View_Shortcodes( array() );
 
 		$class = new Controller\Controller_Shortcodes( $model, $view, $this->log );
@@ -841,7 +841,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$model = new Model\Model_Actions( $this->data, $this->options, $this->notices );
 		$view  = new View\View_Actions( array() );
 
-		$class = new Controller\Controller_Actions( $model, $view, $this->form, $this->log, $this->notices );
+		$class = new Controller\Controller_Actions( $model, $view, $this->gform, $this->log, $this->notices );
 		$class->init();
 
 		/* Add to our singleton controller */

--- a/src/controller/Controller_Actions.php
+++ b/src/controller/Controller_Actions.php
@@ -55,13 +55,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Controller_Actions extends Helper_Abstract_Controller implements Helper_Interface_Actions {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -87,16 +87,16 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 *
 	 * @param Helper_Abstract_Model|\GFPDF\Model\Model_Actions $model   Our Actions Model the controller will manage
 	 * @param Helper_Abstract_View|\GFPDF\View\View_Actions    $view    Our Actions View the controller will manage
-	 * @param \GFPDF\Helper\Helper_Abstract_Form               $form    Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Abstract_Form               $gform   Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface                  $log     Our logger class
 	 * @param \GFPDF\Helper\Helper_Notices                     $notices Our notice class used to queue admin messages and errors
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view, Helper_Abstract_Form $form, LoggerInterface $log, Helper_Notices $notices ) {
+	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view, Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Notices $notices ) {
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->notices = $notices;
 
@@ -193,7 +193,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 		foreach ( $this->get_routes() as $route ) {
 
 			/* Before displaying check the user has the correct capabilities, the notice isn't already been dismissed and the route condition has been met */
-			if ( $this->form->has_capability( $route['capability'] ) &&
+			if ( $this->gform->has_capability( $route['capability'] ) &&
 			     ! $this->model->is_notice_already_dismissed( $route['action'] ) &&
 			     call_user_func( $route['condition'] )
 			) {
@@ -221,7 +221,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 			if ( rgpost( 'gfpdf_action' ) == 'gfpdf_' . $route['action'] && call_user_func( $route['condition'] ) ) {
 
 				/* Check user capability */
-				if ( ! $this->form->has_capability( $route['capability'] ) ) {
+				if ( ! $this->gform->has_capability( $route['capability'] ) ) {
 
 					$this->log->addCritical( 'Lack of User Capabilities.', array(
 						'user'      => wp_get_current_user(),

--- a/src/controller/Controller_Install.php
+++ b/src/controller/Controller_Install.php
@@ -56,13 +56,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Controller_Install extends Helper_Abstract_Controller implements Helper_Interface_Actions, Helper_Interface_Filters {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -107,7 +107,7 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 	 * Setup our class by injecting all our dependancies
 	 *
 	 * @param Helper_Abstract_Model|\GFPDF\Model\Model_Install $model   Our Install Model the controller will manage
-	 * @param \GFPDF\Helper\Helper_Abstract_Form               $form    Our Install View the controller will manage
+	 * @param \GFPDF\Helper\Helper_Abstract_Form               $gform   Our Install View the controller will manage
 	 * @param \Monolog\Logger|LoggerInterface                  $log     Our logger class
 	 * @param \GFPDF\Helper\Helper_Notices                     $notices Our notice class used to queue admin messages and errors
 	 * @param \GFPDF\Helper\Helper_Data                        $data    Our plugin data store
@@ -115,10 +115,10 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_Form $form, LoggerInterface $log, Helper_Notices $notices, Helper_Data $data, Helper_Misc $misc ) {
+	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Notices $notices, Helper_Data $data, Helper_Misc $misc ) {
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->notices = $notices;
 		$this->data    = $data;
@@ -244,7 +244,7 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 			 *
 			 * If multisite only the super admin can uninstall the software. This is due to how the plugin shares similar directory structures across networked sites
 			 */
-			if ( ( ! is_multisite() && ! $this->form->has_capability( 'gravityforms_uninstall' ) ) ||
+			if ( ( ! is_multisite() && ! $this->gform->has_capability( 'gravityforms_uninstall' ) ) ||
 			     ( is_multisite() && ! is_super_admin() )
 			) {
 

--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -56,13 +56,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interface_Actions, Helper_Interface_Filters {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -88,18 +88,18 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	 *
 	 * @param Helper_Abstract_Model|\GFPDF\Model\Model_PDF $model Our PDF Model the controller will manage
 	 * @param Helper_Abstract_View|\GFPDF\View\View_PDF    $view  Our PDF View the controller will manage
-	 * @param \GFPDF\Helper\Helper_Abstract_Form           $form  Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Abstract_Form           $gform Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface              $log   Our logger class
 	 * @param \GFPDF\Helper\Helper_Misc                    $misc  Our miscellaneous class
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view, Helper_Abstract_Form $form, LoggerInterface $log, Helper_Misc $misc ) {
+	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view, Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Misc $misc ) {
 
 		/* Assign our internal variables */
-		$this->form = $form;
-		$this->log  = $log;
-		$this->misc = $misc;
+		$this->gform = $gform;
+		$this->log   = $log;
+		$this->misc  = $misc;
 
 		/* Load our model and view */
 		$this->model = $model;
@@ -296,7 +296,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* only display detailed error to admins */
 		$whitelist_errors = array( 'timeout_expired', 'access_denied' );
-		if ( $this->form->has_capability( 'gravityforms_view_settings' ) || in_array( $error->get_error_code(), $whitelist_errors ) ) {
+		if ( $this->gform->has_capability( 'gravityforms_view_settings' ) || in_array( $error->get_error_code(), $whitelist_errors ) ) {
 			wp_die( $error->get_error_message() );
 		} else {
 			wp_die( __( 'There was a problem generating your PDF', 'gravity-forms-pdf-extended' ) );

--- a/src/controller/Controller_Settings.php
+++ b/src/controller/Controller_Settings.php
@@ -57,14 +57,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0
  */
 class Controller_Settings extends Helper_Abstract_Controller implements Helper_Interface_Actions, Helper_Interface_Filters {
+
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -110,7 +111,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 	 *
 	 * @param Helper_Abstract_Model|\GFPDF\Model\Model_Settings $model   Our Settings Model the controller will manage
 	 * @param Helper_Abstract_View|\GFPDF\View\View_Settings    $view    Our Settings View the controller will manage
-	 * @param \GFPDF\Helper\Helper_Abstract_Form                $form    Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Abstract_Form                $gform   Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface                   $log     Our logger class
 	 * @param \GFPDF\Helper\Helper_Notices                      $notices Our notice class used to queue admin messages and errors
 	 * @param \GFPDF\Helper\Helper_Data                         $data    Our plugin data store
@@ -118,10 +119,10 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view, Helper_Abstract_Form $form, LoggerInterface $log, Helper_Notices $notices, Helper_Data $data, Helper_Misc $misc ) {
+	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view, Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Notices $notices, Helper_Data $data, Helper_Misc $misc ) {
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->notices = $notices;
 		$this->data    = $data;
@@ -181,7 +182,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		 *
 		 * If multisite only the super admin can uninstall the software. This is due to how the plugin shares similar directory structures across networked sites
 		 */
-		if ( ( ! is_multisite() && $this->form->has_capability( 'gravityforms_uninstall' ) ) ||
+		if ( ( ! is_multisite() && $this->gform->has_capability( 'gravityforms_uninstall' ) ) ||
 		     ( is_multisite() && is_super_admin() )
 		) {
 			add_action( 'gfpdf_post_tools_settings_page', array( $this->view, 'uninstaller' ), 5 );
@@ -267,7 +268,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 	public function edit_options_cap() {
 
 		/* because current_user_can() doesn't handle Gravity Forms permissions quite correct we'll do our checks here */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),
@@ -293,7 +294,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 	 */
 	public function disable_tools_on_view_cap( $nav ) {
 
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 			$this->log->addNotice( 'Lack of User Capabilities' );
 
 			unset( $nav[100] ); /* remove tools tab */
@@ -317,7 +318,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		}
 
 		/* check if the user has permission to copy the templates */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),

--- a/src/depreciated.php
+++ b/src/depreciated.php
@@ -234,10 +234,10 @@ class PDF_Common extends GFPDF_Depreciated_Abstract {
 	 * @since 3.0
 	 */
 	public static function do_mergetags( $string, $form_id, $lead_id ) {
-		$misc = GPDFAPI::get_misc_class();
-		$form = GPDFAPI::get_form_class();
+		$misc  = GPDFAPI::get_misc_class();
+		$gform = GPDFAPI::get_form_class();
 
-		return $misc->do_mergetags( $string, $form->get_form( $form_id ), $form->get_entry( $lead_id ) );
+		return $misc->do_mergetags( $string, $gform->get_form( $form_id ), $gform->get_entry( $lead_id ) );
 	}
 
 	/**
@@ -248,9 +248,9 @@ class PDF_Common extends GFPDF_Depreciated_Abstract {
 	 * @since 4.0
 	 */
 	public static function view_data( $form_data ) {
-		$form = GPDFAPI::get_form_class();
+		$gform = GPDFAPI::get_form_class();
 
-		if ( isset( $_GET['data'] ) && $form->has_capability( 'gravityforms_view_settings' ) ) {
+		if ( isset( $_GET['data'] ) && $gform->has_capability( 'gravityforms_view_settings' ) ) {
 			print '<pre>';
 			print_r( $form_data );
 			print '</pre>';
@@ -316,7 +316,7 @@ class PDF_Common extends GFPDF_Depreciated_Abstract {
 	 * @since 4.0
 	 */
 	public static function remove_invalid_characters( $name ) {
-		$misc = GPDFAPI::get_form_class();
+		$misc = GPDFAPI::get_misc_class();
 		return $misc->strip_invalid_characters( $name );
 	}
 }
@@ -407,7 +407,7 @@ class GFPDFEntryDetail extends GFPDF_Depreciated_Abstract {
 
 		/* Output the form title */
 		if ( $config['return'] ) {
-			$results['title'] = $styles . '<h2 id="details" class="default">' . $form['title'] . '</h2>';
+			$results['title'] = '<h2 id="details" class="default">' . $form['title'] . '</h2>';
 		} else {
 			?>
 
@@ -513,7 +513,9 @@ class GFPDFEntryDetail extends GFPDF_Depreciated_Abstract {
 	 *
 	 * @param string $html The original field HTML which we'll be discarding
 	 * @param string $value The field value
+	 * @param boolean $show_label
 	 * @param boolean $label Whether to show or hide the field's label
+	 * @param object $field
 	 *
 	 * @return string
 	 *

--- a/src/helper/Helper_Data.php
+++ b/src/helper/Helper_Data.php
@@ -179,19 +179,19 @@ class Helper_Data {
 	 * A key-value array to be used in a localized script call for our Gravity PDF javascript files
 	 *
 	 * @param \GFPDF\Helper\Helper_Abstract_Options $options
-	 * @param \GFPDF\Helper\Helper_Abstract_Form    $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form    $gform
 	 *
 	 * @return array
 	 *
 	 * @since  4.0
 	 */
-	public function get_localised_script_data( Helper_Abstract_Options $options, Helper_Abstract_Form $form ) {
+	public function get_localised_script_data( Helper_Abstract_Options $options, Helper_Abstract_Form $gform ) {
 
 		$custom_fonts = array_values( $options->get_custom_fonts() );
 
 		return apply_filters( 'gfpdf_localised_script_array', array(
 			'ajaxurl'                     => admin_url( 'admin-ajax.php' ),
-			'GFbaseUrl'                   => $form->get_plugin_url(),
+			'GFbaseUrl'                   => $gform->get_plugin_url(),
 			'pluginUrl'                   => PDF_PLUGIN_URL,
 			'spinnerUrl'                  => admin_url( 'images/spinner-2x.gif' ),
 			'spinnerAlt'                  => __( 'Loading...', 'gravity-forms-pdf-extended' ),

--- a/src/helper/Helper_Migration.php
+++ b/src/helper/Helper_Migration.php
@@ -47,13 +47,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Helper_Migration {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -116,10 +116,10 @@ class Helper_Migration {
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Form $form, LoggerInterface $log, Helper_Data $data, Helper_Abstract_Options $options, Helper_Misc $misc, Helper_Notices $notices ) {
+	public function __construct( Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Data $data, Helper_Abstract_Options $options, Helper_Misc $misc, Helper_Notices $notices ) {
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->data    = $data;
 		$this->options = $options;
@@ -374,7 +374,7 @@ class Helper_Migration {
 		if ( ( ! defined( 'GFPDF_SET_DEFAULT_TEMPLATE' ) || GFPDF_SET_DEFAULT_TEMPLATE === true ) && sizeof( $raw_config['default'] ) > 0 ) {
 
 			/* Get all forms */
-			$forms = $this->form->get_forms();
+			$forms = $this->gform->get_forms();
 
 			/* Create an index of current form IDs */
 			$form_ids = array();
@@ -439,7 +439,7 @@ class Helper_Migration {
 
 		/* Loop through forms and attempt to get the form data */
 		foreach ( $config as $form_id => $nodes ) {
-			$form = $this->form->get_form( $form_id );
+			$form = $this->gform->get_form( $form_id );
 
 			if ( ! is_wp_error( $form ) ) {
 

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -2,8 +2,6 @@
 
 namespace GFPDF\Helper;
 
-use GFPDF\Model\Model_PDF;
-
 use Psr\Log\LoggerInterface;
 
 use GFCommon;
@@ -55,13 +53,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Helper_Misc {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -86,17 +84,17 @@ class Helper_Misc {
 	 * Store required classes locally
 	 *
 	 * @param \Monolog\Logger|LoggerInterface    $log
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Data          $data
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( LoggerInterface $log, Helper_Abstract_Form $form, Helper_Data $data ) {
+	public function __construct( LoggerInterface $log, Helper_Abstract_Form $gform, Helper_Data $data ) {
 
 		/* Assign our internal variables */
-		$this->log  = $log;
-		$this->form = $form;
-		$this->data = $data;
+		$this->log   = $log;
+		$this->gform = $gform;
+		$this->data  = $data;
 	}
 
 	/**
@@ -654,7 +652,7 @@ class Helper_Misc {
 		/* Disable the field encryption checks which can slow down our entry queries */
 		add_filter( 'gform_is_encrypted_field', '__return_false' );
 
-		$form          = $this->form->get_form( $entry['form_id'] );
+		$form          = $this->gform->get_form( $entry['form_id'] );
 		$pdf           = GPDFAPI::get_mvc_class( 'Model_PDF' );
 		$form_settings = GPDFAPI::get_mvc_class( 'Model_Form_Settings' );
 
@@ -765,7 +763,7 @@ class Helper_Misc {
 		$leads    = rgget( 'lid' );
 		$override = ( isset( $settings['public_access'] ) && $settings['public_access'] == 'Yes' ) ? true : false;
 
-		if ( $leads && ( $override === true || $this->form->has_capability( 'gravityforms_view_entries' ) ) ) {
+		if ( $leads && ( $override === true || $this->gform->has_capability( 'gravityforms_view_entries' ) ) ) {
 			$ids = explode( ',', $leads );
 
 			/* ensure all passed ids are integers */
@@ -889,7 +887,7 @@ class Helper_Misc {
 			return true;
 		}
 
-		$form = $this->form->get_form( $entry['form_id'] );
+		$form = $this->gform->get_form( $entry['form_id'] );
 
 		/* Do the evaluation */
 		$evaluation = GFCommon::evaluate_conditional_logic( $logic, $form, $entry );
@@ -942,7 +940,7 @@ class Helper_Misc {
 	 * @since 4.0
 	 */
 	public function get_fields_sorted_by_id( $form_id ) {
-		$form   = $this->form->get_form( $form_id );
+		$form   = $this->gform->get_form( $form_id );
 		$fields = array();
 
 		if ( isset( $form['fields'] ) && is_array( $form['fields'] ) ) {

--- a/src/helper/Helper_PDF.php
+++ b/src/helper/Helper_PDF.php
@@ -137,13 +137,13 @@ class Helper_PDF {
 	protected $print = false;
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our Helper_Data object
@@ -161,17 +161,17 @@ class Helper_PDF {
 	 * @param array                              $entry    The Gravity Form Entry to be processed
 	 * @param array                              $settings The Gravity PDF Settings Array
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Data          $data
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $entry, $settings, Helper_Abstract_Form $form, Helper_Data $data ) {
+	public function __construct( $entry, $settings, Helper_Abstract_Form $gform, Helper_Data $data ) {
 
 		/* Assign our internal variables */
 		$this->entry    = $entry;
 		$this->settings = $settings;
-		$this->form     = $form;
+		$this->gform    = $gform;
 		$this->data     = $data;
 
 		$this->set_path();
@@ -212,7 +212,7 @@ class Helper_PDF {
 			$this->set_template();
 		}
 
-		$form = $this->form->get_form( $this->entry['form_id'] );
+		$form = $this->gform->get_form( $this->entry['form_id'] );
 
 		/* Load in our PHP template */
 		if ( empty( $html ) ) {
@@ -224,7 +224,7 @@ class Helper_PDF {
 		$html = apply_filters( 'gfpdfe_pdf_template_' . $form['id'], $html, $this->entry['id'], $this->settings ); /* Backwards compat */
 
 		$html = apply_filters( 'gfpdf_pdf_html_output', $html, $form, $this->entry, $this->settings, $this );
-		$html = apply_filters( 'gfpdf_pdf_html_output_' . $form['id'], $html, $this->form, $this->entry, $this->settings, $this );
+		$html = apply_filters( 'gfpdf_pdf_html_output_' . $form['id'], $html, $this->gform, $this->entry, $this->settings, $this );
 
 		/* Check if we should output the HTML to the browser, for debugging */
 		$this->maybe_display_raw_html( $html );
@@ -246,7 +246,7 @@ class Helper_PDF {
 		$this->show_print_dialog();
 		$this->set_metadata();
 
-		$form = $this->form->get_form( $this->entry['form_id'] );
+		$form = $this->gform->get_form( $this->entry['form_id'] );
 
 		/* allow $mpdf object class to be modified */
 		$this->mpdf = apply_filters( 'gfpdf_mpdf_class', $this->mpdf, $form, $this->entry, $this->settings, $this );
@@ -322,7 +322,7 @@ class Helper_PDF {
 		$template = ( isset( $this->settings['template'] ) ) ? $this->get_file_with_extension( $this->settings['template'] ) : '';
 
 		/* Allow a user to change the current template if they have the appropriate capabilities */
-		if ( rgget( 'template' ) && is_user_logged_in() && $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( rgget( 'template' ) && is_user_logged_in() && $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 			$template = $this->get_file_with_extension( rgget( 'template' ) );
 		}
 
@@ -588,7 +588,7 @@ class Helper_PDF {
 	protected function begin_pdf() {
 		$this->mpdf = new mPDF( '', $this->paper_size, 0, '', 15, 15, 16, 16, 9, 9, $this->orientation );
 
-		$form = $this->form->get_form( $this->entry['form_id'] );
+		$form = $this->gform->get_form( $this->entry['form_id'] );
 
 		/**
 		 * Allow $mpdf object class to be modified
@@ -759,8 +759,8 @@ class Helper_PDF {
 	 */
 	protected function maybe_display_raw_html( $html ) {
 
-		if ( $this->output !== 'SAVE' && rgget( 'html' ) && $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
-			echo apply_filters( 'gfpdf_pre_html_browser_output', $html, $this->settings, $this->entry, $this->form, $this );
+		if ( $this->output !== 'SAVE' && rgget( 'html' ) && $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
+			echo apply_filters( 'gfpdf_pre_html_browser_output', $html, $this->settings, $this->entry, $this->gform, $this );
 			exit;
 		}
 	}

--- a/src/helper/Helper_PDF_List_Table.php
+++ b/src/helper/Helper_PDF_List_Table.php
@@ -53,16 +53,16 @@ class Helper_PDF_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.0
 	 */
-	public $form_array;
+	public $form;
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form_plugin;
+	protected $gform;
 
 	/**
 	 * Holds our Helper_Misc object
@@ -87,20 +87,20 @@ class Helper_PDF_List_Table extends WP_List_Table {
 	/**
 	 * Setup our class with appropriate data
 	 *
-	 * @param array                                 $form_array
-	 * @param \GFPDF\Helper\Helper_Abstract_Form    $form_plugin
+	 * @param array                                 $form The Gravity Forms object
+	 * @param \GFPDF\Helper\Helper_Abstract_Form    $gform Our abstracted Gravity Forms API
 	 * @param \GFPDF\Helper\Helper_Misc             $misc
 	 * @param \GFPDF\Helper\Helper_Abstract_Options $options
 	 *
 	 * @since    4.0
 	 */
-	public function __construct( $form_array, Helper_Abstract_Form $form_plugin, Helper_Misc $misc, Helper_Abstract_Options $options ) {
+	public function __construct( $form, Helper_Abstract_Form $gform, Helper_Misc $misc, Helper_Abstract_Options $options ) {
 
 		/* Assign our internal variables */
-		$this->form_array  = $form_array;
-		$this->form_plugin = $form_plugin;
-		$this->misc        = $misc;
-		$this->options     = $options;
+		$this->form    = $form;
+		$this->gform   = $gform;
+		$this->misc    = $misc;
+		$this->options = $options;
 
 		/* Cache column header internally so we don't have to work with the global get_column_headers() function */
 		$this->_column_headers = array(
@@ -149,7 +149,7 @@ class Helper_PDF_List_Table extends WP_List_Table {
 	 * @since 4.0
 	 */
 	public function prepare_items() {
-		$this->items = ( isset( $this->form_array['gfpdf_form_settings'] ) ) ? $this->form_array['gfpdf_form_settings'] : array();
+		$this->items = ( isset( $this->form['gfpdf_form_settings'] ) ) ? $this->form['gfpdf_form_settings'] : array();
 	}
 
 	/**
@@ -242,7 +242,7 @@ class Helper_PDF_List_Table extends WP_List_Table {
 
 		<img data-id="<?php echo $item['id'] ?>" data-nonce="<?php echo $state_nonce; ?>"
 		     data-fid="<?php echo $form_id; ?>"
-		     src="<?php echo $this->form_plugin->get_plugin_url() ?>/images/active<?php echo intval( $is_active ) ?>.png"
+		     src="<?php echo $this->gform->get_plugin_url() ?>/images/active<?php echo intval( $is_active ) ?>.png"
 		     style="cursor: pointer;margin:-1px 0 0 8px;"
 		     alt="<?php $is_active ? __( 'Active', 'gravity-forms-pdf-extended' ) : __( 'Inactive', 'gravity-forms-pdf-extended' ); ?>"
 		     title="<?php echo $is_active ? __( 'Active', 'gravity-forms-pdf-extended' ) : __( 'Inactive', 'gravity-forms-pdf-extended' ); ?>"/>
@@ -267,7 +267,7 @@ class Helper_PDF_List_Table extends WP_List_Table {
 
 		/* Convert our IDs to names */
 		$notification_names = array();
-		foreach ( $this->form_array['notifications'] as $notification ) {
+		foreach ( $this->form['notifications'] as $notification ) {
 			if ( in_array( $notification['id'], $item['notification'] ) ) {
 				$notification_names[] = $notification['name'];
 			}

--- a/src/helper/abstract/Helper_Abstract_Fields.php
+++ b/src/helper/abstract/Helper_Abstract_Fields.php
@@ -114,14 +114,14 @@ abstract class Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		/* Assign our internal variables */
 		$this->misc = $misc;
@@ -142,7 +142,7 @@ abstract class Helper_Abstract_Fields {
 
 		$this->field = $field;
 		$this->entry = $entry;
-		$this->form  = $form->get_form( $entry['form_id'] );
+		$this->form  = $gform->get_form( $entry['form_id'] );
 
 	}
 

--- a/src/helper/abstract/Helper_Abstract_Options.php
+++ b/src/helper/abstract/Helper_Abstract_Options.php
@@ -52,13 +52,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -122,18 +122,18 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	 * Helper_Abstract_Options constructor.
 	 *
 	 * @param \Monolog\Logger|LoggerInterface    $log
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Data          $data
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 * @param \GFPDF\Helper\Helper_Notices       $notices
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( LoggerInterface $log, Helper_Abstract_Form $form, Helper_Data $data, Helper_Misc $misc, Helper_Notices $notices ) {
+	public function __construct( LoggerInterface $log, Helper_Abstract_Form $gform, Helper_Data $data, Helper_Misc $misc, Helper_Notices $notices ) {
 
 		/* Assign our internal variables */
 		$this->log     = $log;
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->data    = $data;
 		$this->misc    = $misc;
 		$this->notices = $notices;
@@ -385,7 +385,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		/* If we haven't pulled the form meta data from the database do so now */
 		if ( ! isset( $this->data->form_settings[ $form_id ] ) ) {
 
-			$form = $this->form->get_form( $form_id );
+			$form = $this->gform->get_form( $form_id );
 
 			if ( empty( $form ) ) {
 
@@ -548,7 +548,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			$options[ $pdf_id ] = $pdf;
 
 			/* get the up-to-date form object and merge in the results */
-			$form = $this->form->get_form( $form_id );
+			$form = $this->gform->get_form( $form_id );
 
 			/* Update our GFPDF settings */
 			$form['gfpdf_form_settings'] = $options;
@@ -559,7 +559,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 				$this->log->addNotice( 'Update Form.', array( 'form' => $form ) );
 
 				/* Update the database, if able */
-				$did_update = $this->form->update_form( $form );
+				$did_update = $this->gform->update_form( $form );
 			}
 
 			if ( ! $update_db || $did_update !== false ) {
@@ -611,13 +611,13 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			}
 
 			/* get the form and merge in the results */
-			$form = $this->form->get_form( $form_id );
+			$form = $this->gform->get_form( $form_id );
 
 			/* Update our GFPDF settings */
 			$form['gfpdf_form_settings'] = $options;
 
 			/* update the database, if able */
-			$did_update = $this->form->update_form( $form );
+			$did_update = $this->gform->update_form( $form );
 
 			/* If it updated, let's update the global variable */
 			if ( $did_update !== false ) {
@@ -766,7 +766,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		$capabilities = array();
 
 		/* Add Gravity Forms Capabilities */
-		$gf_caps = $this->form->get_capabilities();
+		$gf_caps = $this->gform->get_capabilities();
 
 		foreach ( $gf_caps as $gf_cap ) {
 			$capabilities[ __( 'Gravity Forms Capabilities', 'gravity-forms-pdf-extended' ) ][ $gf_cap ] = $gf_cap;

--- a/src/helper/abstract/Helper_Abstract_View.php
+++ b/src/helper/abstract/Helper_Abstract_View.php
@@ -44,6 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0
  */
 abstract class Helper_Abstract_View extends Helper_Abstract_Model {
+
 	/**
 	 * Each object should have a view name
 	 *

--- a/src/helper/fields/Field_Address.php
+++ b/src/helper/fields/Field_Address.php
@@ -57,21 +57,21 @@ class Field_Address extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Address ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Address' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Checkbox.php
+++ b/src/helper/fields/Field_Checkbox.php
@@ -59,21 +59,21 @@ class Field_Checkbox extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Checkbox ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Checkbox' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Creditcard.php
+++ b/src/helper/fields/Field_Creditcard.php
@@ -57,21 +57,21 @@ class Field_CreditCard extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! ( $field instanceof GF_Field_CreditCard ) ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_CreditCard' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Date.php
+++ b/src/helper/fields/Field_Date.php
@@ -58,21 +58,21 @@ class Field_Date extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Date ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Date' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Email.php
+++ b/src/helper/fields/Field_Email.php
@@ -57,21 +57,21 @@ class Field_Email extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Email ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Email' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Fileupload.php
+++ b/src/helper/fields/Field_Fileupload.php
@@ -58,21 +58,21 @@ class Field_Fileupload extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_FileUpload ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_FileUpload' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Hidden.php
+++ b/src/helper/fields/Field_Hidden.php
@@ -57,21 +57,21 @@ class Field_Hidden extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Hidden ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Hidden' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Html.php
+++ b/src/helper/fields/Field_Html.php
@@ -57,21 +57,21 @@ class Field_Html extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_HTML ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_HTML' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_List.php
+++ b/src/helper/fields/Field_List.php
@@ -58,21 +58,21 @@ class Field_List extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_List ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_List' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Multiselect.php
+++ b/src/helper/fields/Field_Multiselect.php
@@ -59,21 +59,21 @@ class Field_Multiselect extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_MultiSelect ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_MultiSelect' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Name.php
+++ b/src/helper/fields/Field_Name.php
@@ -57,21 +57,21 @@ class Field_Name extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! ( $field instanceof GF_Field_Name ) ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Name' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Number.php
+++ b/src/helper/fields/Field_Number.php
@@ -58,21 +58,21 @@ class Field_Number extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Number ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Number' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Phone.php
+++ b/src/helper/fields/Field_Phone.php
@@ -57,21 +57,21 @@ class Field_Phone extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! ( $field instanceof GF_Field_Phone ) ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Phone' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Poll.php
+++ b/src/helper/fields/Field_Poll.php
@@ -57,17 +57,17 @@ class Field_Poll extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 
 		/*
          * Custom Field can be any of the following field types:
@@ -79,14 +79,14 @@ class Field_Poll extends Helper_Abstract_Fields {
 		try {
 			/* check load our class */
 			if ( class_exists( $class ) ) {
-				$this->fieldObject = apply_filters( 'gfpdf_field_class', new $class( $field, $entry, $form, $misc ), $field, $entry, $form );
+				$this->fieldObject = apply_filters( 'gfpdf_field_class', new $class( $field, $entry, $gform, $misc ), $field, $entry, $form );
 				$this->fieldObject = apply_filters( 'gfpdf_field_class_' . $field->inputType , $this->fieldObject, $field, $entry, $form );
 			} else {
 				throw new Exception( 'Class not found' );
 			}
 		} catch ( Exception $e ) {
 			/* Exception thrown. Load generic field loader */
-			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $form, $misc ), $field, $entry, $form );
+			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $gform, $misc ), $field, $entry, $form );
 		}
 	}
 

--- a/src/helper/fields/Field_Post_Category.php
+++ b/src/helper/fields/Field_Post_Category.php
@@ -58,17 +58,17 @@ class Field_Post_Category extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 
 		/*
          * Category can be multiple field types
@@ -79,14 +79,14 @@ class Field_Post_Category extends Helper_Abstract_Fields {
 		try {
 			/* check load our class */
 			if ( class_exists( $class ) ) {
-				$this->fieldObject = apply_filters( 'gfpdf_field_class', new $class( $field, $entry, $form, $misc ), $field, $entry, $form );
+				$this->fieldObject = apply_filters( 'gfpdf_field_class', new $class( $field, $entry, $gform, $misc ), $field, $entry, $form );
 				$this->fieldObject = apply_filters( 'gfpdf_field_class_' . $field->inputType , $this->fieldObject, $field, $entry, $form );
 			} else {
 				throw new Exception( 'Class not found' );
 			}
 		} catch ( Exception $e ) {
 			/* Exception thrown. Load generic field loader */
-			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $form, $misc ), $field, $entry, $form );
+			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $gform, $misc ), $field, $entry, $form );
 		}
 
 		/* force the fieldObject value cache */

--- a/src/helper/fields/Field_Post_Content.php
+++ b/src/helper/fields/Field_Post_Content.php
@@ -57,21 +57,21 @@ class Field_Post_Content extends Helper_Abstract_Fields {
 	 * @param object               $field The GF_Field_* Object
 	 * @param array                $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Post_Content ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Post_Content' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Post_Custom_Field.php
+++ b/src/helper/fields/Field_Post_Custom_Field.php
@@ -55,17 +55,17 @@ class Field_Post_Custom_Field extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 
 		/*
          * Custom Field can be any of the following field types:
@@ -77,14 +77,14 @@ class Field_Post_Custom_Field extends Helper_Abstract_Fields {
 		try {
 			/* check load our class */
 			if ( class_exists( $class ) ) {
-				$this->fieldObject = apply_filters( 'gfpdf_field_class', new $class( $field, $entry, $form, $misc ), $field, $entry, $form );
-				$this->fieldObject = apply_filters( 'gfpdf_field_class_' . $field->inputType , $this->fieldObject, $field, $entry, $form );
+				$this->fieldObject = apply_filters( 'gfpdf_field_class', new $class( $field, $entry, $gform, $misc ), $field, $entry, $gform );
+				$this->fieldObject = apply_filters( 'gfpdf_field_class_' . $field->inputType , $this->fieldObject, $field, $entry, $gform );
 			} else {
 				throw new Exception( 'Class not found' );
 			}
 		} catch ( Exception $e ) {
 			/* Exception thrown. Load generic field loader */
-			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $form, $misc ), $field, $entry, $form );
+			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $gform, $misc ), $field, $entry, $gform );
 		}
 
 		/* force the fieldObject value cache */

--- a/src/helper/fields/Field_Post_Excerpt.php
+++ b/src/helper/fields/Field_Post_Excerpt.php
@@ -57,21 +57,21 @@ class Field_Post_Excerpt extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Post_Excerpt ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Post_Excerpt' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Post_Image.php
+++ b/src/helper/fields/Field_Post_Image.php
@@ -57,21 +57,21 @@ class Field_Post_Image extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Post_Image ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Post_Image' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Post_Tags.php
+++ b/src/helper/fields/Field_Post_Tags.php
@@ -58,21 +58,21 @@ class Field_Post_Tags extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Post_Tags ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Post_Tags' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Post_Title.php
+++ b/src/helper/fields/Field_Post_Title.php
@@ -57,21 +57,21 @@ class Field_Post_Title extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Post_Title ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Post_Title' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Radio.php
+++ b/src/helper/fields/Field_Radio.php
@@ -59,21 +59,21 @@ class Field_Radio extends Helper_Abstract_Fields {
 	 * @param object               $field The GF_Field_* Object
 	 * @param array                $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Radio ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Radio' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Section.php
+++ b/src/helper/fields/Field_Section.php
@@ -58,21 +58,21 @@ class Field_Section extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Section ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Section' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Select.php
+++ b/src/helper/fields/Field_Select.php
@@ -59,21 +59,21 @@ class Field_Select extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Select ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Select' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Survey.php
+++ b/src/helper/fields/Field_Survey.php
@@ -57,17 +57,17 @@ class Field_Survey extends Helper_Abstract_Fields {
 	 * @param object                             $field The GF_Field_* Object
 	 * @param array                              $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 
 		/*
          * Survey Field can be any of the following:
@@ -79,14 +79,14 @@ class Field_Survey extends Helper_Abstract_Fields {
 		try {
 			/* check load our class */
 			if ( class_exists( $class ) ) {
-				$this->fieldObject = apply_filters( 'gfpdf_field_class', new $class( $field, $entry, $form, $misc ), $field, $entry, $form );
+				$this->fieldObject = apply_filters( 'gfpdf_field_class', new $class( $field, $entry, $gform, $misc ), $field, $entry, $form );
 				$this->fieldObject = apply_filters( 'gfpdf_field_class_' . $field->inputType , $this->fieldObject, $field, $entry, $form );
 			} else {
 				throw new Exception();
 			}
 		} catch ( Exception $e ) {
 			/* Exception thrown. Load generic field loader */
-			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $form, $misc ), $field, $entry, $form );
+			$this->fieldObject = apply_filters( 'gfpdf_field_default_class', new Field_Default( $field, $entry, $gform, $misc ), $field, $entry, $form );
 		}
 
 		/* force the fieldObject value cache */

--- a/src/helper/fields/Field_Text.php
+++ b/src/helper/fields/Field_Text.php
@@ -57,21 +57,21 @@ class Field_Text extends Helper_Abstract_Fields {
 	 * @param object               $field The GF_Field_* Object
 	 * @param array                $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Text ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Text' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Textarea.php
+++ b/src/helper/fields/Field_Textarea.php
@@ -57,21 +57,21 @@ class Field_Textarea extends Helper_Abstract_Fields {
 	 * @param object               $field The GF_Field_* Object
 	 * @param array                $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Textarea ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Textarea' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	public function html( $value = '', $label = true ) {

--- a/src/helper/fields/Field_Time.php
+++ b/src/helper/fields/Field_Time.php
@@ -57,21 +57,21 @@ class Field_Time extends Helper_Abstract_Fields {
 	 * @param object               $field The GF_Field_* Object
 	 * @param array                $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Time ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Time' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/helper/fields/Field_Website.php
+++ b/src/helper/fields/Field_Website.php
@@ -58,21 +58,21 @@ class Field_Website extends Helper_Abstract_Fields {
 	 * @param object               $field The GF_Field_* Object
 	 * @param array                $entry The Gravity Forms Entry
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform
 	 * @param \GFPDF\Helper\Helper_Misc          $misc
 	 *
 	 * @throws Exception
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $field, $entry, Helper_Abstract_Form $form, Helper_Misc $misc ) {
+	public function __construct( $field, $entry, Helper_Abstract_Form $gform, Helper_Misc $misc ) {
 
 		if ( ! is_object( $field ) || ! $field instanceof GF_Field_Website ) {
 			throw new Exception( '$field needs to be in instance of GF_Field_Website' );
 		}
 
 		/* call our parent method */
-		parent::__construct( $field, $entry, $form, $misc );
+		parent::__construct( $field, $entry, $gform, $misc );
 	}
 
 	/**

--- a/src/model/Model_Form_Settings.php
+++ b/src/model/Model_Form_Settings.php
@@ -63,13 +63,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Model_Form_Settings extends Helper_Abstract_Model {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -123,7 +123,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	/**
 	 * Setup our class by injecting all our dependancies
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form    $form    Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Abstract_Form    $gform   Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface       $log     Our logger class
 	 * @param \GFPDF\Helper\Helper_Data             $data    Our plugin data store
 	 * @param \GFPDF\Helper\Helper_Abstract_Options $options Our options class which allows us to access any settings
@@ -132,10 +132,10 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Form $form, LoggerInterface $log, Helper_Data $data, Helper_Abstract_Options $options, Helper_Misc $misc, Helper_Notices $notices ) {
+	public function __construct( Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Data $data, Helper_Abstract_Options $options, Helper_Misc $misc, Helper_Notices $notices ) {
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->data    = $data;
 		$this->options = $options;
@@ -176,7 +176,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	public function process_list_view( $form_id ) {
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
 			$this->log->addWarning( 'Lack of User Capabilities.' );
 			wp_die( __( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
@@ -185,10 +185,10 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$controller = $this->getController();
 
 		/* get the form object */
-		$form = $this->form->get_form( $form_id );
+		$form = $this->gform->get_form( $form_id );
 
 		/* load our list table */
-		$pdf_table = new Helper_PDF_List_Table( $form, $this->form, $this->misc, $this->options );
+		$pdf_table = new Helper_PDF_List_Table( $form, $this->gform, $this->misc, $this->options );
 		$pdf_table->prepare_items();
 
 		/* pass to view */
@@ -212,7 +212,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	public function show_edit_view( $form_id, $pdf_id ) {
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 			$this->log->addWarning( 'Lack of User Capabilities.' );
 			wp_die( __( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
 		}
@@ -220,7 +220,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$controller = $this->getController();
 
 		/* get the form object */
-		$form = $this->form->get_form( $form_id );
+		$form = $this->gform->get_form( $form_id );
 
 		/* parse input and get required information */
 		if ( ! $pdf_id ) {
@@ -267,7 +267,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	public function process_submission( $form_id, $pdf_id ) {
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),
@@ -801,7 +801,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$this->log->addNotice( 'Running AJAX Endpoint', array( 'type' => 'Delete PDF Settings' ) );
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),
@@ -867,7 +867,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$this->log->addNotice( 'Running AJAX Endpoint', array( 'type' => 'Duplicate PDF Settings' ) );
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),
@@ -948,7 +948,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$this->log->addNotice( 'Running AJAX Endpoint', array( 'type' => 'Change PDF Settings State' ) );
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),
@@ -982,7 +982,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			/* toggle state */
 			$config['active'] = ( $config['active'] === true ) ? false : true;
 			$state            = ( $config['active'] ) ? __( 'Active', 'gravity-forms-pdf-extended' ) : __( 'Inactive', 'gravity-forms-pdf-extended' );
-			$src              = $this->form->get_plugin_url() . '/images/active' . intval( $config['active'] ) . '.png';
+			$src              = $this->gform->get_plugin_url() . '/images/active' . intval( $config['active'] ) . '.png';
 
 			$results = $this->options->update_pdf( $fid, $config['id'], $config );
 
@@ -1023,7 +1023,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$this->log->addNotice( 'Running AJAX Endpoint', array( 'type' => 'Render Template Custom Fields' ) );
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),

--- a/src/model/Model_Install.php
+++ b/src/model/Model_Install.php
@@ -56,13 +56,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Model_Install extends Helper_Abstract_Model {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -106,7 +106,7 @@ class Model_Install extends Helper_Abstract_Model {
 	/**
 	 * Setup our class by injecting all our dependancies
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form $form    Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Abstract_Form $gform   Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface    $log     Our logger class
 	 * @param \GFPDF\Helper\Helper_Data          $data    Our plugin data store
 	 * @param \GFPDF\Helper\Helper_Misc          $misc    Our miscellaneous class
@@ -114,10 +114,10 @@ class Model_Install extends Helper_Abstract_Model {
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Form $form, LoggerInterface $log, Helper_Data $data, Helper_Misc $misc, Helper_Notices $notices ) {
+	public function __construct( Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Data $data, Helper_Misc $misc, Helper_Notices $notices ) {
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->data    = $data;
 		$this->misc    = $misc;
@@ -437,13 +437,13 @@ class Model_Install extends Helper_Abstract_Model {
 	 */
 	public function remove_plugin_form_settings() {
 
-		$forms = $this->form->get_forms();
+		$forms = $this->gform->get_forms();
 
 		foreach ( $forms as $form ) {
 			/* only update forms which have a PDF configuration */
 			if ( isset( $form['gfpdf_form_settings'] ) ) {
 				unset( $form['gfpdf_form_settings'] );
-				if ( $this->form->update_form( $form ) !== true ) {
+				if ( $this->gform->update_form( $form ) !== true ) {
 					$this->log->addError( 'Cannot Remove PDF Settings from Form.', array( 'form' => $form ) );
 					$this->notices->add_error( sprintf( __( 'There was a problem removing the Gravity Form "%s" PDF configuration. Try delete manually.', 'gravity-forms-pdf-extended' ), $form['id'] . ': ' . $form['title'] ) );
 				}

--- a/src/model/Model_Settings.php
+++ b/src/model/Model_Settings.php
@@ -64,13 +64,13 @@ class Model_Settings extends Helper_Abstract_Model {
 	public $form_settings_errors;
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -114,7 +114,7 @@ class Model_Settings extends Helper_Abstract_Model {
 	/**
 	 * Set up our dependancies
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form    $form    Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Abstract_Form    $gform   Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface       $log     Our logger class
 	 * @param \GFPDF\Helper\Helper_Notices          $notices Our notice class used to queue admin messages and errors
 	 * @param \GFPDF\Helper\Helper_Abstract_Options $options Our options class which allows us to access any settings
@@ -123,10 +123,10 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Form $form, LoggerInterface $log, Helper_Notices $notices, Helper_Abstract_Options $options, Helper_Data $data, Helper_Misc $misc ) {
+	public function __construct( Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Notices $notices, Helper_Abstract_Options $options, Helper_Data $data, Helper_Misc $misc ) {
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->options = $options;
 		$this->notices = $notices;
@@ -560,7 +560,7 @@ class Model_Settings extends Helper_Abstract_Model {
 	private function ajax_font_validation() {
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 			/* fail */
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),
@@ -756,7 +756,7 @@ class Model_Settings extends Helper_Abstract_Model {
 	public function check_tmp_pdf_security() {
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_view_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_view_settings' ) ) {
 			/* fail */
 			$this->log->addCritical( 'Lack of User Capabilities.', array(
 				'user'      => wp_get_current_user(),

--- a/src/model/Model_Shortcodes.php
+++ b/src/model/Model_Shortcodes.php
@@ -55,13 +55,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Model_Shortcodes extends Helper_Abstract_Model {
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -95,16 +95,16 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 	/**
 	 * Setup our class by injecting all our dependancies
 	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form|\GFPDF\Helper\Helper_Form              $form    Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Abstract_Form|\GFPDF\Helper\Helper_Form              $gform   Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface                                           $log     Our logger class
 	 * @param \GFPDF\Helper\Helper_Abstract_Options|\GFPDF\Helper\Helper_Options_Fields $options Our options class which allows us to access any settings
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( Helper_Abstract_Form $form, LoggerInterface $log, Helper_Abstract_Options $options, Helper_Misc $misc ) {
+	public function __construct( Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Abstract_Options $options, Helper_Misc $misc ) {
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->options = $options;
 		$this->misc    = $misc;
@@ -126,7 +126,7 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 		$this->log->addNotice( 'Generating Shortcode' );
 
 		$controller           = $this->getController();
-		$has_view_permissions = $this->form->has_capability( 'gravityforms_view_entries' );
+		$has_view_permissions = $this->gform->has_capability( 'gravityforms_view_entries' );
 
 		/* merge in any missing defaults */
 		$attributes = shortcode_atts( array(
@@ -164,7 +164,7 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 		}
 
 		/* Check if we have a valid PDF configuration */
-		$entry  = $this->form->get_entry( $attributes['entry'] );
+		$entry  = $this->gform->get_entry( $attributes['entry'] );
 		$config = ( ! is_wp_error( $entry ) ) ? $this->options->get_pdf( $entry['form_id'], $attributes['id'] ) : $entry; /* if invalid entry a WP_Error will be thrown */
 
 		if ( is_wp_error( $config ) ) {
@@ -197,7 +197,7 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 		}
 
 		/* Everything looks valid so let's get the URL */
-		$pdf               = new Model_PDF( $this->form, $this->log, $this->options, GPDFAPI::get_data_class(), GPDFAPI::get_misc_class(), GPDFAPI::get_notice_class() );
+		$pdf               = new Model_PDF( $this->gform, $this->log, $this->options, GPDFAPI::get_data_class(), GPDFAPI::get_misc_class(), GPDFAPI::get_notice_class() );
 		$download          = ( $attributes['type'] == 'download' ) ? true : false;
 		$print             = ( ! empty( $attributes['print'] ) ) ? true : false;
 		$attributes['url'] = $pdf->get_pdf_url( $attributes['id'], $attributes['entry'], $download, $print );
@@ -353,7 +353,7 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 					if ( ! empty( $pid ) ) {
 
 						/* generate the PDF URL */
-						$pdf      = new Model_PDF( $this->form, $this->log, $this->options, GPDFAPI::get_data_class(), GPDFAPI::get_misc_class(), GPDFAPI::get_notice_class() );
+						$pdf      = new Model_PDF( $this->gform, $this->log, $this->options, GPDFAPI::get_data_class(), GPDFAPI::get_misc_class(), GPDFAPI::get_notice_class() );
 						$download = ( ! isset( $code['attr']['type'] ) || $code['attr']['type'] == 'download' ) ? true : false;
 						$pdf_url  = $pdf->get_pdf_url( $pid, '{entry_id}', $download, false, false );
 

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -75,13 +75,13 @@ class View_PDF extends Helper_Abstract_View {
 	protected $view_type = 'PDF';
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -125,7 +125,7 @@ class View_PDF extends Helper_Abstract_View {
 	 * Setup our class by injecting all our dependancies
 	 *
 	 * @param array                                          $data_cache An array of data to pass to the view
-	 * @param \GFPDF\Helper\Helper_Form|Helper_Abstract_Form $form       Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Form|Helper_Abstract_Form $gform       Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface                $log        Our logger class
 	 * @param \GFPDF\Helper\Helper_Abstract_Options          $options    Our options class which allows us to access any settings
 	 * @param \GFPDF\Helper\Helper_Data                      $data       Our plugin data store
@@ -133,13 +133,13 @@ class View_PDF extends Helper_Abstract_View {
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $data_cache = array(), Helper_Abstract_Form $form, LoggerInterface $log, Helper_Abstract_Options $options, Helper_Data $data, Helper_Misc $misc ) {
+	public function __construct( $data_cache = array(), Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Abstract_Options $options, Helper_Data $data, Helper_Misc $misc ) {
 
 		/* Call our parent constructor */
 		parent::__construct( $data_cache );
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->options = $options;
 		$this->data    = $data;
@@ -171,7 +171,7 @@ class View_PDF extends Helper_Abstract_View {
 		/**
 		 * Show $form_data array if requested
 		 */
-		if ( isset( $_GET['data'] ) && $this->form->has_capability( 'gravityforms_view_settings' ) && isset( $args['form_data'] ) ) {
+		if ( isset( $_GET['data'] ) && $this->gform->has_capability( 'gravityforms_view_settings' ) && isset( $args['form_data'] ) ) {
 			echo '<pre>';
 			print_r( $args['form_data'] );
 			echo '</pre>';
@@ -184,7 +184,7 @@ class View_PDF extends Helper_Abstract_View {
 		/**
 		 * Set out our PDF abstraction class
 		 */
-		$pdf = new Helper_PDF( $entry, $settings, $this->form, $this->data );
+		$pdf = new Helper_PDF( $entry, $settings, $this->gform, $this->data );
 		$pdf->set_filename( $model->get_pdf_name( $settings, $entry ) );
 
 		try {
@@ -230,7 +230,7 @@ class View_PDF extends Helper_Abstract_View {
 				'exception' => $e->getMessage(),
 			) );
 
-			if ( $this->form->has_capability( 'gravityforms_view_entries' ) ) {
+			if ( $this->gform->has_capability( 'gravityforms_view_entries' ) ) {
 				wp_die( $e->getMessage() );
 			}
 
@@ -305,8 +305,8 @@ class View_PDF extends Helper_Abstract_View {
 	public function generate_html_structure( $entry, Helper_Abstract_Model $model, $config = array() ) {
 
 		/* Set up required variables */
-		$form         = $this->form->get_form( $entry['form_id'] );
-		$products     = new Field_Products( new GF_Field(), $entry, $this->form, $this->misc );
+		$form         = $this->gform->get_form( $entry['form_id'] );
+		$products     = new Field_Products( new GF_Field(), $entry, $this->gform, $this->misc );
 		$has_products = false;
 		$page_number  = 0;
 		$container    = new Helper_Field_Container();
@@ -521,7 +521,7 @@ class View_PDF extends Helper_Abstract_View {
 	 * @since 4.0
 	 */
 	public function get_core_template_styles( $settings, $entry ) {
-		$form = $this->form->get_form( $entry['form_id'] );
+		$form = $this->gform->get_form( $entry['form_id'] );
 
 		$html = $this->load_core_template_styles( $settings );
 

--- a/src/view/View_Settings.php
+++ b/src/view/View_Settings.php
@@ -64,13 +64,13 @@ class View_Settings extends Helper_Abstract_View {
 	protected $view_type = 'Settings';
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Holds our log class
@@ -115,7 +115,7 @@ class View_Settings extends Helper_Abstract_View {
 	 * Setup our class by injecting all our dependancies
 	 *
 	 * @param array                                          $data_cache An array of data to pass to the view
-	 * @param \GFPDF\Helper\Helper_Form|Helper_Abstract_Form $form       Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Form|Helper_Abstract_Form $gform      Our abstracted Gravity Forms helper functions
 	 * @param \Monolog\Logger|LoggerInterface                $log        Our logger class
 	 * @param \GFPDF\Helper\Helper_Abstract_Options          $options    Our options class which allows us to access any settings
 	 * @param \GFPDF\Helper\Helper_Data                      $data       Our plugin data store
@@ -123,13 +123,13 @@ class View_Settings extends Helper_Abstract_View {
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $data_cache = array(), Helper_Abstract_Form $form, LoggerInterface $log, Helper_Abstract_Options $options, Helper_Data $data, Helper_Misc $misc ) {
+	public function __construct( $data_cache = array(), Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Abstract_Options $options, Helper_Data $data, Helper_Misc $misc ) {
 
 		/* Call our parent constructor */
 		parent::__construct( $data_cache );
 
 		/* Assign our internal variables */
-		$this->form    = $form;
+		$this->gform   = $gform;
 		$this->log     = $log;
 		$this->options = $options;
 		$this->data    = $data;
@@ -211,7 +211,7 @@ class View_Settings extends Helper_Abstract_View {
 			'memory' => $status->get_ram( $this->data->memory_limit ),
 			'wp'     => $wp_version,
 			'php'    => phpversion(),
-			'gf'     => $this->form->get_version(),
+			'gf'     => $this->gform->get_version(),
 		);
 
 		$this->log->addNotice( 'System Status', array( 'status' => $vars ) );
@@ -230,7 +230,7 @@ class View_Settings extends Helper_Abstract_View {
 	public function general() {
 
 		$vars = array(
-			'edit_cap' => $this->form->has_capability( 'gravityforms_edit_settings' ),
+			'edit_cap' => $this->gform->has_capability( 'gravityforms_edit_settings' ),
 		);
 
 		/* load the system status view */
@@ -247,7 +247,7 @@ class View_Settings extends Helper_Abstract_View {
 	public function tools() {
 
 		/* prevent unauthorized access */
-		if ( ! $this->form->has_capability( 'gravityforms_edit_settings' ) ) {
+		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 			$this->log->addWarning( 'Lack of User Capabilities.' );
 
 			wp_die( __( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );

--- a/src/view/View_Welcome_Screen.php
+++ b/src/view/View_Welcome_Screen.php
@@ -58,29 +58,29 @@ class View_Welcome_Screen extends Helper_Abstract_View {
 	protected $view_type = 'Welcome';
 
 	/**
-	 * Holds abstracted functions related to the forms plugin
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
 	 *
 	 * @var \GFPDF\Helper\Helper_Form
 	 *
 	 * @since 4.0
 	 */
-	protected $form;
+	protected $gform;
 
 	/**
 	 * Setup our class by injecting all our dependancies
 	 *
 	 * @param array                                          $data_cache An array of data to pass to the view
-	 * @param \GFPDF\Helper\Helper_Form|Helper_Abstract_Form $form       Our abstracted Gravity Forms helper functions
+	 * @param \GFPDF\Helper\Helper_Form|Helper_Abstract_Form $gform      Our abstracted Gravity Forms helper functions
 	 *
 	 * @since 4.0
 	 */
-	public function __construct( $data_cache = array(), Helper_Abstract_Form $form ) {
+	public function __construct( $data_cache = array(), Helper_Abstract_Form $gform ) {
 
 		/* Call our parent constructor */
 		parent::__construct( $data_cache );
 
 		/* Assign our internal variables */
-		$this->form = $form;
+		$this->gform = $gform;
 	}
 
 	/**
@@ -108,7 +108,7 @@ class View_Welcome_Screen extends Helper_Abstract_View {
 
 		/* Load any variables we want to pass to our view */
 		$args = array(
-			'forms' => $this->form->get_forms(),
+			'forms' => $this->gform->get_forms(),
 		);
 
 		/* Render our view */

--- a/tests/phpunit/unit-tests/test-actions.php
+++ b/tests/phpunit/unit-tests/test-actions.php
@@ -89,7 +89,7 @@ class Test_Actions extends WP_UnitTestCase {
 		$this->model = new Model_Actions( $gfpdf->data, $gfpdf->options, $gfpdf->notices );
 		$this->view  = new View_Actions( array() );
 
-		$this->controller = new Controller_Actions( $this->model, $this->view, $gfpdf->form, $gfpdf->log, $gfpdf->notices );
+		$this->controller = new Controller_Actions( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->notices );
 		$this->controller->init();
 	}
 

--- a/tests/phpunit/unit-tests/test-bootstrap.php
+++ b/tests/phpunit/unit-tests/test-bootstrap.php
@@ -117,7 +117,7 @@ class Test_Bootstrap extends WP_UnitTestCase {
 	 */
 	public function provider_dependant_helper_classes() {
 		return array(
-			array( 'GFPDF\Helper\Helper_Form', 'form' ),
+			array( 'GFPDF\Helper\Helper_Form', 'gform' ),
 			array( 'GFPDF\Helper\Helper_Data', 'data' ),
 			array( 'GFPDF\Helper\Helper_Misc', 'misc' ),
 			array( 'GFPDF\Helper\Helper_Notices', 'notices' ),

--- a/tests/phpunit/unit-tests/test-data-helper.php
+++ b/tests/phpunit/unit-tests/test-data-helper.php
@@ -164,7 +164,7 @@ class Test_Data_Helper extends WP_UnitTestCase {
 	public function test_localised_script() {
 		global $gfpdf;
 
-		$localised_data = $this->data->get_localised_script_data( $gfpdf->options, $gfpdf->form );
+		$localised_data = $this->data->get_localised_script_data( $gfpdf->options, $gfpdf->gform );
 		$required_keys  = array(
 			'ajaxurl',
 			'GFbaseUrl',

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -104,7 +104,7 @@ class Test_Form_Settings extends WP_UnitTestCase {
 		$this->setup_form();
 
 		/* Setup our test classes */
-		$this->model = new Model_Form_Settings( $gfpdf->form, $gfpdf->log, $gfpdf->data, $gfpdf->options, $gfpdf->misc, $gfpdf->notices );
+		$this->model = new Model_Form_Settings( $gfpdf->gform, $gfpdf->log, $gfpdf->data, $gfpdf->options, $gfpdf->misc, $gfpdf->notices );
 		$this->view  = new View_Form_Settings( array() );
 
 		$this->controller = new Controller_Form_Settings( $this->model, $this->view, $gfpdf->data, $gfpdf->options, $gfpdf->misc );

--- a/tests/phpunit/unit-tests/test-gravity-forms.php
+++ b/tests/phpunit/unit-tests/test-gravity-forms.php
@@ -256,7 +256,7 @@ class Test_Gravity_Forms extends WP_UnitTestCase {
 
 	/**
 	 * Test Gravity Form user privlages
-	 * i.e $gfpdf->form->has_capability("gravityforms_edit_settings")
+	 * i.e $gfpdf->gform->has_capability("gravityforms_edit_settings")
 	 *
 	 * @since 4.0
 	 */
@@ -271,7 +271,7 @@ class Test_Gravity_Forms extends WP_UnitTestCase {
          * Set up our users and test the privilages
          */
 		wp_set_current_user( $user_id );
-		$this->assertFalse( $gfpdf->form->has_capability( 'gravityforms_edit_settings' ) );
+		$this->assertFalse( $gfpdf->gform->has_capability( 'gravityforms_edit_settings' ) );
 
 		/* Create second user we'll use to test out the privilage */
 		$user_id = $this->factory->user->create();
@@ -285,7 +285,7 @@ class Test_Gravity_Forms extends WP_UnitTestCase {
 
 		wp_set_current_user( $user_id );
 
-		$this->assertTrue( $gfpdf->form->has_capability( 'gravityforms_edit_settings' ) );
+		$this->assertTrue( $gfpdf->gform->has_capability( 'gravityforms_edit_settings' ) );
 
 		/* Create third user we'll use to test out the privilage */
 		$user_id = $this->factory->user->create();
@@ -299,7 +299,7 @@ class Test_Gravity_Forms extends WP_UnitTestCase {
 
 		wp_set_current_user( $user_id );
 
-		$this->assertTrue( $gfpdf->form->has_capability( 'gravityforms_edit_settings' ) );
+		$this->assertTrue( $gfpdf->gform->has_capability( 'gravityforms_edit_settings' ) );
 
 		wp_set_current_user( 0 );
 	}

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -63,7 +63,7 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->misc = new Helper_Misc( $gfpdf->log, $gfpdf->form, $gfpdf->data );
+		$this->misc = new Helper_Misc( $gfpdf->log, $gfpdf->gform, $gfpdf->data );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-installer.php
+++ b/tests/phpunit/unit-tests/test-installer.php
@@ -75,9 +75,9 @@ class Test_Installer extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->model = new Model_Install( $gfpdf->form, $gfpdf->log, $gfpdf->data, $gfpdf->misc, $gfpdf->notices );
+		$this->model = new Model_Install( $gfpdf->gform, $gfpdf->log, $gfpdf->data, $gfpdf->misc, $gfpdf->notices );
 
-		$this->controller = new Controller_Install( $this->model, $gfpdf->form, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
+		$this->controller = new Controller_Install( $this->model, $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
 		$this->controller->init();
 	}
 
@@ -361,7 +361,7 @@ class Test_Installer extends WP_UnitTestCase {
 		global $gfpdf;
 
 		/* Verify the form data is there */
-		$forms = $gfpdf->form->get_forms();
+		$forms = $gfpdf->gform->get_forms();
 		$found = false;
 		foreach ( $forms as $form ) {
 			if ( isset( $form['gfpdf_form_settings'] ) ) {
@@ -375,7 +375,7 @@ class Test_Installer extends WP_UnitTestCase {
 		/* Verify the form data is removed */
 		$this->model->remove_plugin_form_settings();
 
-		$forms = $gfpdf->form->get_forms();
+		$forms = $gfpdf->gform->get_forms();
 		foreach ( $forms as $form ) {
 			$this->assertFalse( isset( $form['gfpdf_form_settings'] ) );
 		}

--- a/tests/phpunit/unit-tests/test-migration.php
+++ b/tests/phpunit/unit-tests/test-migration.php
@@ -74,11 +74,11 @@ class Test_Migration extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->migration = new Helper_Migration( $gfpdf->form, $gfpdf->log, $gfpdf->data, $gfpdf->options, $gfpdf->misc, $gfpdf->notices );
+		$this->migration = new Helper_Migration( $gfpdf->gform, $gfpdf->log, $gfpdf->data, $gfpdf->options, $gfpdf->misc, $gfpdf->notices );
 
 		/* Get our form ID */
-		$this->form_id[] = $gfpdf->form->add_form( json_decode( trim( file_get_contents( dirname( __FILE__ ) . '/json/migration_v3_to_v4.json' ) ), true ) );
-		$this->form_id[] = $gfpdf->form->add_form( json_decode( trim( file_get_contents( dirname( __FILE__ ) . '/json/migration_v3_to_v4.json' ) ), true ) );
+		$this->form_id[] = $gfpdf->gform->add_form( json_decode( trim( file_get_contents( dirname( __FILE__ ) . '/json/migration_v3_to_v4.json' ) ), true ) );
+		$this->form_id[] = $gfpdf->gform->add_form( json_decode( trim( file_get_contents( dirname( __FILE__ ) . '/json/migration_v3_to_v4.json' ) ), true ) );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-mvc-abstracts.php
+++ b/tests/phpunit/unit-tests/test-mvc-abstracts.php
@@ -87,9 +87,9 @@ class Test_MVC_Abstracts extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup out loader class */
-		$this->model      = new Model_Settings( $gfpdf->form, $gfpdf->log, $gfpdf->notices, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
-		$this->view       = new View_Settings( array(), $gfpdf->form, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
-		$this->controller = new Controller_Settings( $this->model, $this->view, $gfpdf->form, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
+		$this->model      = new Model_Settings( $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
+		$this->view       = new View_Settings( array(), $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
+		$this->controller = new Controller_Settings( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -76,7 +76,7 @@ class Test_Options_API extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* setup our object */
-		$this->options = new Helper_Options_Fields( $gfpdf->log, $gfpdf->form, $gfpdf->data, $gfpdf->misc, $gfpdf->notices );
+		$this->options = new Helper_Options_Fields( $gfpdf->log, $gfpdf->gform, $gfpdf->data, $gfpdf->misc, $gfpdf->notices );
 
 		/* load settings in database  */
 		update_option( 'gfpdf_settings', json_decode( file_get_contents( dirname( __FILE__ ) . '/json/options-settings.json' ), true ) );

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -98,10 +98,10 @@ class Test_PDF extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->model = new Model_PDF( $gfpdf->form, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices );
-		$this->view  = new View_PDF( array(), $gfpdf->form, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
+		$this->model = new Model_PDF( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices );
+		$this->view  = new View_PDF( array(), $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
 
-		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->form, $gfpdf->log, $gfpdf->misc );
+		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->misc );
 		$this->controller->init();
 	}
 
@@ -896,7 +896,7 @@ class Test_PDF extends WP_UnitTestCase {
 	public function test_does_pdf_exist() {
 		global $gfpdf;
 
-		$pdf = new Helper_PDF( '', '', $gfpdf->form, $gfpdf->data );
+		$pdf = new Helper_PDF( '', '', $gfpdf->gform, $gfpdf->data );
 		$pdf->set_path( ABSPATH );
 		$pdf->set_filename( 'unittest' );
 
@@ -917,7 +917,7 @@ class Test_PDF extends WP_UnitTestCase {
 	public function test_get_output_type() {
 		global $gfpdf;
 
-		$pdf = new Helper_PDF( '', '', $gfpdf->form, $gfpdf->data );
+		$pdf = new Helper_PDF( '', '', $gfpdf->gform, $gfpdf->data );
 
 		$pdf->set_output_type( 'display' );
 		$this->assertEquals( 'DISPLAY', $pdf->get_output_type() );
@@ -937,7 +937,7 @@ class Test_PDF extends WP_UnitTestCase {
 	public function test_get_template_path() {
 		global $gfpdf;
 
-		$pdf = new Helper_PDF( '', array( 'template' => 'zadani' ), $gfpdf->form, $gfpdf->data );
+		$pdf = new Helper_PDF( '', array( 'template' => 'zadani' ), $gfpdf->gform, $gfpdf->data );
 
 		/* Cleanup any previous tests */
 		@unlink( $gfpdf->data->template_location . 'zadani.php' );
@@ -972,7 +972,7 @@ class Test_PDF extends WP_UnitTestCase {
 		}
 
 		/* Check for errors */
-		$pdf = new Helper_PDF( '', array( 'template' => 'non-existant' ), $gfpdf->form, $gfpdf->data );
+		$pdf = new Helper_PDF( '', array( 'template' => 'non-existant' ), $gfpdf->gform, $gfpdf->data );
 
 		try {
 			/* Set our current PDF template */
@@ -986,7 +986,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$template = str_replace( 'Required PDF Version: 4.0-alpha', 'Required PDF Version: 10', $template );
 		file_put_contents( $gfpdf->data->template_location . 'zadani.php', $template );
 
-		$pdf = new Helper_PDF( '', array( 'template' => 'zadani' ), $gfpdf->form, $gfpdf->data );
+		$pdf = new Helper_PDF( '', array( 'template' => 'zadani' ), $gfpdf->gform, $gfpdf->data );
 
 		try {
 			$pdf->set_template();
@@ -1196,7 +1196,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$results   = $this->create_form_and_entries();
 		$form      = $results['form'];
 		$entry     = $results['entry'];
-		$products  = new Field_Products( new GF_Field(), $entry, $gfpdf->form, $gfpdf->misc );
+		$products  = new Field_Products( new GF_Field(), $entry, $gfpdf->gform, $gfpdf->misc );
 		$namespace = 'GFPDF\Helper\Fields\\';
 
 		$expected = array(
@@ -1365,7 +1365,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$form     = $results['form'];
 		$entry    = $results['entry'];
 		$field    = $form['fields'][0];
-		$products = new Field_Products( new GF_Field(), $entry, $gfpdf->form, $gfpdf->misc );
+		$products = new Field_Products( new GF_Field(), $entry, $gfpdf->gform, $gfpdf->misc );
 
 		/* Check for standard output */
 		GFCache::flush();
@@ -1620,7 +1620,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$entry    = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
 		$args     = $gfpdf->misc->get_template_args( $entry, $settings );
 
-		$pdf = new Helper_PDF( '', $settings, $gfpdf->form, $gfpdf->data );
+		$pdf = new Helper_PDF( '', $settings, $gfpdf->gform, $gfpdf->data );
 		$pdf->set_template();
 		$pdf->set_output_type( 'save' );
 

--- a/tests/phpunit/unit-tests/test-settings.php
+++ b/tests/phpunit/unit-tests/test-settings.php
@@ -86,10 +86,10 @@ class Test_Settings extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->model = new Model_Settings( $gfpdf->form, $gfpdf->log, $gfpdf->notices, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
-		$this->view  = new View_Settings( array(), $gfpdf->form, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
+		$this->model = new Model_Settings( $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
+		$this->view  = new View_Settings( array(), $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
 
-		$this->controller = new Controller_Settings( $this->model, $this->view, $gfpdf->form, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
+		$this->controller = new Controller_Settings( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
 		$this->controller->init();
 	}
 

--- a/tests/phpunit/unit-tests/test-shortcodes.php
+++ b/tests/phpunit/unit-tests/test-shortcodes.php
@@ -84,7 +84,7 @@ class Test_Shortcode extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->model = new Model_Shortcodes( $gfpdf->form, $gfpdf->log, $gfpdf->options, $gfpdf->misc );
+		$this->model = new Model_Shortcodes( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->misc );
 		$this->view  = new View_Shortcodes( array() );
 
 		$this->controller = new Controller_Shortcodes( $this->model, $this->view, $gfpdf->log );

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -91,10 +91,10 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->model = new Model_PDF( $gfpdf->form, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices );
-		$this->view  = new View_PDF( array(), $gfpdf->form, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
+		$this->model = new Model_PDF( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices );
+		$this->view  = new View_PDF( array(), $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc );
 
-		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->form, $gfpdf->log, $gfpdf->misc );
+		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->misc );
 		$this->controller->init();
 	}
 
@@ -177,7 +177,7 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 		$settings['template'] = 'zadani';
 
 		/* Create our PDF object */
-		$pdf_generator = new Helper_PDF( $entry, $settings, $gfpdf->form, $gfpdf->data );
+		$pdf_generator = new Helper_PDF( $entry, $settings, $gfpdf->gform, $gfpdf->data );
 		$pdf_generator->set_filename( 'Unit Testing' );
 
 		/* Generate the PDF and verify it was successfull */

--- a/tests/phpunit/unit-tests/test-welcome-screen.php
+++ b/tests/phpunit/unit-tests/test-welcome-screen.php
@@ -87,7 +87,7 @@ class Test_Welcome_Screen extends WP_UnitTestCase {
 		$this->model = new Model_Welcome_Screen( $gfpdf->log );
 		$this->view  = new View_Welcome_Screen( array(
 			'display_version' => PDF_EXTENDED_VERSION,
-		), $gfpdf->form );
+		), $gfpdf->gform );
 
 		$this->controller = new Controller_Welcome_Screen( $this->model, $this->view, $gfpdf->log, $gfpdf->data, $gfpdf->options );
 		$this->controller->init();


### PR DESCRIPTION
This prevents a naming conflict as the Gravity Form data is always referenced as $form. It also gets very confusing dealing with $form and $this->form (which is where we usually store our $gform object).

Resolves #283