### PR TITLE
Fix font caching bug and duplicate custom font types

### DIFF
--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -415,6 +415,18 @@ class Helper_Misc {
 	}
 
 	/**
+	 * Wrapper function for rmdir() which ensures the directory gets automatically recreated after being deleted
+	 *
+	 * @param string $path
+	 *
+	 * @since 4.0
+	 */
+	public function cleanup_dir( $path ) {
+		$this->rmdir( $path );
+		wp_mkdir_p( $path );
+	}
+
+	/**
 	 * This function recursively copies all files and folders under a given directory
 	 * equivalent to Bash: cp -R $dir
 	 *
@@ -1017,5 +1029,26 @@ class Helper_Misc {
 				require_once( $entry_details_file );
 			}
 		}
+	}
+
+	/**
+	 * A recursive function that will search a multidimensional array for the value
+	 *
+	 * @param mixed $needle The value to search for
+	 * @param array $haystack The multidimensional array to search in
+	 * @param bool $strict Pass `true` to match for the value and type, false for just the type.
+	 *
+	 * @return bool True when found, false otherwise
+	 */
+	public function in_array( $needle, $haystack, $strict = true ) {
+		foreach ( $haystack as $item ) {
+			if ( ( $strict ? $item === $needle : $item == $needle ) ||
+			     ( is_array( $item ) && $this->in_array( $needle, $item, $strict ) )
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -1217,7 +1217,7 @@ class Model_PDF extends Helper_Abstract_Model {
 			$short_name = $this->options->get_font_short_name( substr( $font_name, 0, -4 ) );
 
 			/* Check if it exists already, otherwise add it */
-			if ( ! isset( $fonts[ $short_name ] ) ) {
+			if ( ! isset( $fonts[ $short_name ] ) && ! $this->misc->in_array( $font_name, $fonts ) ) {
 				$fonts[ $short_name ] = array(
 					'R' => $font_name,
 				);

--- a/src/model/Model_Settings.php
+++ b/src/model/Model_Settings.php
@@ -389,10 +389,13 @@ class Model_Settings extends Helper_Abstract_Model {
 
 			/* Update our font database */
 			$this->options->update_option( 'custom_fonts', $custom_fonts );
+
+			/* Cleanup our fontdata directory to prevent caching issues with mPDF */
+			$this->misc->cleanup_dir( $this->data->template_font_location . 'fontdata/' );
+
 		}
 
 		/* Fonts sucessfully installed so return font data */
-
 		return $fonts;
 	}
 
@@ -503,6 +506,9 @@ class Model_Settings extends Helper_Abstract_Model {
 
 			if ( $this->remove_font_file( $fonts[ $id ] ) ) {
 				unset( $fonts[ $id ] );
+
+				/* Cleanup our fontdata directory to prevent caching issues with mPDF */
+				$this->misc->cleanup_dir( $this->data->template_font_location . 'fontdata/' );
 
 				if ( $this->options->update_option( 'custom_fonts', $fonts ) ) {
 					/* Success */

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -559,6 +559,8 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 
 	/**
 	 * Check if our backwards compatible settings conversion works correctly
+	 *
+	 * @since 4.0
 	 */
 	public function test_backwards_compat_conversion() {
 		$settings = array(
@@ -604,10 +606,100 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 
 	/**
 	 * Check if our backwards compatible output functions work correctly
+	 *
+	 * @since 4.0
 	 */
 	public function test_backwards_compat_output() {
 		$this->assertEquals( 'save', $this->misc->backwards_compat_output() );
 		$this->assertEquals( 'view', $this->misc->backwards_compat_output( 'display' ) );
 		$this->assertEquals( 'download', $this->misc->backwards_compat_output( 'download' ) );
+	}
+
+	/**
+	 * Check our recursive in_array() method works as expected
+	 *
+	 * @param boolean $expected
+	 * @param boolean $strict
+	 * @param mixed $needle
+	 * @param array $haystack
+	 *
+	 * @dataProvider provider_in_array
+	 *
+	 * @since        4.0
+	 */
+	public function test_in_array( $expected, $strict, $needle, $haystack ) {
+		$this->assertSame( $expected, $this->misc->in_array( $needle, $haystack, $strict ) );
+	}
+
+	public function provider_in_array() {
+		return array(
+
+			/* basic multi-dimensional search */
+			array( true, true, 'find me', array(
+				'item 1',
+				'item 2',
+				'item 3' => array( 'test', 'find me' ),
+				'item 4',
+			) ),
+
+			/* type check (strict) */
+			array( false, true, 20, array(
+				'item 1',
+				'item 2' => array( 'stuff', 'here', array( '20' ) ),
+				'item 3'
+			) ),
+
+			/* type check (not strict) */
+			array( true, false, 20, array(
+				'item 1',
+				'item 2' => array( 'stuff', 'here', array( '20' ) ),
+				'item 3'
+			) ),
+
+			/* deep multi-dimensional array */
+			array( true, true, 'Find Me', array(
+				'item 1' => array( 'hi', 'how', 'are', array( 'you' => array( 'going' ) ) ),
+				'item 2' => array( 'stuff', 'here', array( 'Find Me' ) ),
+				'item 3'
+			) ),
+
+			/* deep multi-dimensional array */
+			array( true, true, 'Find Me', array(
+				'item 1' => array( 'hi', 'how', 'are', array( 'you' => array( 'going' => array( 'Find Me' ) ) ) ),
+				'item 2' => array( 'stuff', 'here', array( 'wow' ) ),
+				'item 3'
+			) ),
+
+			/* ensure case sensitive match */
+			array( false, true, 'find me', array(
+				'item 1',
+				'item 2' => array( 'stuff', 'here', array( 'Find Me' ) ),
+				'item 3'
+			) ),
+		);
+	}
+
+	/**
+	 * Test that the everything inside a directory gets removed
+	 *
+	 * @since 4.0
+	 */
+	public function test_cleanup_dir() {
+
+		/* Create our test data */
+		$path = ABSPATH . 'test/';
+		wp_mkdir_p( $path );
+		touch( $path . 'test' );
+
+		/* Ensure it created correctly */
+		$this->assertFileExists( $path . 'test' );
+
+		/* Run our test */
+		$this->misc->cleanup_dir( $path );
+
+		/* Check the file was deleted but the directory still exists */
+		$this->assertFileNotExists( $path . 'test' );
+		$this->assertTrue( is_dir( $path ) );
+
 	}
 }


### PR DESCRIPTION
mPDF caches the processed font files and saves it for later (see https://github.com/GravityPDF/gravity-pdf/pull/193). The problem occurs when a user drops a font file directly in the /fonts/ directory without installing it via our font installer (we're most effected by this when doing PDF integrations), loads some PDFs but then decides to install the font via the installer with the same name. Because of the font cache this causes problems. To get around this issue we are no clearing the fontdata cache when fonts are installed, edited or deleted.

While reviewing this problem we found that font files assigned to a group could still be included in mPDFs font array because we were only checking the top array key. To fix this problem we now recursively look through the multidimensional array and check if the font already exists.

Add unit test for our Helper_Misc::is_array() method