### PR TITLE
Fix issue with Appearance tab not showing up on template change

### DIFF
--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -654,6 +654,9 @@
 		      			/* Remove our UI loader */
 		      			$spinner.remove();
 
+						/* Reset our legacy Advanced Template option */
+						$('input[name="gfpdf_settings[advanced_template]"][value="No"]').prop("checked", true).trigger('change');
+
 		      			/* Only process if the response is valid */
 		      			if(response.fields) {
 


### PR DESCRIPTION
This problem occurs when a template is saved with the Advanced Template option enabled. Then, when you try change the template to another the Appearance tab doesn't show up because the Advanced Template option is still activated. To resolve this I reset that option to No on template change. It's a legacy option anyway so I'm not concerned about doing it this way.

Fixes #333