### PR TITLE
Prevent PDF trying to be generated when using "save and continue" feature

### DIFF
--- a/src/helper/Helper_Migration.php
+++ b/src/helper/Helper_Migration.php
@@ -445,10 +445,17 @@ class Helper_Migration {
 
 				/* Get an array of all the form notification for later use */
 				$notifications = array();
-				foreach ( $form['notifications'] as $not ) {
-					$notifications[ $not['id'] ] = $not['name'];
-				}
 
+				/* Filter out the save and continue notifications */
+				$omit = array( 'form_saved', 'form_save_email_requested' );
+
+				foreach ( $form['notifications'] as $notification ) {
+					$event = ( isset( $notification['event'] ) ) ? $notification['event'] : '';
+
+					if ( ! in_array( $event, $omit ) ) {
+						$notifications[ $notification['id'] ] = $notification['name'];
+					}
+				}
 
 				/* Hold name in array so we can prevent duplicates */
 				$name = array();

--- a/src/model/Model_Form_Settings.php
+++ b/src/model/Model_Form_Settings.php
@@ -796,8 +796,15 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		if ( is_array( $notifications ) ) {
 			$options = array();
 
-			foreach ( $notifications as $notif ) {
-				$options[ $notif['id'] ] = $notif['name'];
+			/* Filter out the save and continue notifications */
+			$omit = array( 'form_saved', 'form_save_email_requested' );
+
+			foreach ( $notifications as $notification ) {
+				$event = ( isset( $notification['event'] ) ) ? $notification['event'] : '';
+
+				if ( ! in_array( $event, $omit ) ) {
+					$options[ $notification['id'] ] = $notification['name'];
+				}
 			}
 
 			/* Apply our settings update */

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -893,6 +893,15 @@ class Model_PDF extends Helper_Abstract_Model {
 	 */
 	public function notifications( $notifications, $form, $entry ) {
 
+		/*
+		 * Ensure our entry is stored in the database by checking it has an ID
+		 * This resolves any issues with the "Save and Continue" feature
+		 * See https://github.com/GravityPDF/gravity-pdf/issues/360
+		 */
+		if ( NULL === $entry['id'] ) {
+			return $notifications;
+		}
+
 		$pdfs = ( isset( $form['gfpdf_form_settings'] ) ) ? $this->get_active_pdfs( $form['gfpdf_form_settings'], $entry ) : array();
 
 		if ( sizeof( $pdfs ) > 0 ) {

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -641,6 +641,17 @@ class Test_Form_Settings extends WP_UnitTestCase {
 
 		$this->assertSame( 3, sizeof( $wp_settings_fields[ $group ][ $group ][ $setting ]['args'][ $option_id ] ) );
 
+		/* Check that certain notification events are ignored */
+		$notifications = array(
+			array( 'id' => 'id1', 'name' => 'Notification  1' ),
+			array( 'id' => 'id2', 'name' => 'Notification  2', 'event' => 'form_saved' ),
+			array( 'id' => 'id3', 'name' => 'Notification  3', 'event' => 'form_save_email_requested' ),
+		);
+
+		$this->model->register_notifications( $notifications );
+
+		$this->assertSame( 1, sizeof( $wp_settings_fields[ $group ][ $group ][ $setting ]['args'][ $option_id ] ) );
+
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -886,6 +886,13 @@ class Test_PDF extends WP_UnitTestCase {
 
 		/* Clean up */
 		unlink( $notifications['attachments'][0] );
+
+		/* Check we don't process an entry not stored in the database */
+		$entry['id'] = NULL;
+
+		$notifications = $this->model->notifications( $form['notifications']['54bca349732b8'], $form, $entry );
+
+		$this->assertSame( 0, sizeof( $notifications['attachments'] ) );
 	}
 
 	/**


### PR DESCRIPTION
- Also omit Save and Continue notification(s) from our notifications list
- Ensure save and continue notification cannot be imported during v3 migration
- Add appropriate unit tests

Resolves #360