### PR TITLE
Fix up parse error suffered in Chrome when the tinyMCE editor isn't found.

### DIFF
--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -611,7 +611,12 @@
 
 						/* Remove TinyMCE Content */
 						$container.find('.wp-editor-area').each(function() {
-							tinyMCE.get( $(this).attr('id') ).setContent('');
+							var editor = tinyMCE.get( $(this).attr('id') );
+
+							if( editor !== null ) {
+								editor.setContent('');
+							}
+
 						});
 
 						/* Remove textarea content */


### PR DESCRIPTION
Resolves #347