### PR TITLE
Move mergtag processing function to Helper_Form

### DIFF
--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -183,10 +183,10 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_filter( 'mpdf_font_data', array( $this->model, 'add_unregistered_fonts_to_mPDF' ), 20 );
 
 		/* Process mergetags and shortcodes in PDF */
-		add_filter( 'gfpdf_pdf_html_output', array( $this->misc, 'do_mergetags' ), 10, 3 );
+		add_filter( 'gfpdf_pdf_html_output', array( $this->gform, 'process_tags' ), 10, 3 );
 		add_filter( 'gfpdf_pdf_html_output', 'do_shortcode' );
 
-		add_filter( 'gfpdf_pdf_core_template_html_output', array( $this->misc, 'do_mergetags' ), 10, 3 );
+		add_filter( 'gfpdf_pdf_core_template_html_output', array( $this->gform, 'process_tags' ), 10, 3 );
 
 		/* Backwards compatibility for our Tier 2 plugin */
 		add_filter( 'gfpdfe_pre_load_template', array( 'PDFRender', 'prepare_ids' ), 1, 8 );

--- a/src/depreciated.php
+++ b/src/depreciated.php
@@ -234,10 +234,9 @@ class PDF_Common extends GFPDF_Depreciated_Abstract {
 	 * @since 3.0
 	 */
 	public static function do_mergetags( $string, $form_id, $lead_id ) {
-		$misc  = GPDFAPI::get_misc_class();
 		$gform = GPDFAPI::get_form_class();
 
-		return $misc->do_mergetags( $string, $gform->get_form( $form_id ), $gform->get_entry( $lead_id ) );
+		return $gform->process_tags( $string, $gform->get_form( $form_id ), $gform->get_entry( $lead_id ) );
 	}
 
 	/**

--- a/src/helper/Helper_Form.php
+++ b/src/helper/Helper_Form.php
@@ -247,4 +247,22 @@ class Helper_Form extends Helper_Abstract_Form {
 
 		return $has_capability;
 	}
+
+	/**
+	 * Replace all the Merge Tag data in the string
+	 *
+	 * @param  string $string The string to process
+	 * @param  array  $form   The Gravity Form array
+	 * @param  array  $entry  The Gravity Form Entry Array
+	 *
+	 * @return string
+	 *
+	 * @since 4.0
+	 */
+	public function process_tags( $string, $form, $entry ) {
+
+		$string = str_replace( '{all_fields}', '', $string );
+
+		return trim( GFCommon::replace_variables( $string, $form, $entry, false, false, false ) );
+	}
 }

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -751,27 +751,6 @@ class Helper_Misc {
 	}
 
 	/**
-	 * Replace all the merge tag fields in the string
-	 *
-	 * @param  string $string The string to process
-	 * @param  array  $form   The Gravity Form array
-	 * @param  array  $lead   The Gravity Form Entry Array
-	 *
-	 * @return string
-	 *
-	 * @since 4.0
-	 */
-	public function do_mergetags( $string, $form, $lead ) {
-		/* Unconvert { and } symbols from HTML entities and remove {all_fields} tag */
-		$find    = array( '&#123;', '&#125;', '{all_fields}' );
-		$replace = array( '{', '}', '' );
-
-		$string = str_replace( $find, $replace, $string );
-
-		return trim( GFCommon::replace_variables( $string, $form, $lead, false, false, false ) );
-	}
-
-	/**
 	 * Backwards compatibility that allows multiple IDs to be passed to the renderer
 	 *
 	 * @param  integer $entry_id The fallback ID if none present

--- a/src/helper/abstract/Helper_Abstract_Fields.php
+++ b/src/helper/abstract/Helper_Abstract_Fields.php
@@ -284,7 +284,7 @@ abstract class Helper_Abstract_Fields {
 	 */
 	public function html( $value = '', $show_label = true ) {
 
-		$value = $this->encode_tags( $value, $this->field->type ); /* Prevent shortcodes being processed from user input */
+		$value = $this->encode_tags( $value, $this->field->type ); /* Prevent shortcodes and merge tags being processed from user input */
 		$value = apply_filters( 'gfpdf_field_content', $value, $this->field, GFFormsModel::get_lead_field_value( $this->entry, $this->field ), $this->entry['id'], $this->form['id'] ); /* Backwards compat */
 
 		$label = esc_html( GFFormsModel::get_label( $this->field ) );
@@ -330,7 +330,9 @@ abstract class Helper_Abstract_Fields {
 	 */
 	public function encode_tags( $value, $type ) {
 
-		if ( $type != 'html' && $type != 'signature' && $type != 'section' ) {
+		$skip_fields = array( 'html', 'signature', 'section' );
+
+		if ( ! in_array( $type, $skip_fields ) ) {
 
 			$find      = array( '[', ']', '{', '}' );
 			$converted = array( '&#91;', '&#93;', '&#123;', '&#125;' );

--- a/src/helper/abstract/Helper_Abstract_Form.php
+++ b/src/helper/abstract/Helper_Abstract_Form.php
@@ -160,4 +160,17 @@ abstract class Helper_Abstract_Form {
 	 * @since 4.0
 	 */
 	abstract public function has_capability( $capability, $user_id = null );
+
+	/**
+	 * Replace all the tag fields (that represent the field data) in the string
+	 *
+	 * @param  string $string The string to process
+	 * @param  array  $form   The Gravity Form array
+	 * @param  array  $entry  The Gravity Form Entry Array
+	 *
+	 * @return string
+	 *
+	 * @since 4.0
+	 */
+	abstract public function process_tags( $string, $form, $entry );
 }

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -656,7 +656,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	public function get_pdf_name( $settings, $entry ) {
 
 		$form = $this->gform->get_form( $entry['form_id'] );
-		$name = $this->misc->do_mergetags( $settings['filename'], $form, $entry );
+		$name = $this->gform->process_tags( $settings['filename'], $form, $entry );
 
 		/* Remove any characters that cannot be present in a filename */
 		$name = $this->misc->strip_invalid_characters( $name );
@@ -1079,6 +1079,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 				/* Only generate if the PDF wasn't during the notification process */
 				if ( ! is_wp_error( $settings ) ) {
+					
 					$pdf_generator = new Helper_PDF( $entry, $settings, $this->gform, $this->data );
 					$pdf_generator->set_filename( $this->get_pdf_name( $settings, $entry ) );
 

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -165,7 +165,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertSame( 10, has_filter( 'mpdf_font_data', array( $this->model, 'register_custom_font_data_with_mPDF' ) ) );
 		$this->assertSame( 20, has_filter( 'mpdf_font_data', array( $this->model, 'add_unregistered_fonts_to_mPDF' ) ) );
 
-		$this->assertSame( 10, has_filter( 'gfpdf_pdf_html_output', array( $gfpdf->misc, 'do_mergetags' ) ) );
+		$this->assertSame( 10, has_filter( 'gfpdf_pdf_html_output', array( $gfpdf->gform, 'process_tags' ) ) );
 		$this->assertSame( 10, has_filter( 'gfpdf_pdf_html_output', 'do_shortcode' ) );
 
 		$this->assertSame( 10, has_filter( 'gfpdf_template_args', array( $this->model, 'preprocess_template_arguments' ) ) );


### PR DESCRIPTION
This makes it much simpler for us to fix https://github.com/GravityPDF/gravity-pdf/issues/358. It also makes more sense that tags are handled by our form helper class.