### PR TITLE
Fix up welcome page bugs

### DIFF
--- a/src/assets/css/gfpdf-styles.css
+++ b/src/assets/css/gfpdf-styles.css
@@ -32,6 +32,10 @@
 .gfpdf-page .about-wrap .feature-section {
     border-bottom: 1px solid rgba(0, 0, 0, 0.1 );
 }
+ 
+.gfpdf-page .about-wrap .feature-section.two-col .col {
+    vertical-align: middle;
+}
 
 div img.gfpdf-image {
   border: 1px solid #CCC;

--- a/src/controller/Controller_Welcome_Screen.php
+++ b/src/controller/Controller_Welcome_Screen.php
@@ -131,6 +131,7 @@ class Controller_Welcome_Screen extends Helper_Abstract_Controller implements He
 	public function add_actions() {
 		/* Load the welcome screen into the menu */
 		add_action( 'admin_menu', array( $this->model, 'admin_menus' ) );
+		add_action( 'admin_head', array( $this->model, 'hide_admin_menus' ) );
 		add_action( 'init', array( $this, 'welcome' ) );
 	}
 

--- a/src/model/Model_Welcome_Screen.php
+++ b/src/model/Model_Welcome_Screen.php
@@ -54,7 +54,7 @@ class Model_Welcome_Screen extends Helper_Abstract_Model {
 	 *
 	 * @since 4.0
 	 */
-	public $minimum_capability = 'manage_options';
+	public $minimum_capability = 'activate_plugins';
 
 	/**
 	 * @var string The welcome page title
@@ -119,8 +119,18 @@ class Model_Welcome_Screen extends Helper_Abstract_Model {
 			'gfpdf-update',
 			array( $controller, 'update_screen' )
 		);
+	}
 
-		/* hide the new page from the menu bar */
+	/**
+	 * Hide the new dashboard pages we registered in self::admin_menus()
+	 * We had to move this to the "admin_head" action instead of all in one place
+	 * because it was causing authentication problems for some users.
+	 *
+	 * @since  4.0
+	 *
+	 * @return void
+	 */
+	public function hide_admin_menus() {
 		remove_submenu_page( 'index.php', 'gfpdf-getting-started' );
 		remove_submenu_page( 'index.php', 'gfpdf-update' );
 	}


### PR DESCRIPTION
- Fix up display issues in WordPress 4.5
- Move the hiding of our welcome pages to the "admin_head" action which stops an authentication error for some users
- Change the minimum capability of these pages to match that of our controller class

Partially resolves the problem in #324. Haven't been able to track down (or replicate) why an update from another plugin triggered the redirect as of yet.