### PR TITLE
Add switch to disable CSS Ready Class support

### DIFF
--- a/src/helper/Helper_Field_Container_Void.php
+++ b/src/helper/Helper_Field_Container_Void.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace GFPDF\Helper;
+
+use GF_Field;
+
+/**
+ * Extends the Helper_Field_Container class and disables
+ * Gravity Forms CSS Ready Class support
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2015, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF Copyright (C) 2015 Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * @since 4.0
+ */
+class Helper_Field_Container_Void extends Helper_Field_Container {
+
+	/*
+	 * Empty method easily disables Helper_Field_Container functionality
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	public function generate( GF_Field $field ) {
+		/* Do nothing */
+	}
+
+	/**
+	 * Empty method easily disables Helper_Field_Container functionality
+	 * 
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	public function close() {
+		/* Do nothing */
+	}
+}

--- a/src/templates/blank-slate.php
+++ b/src/templates/blank-slate.php
@@ -233,15 +233,16 @@ $show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_
 $config = array(
     'settings'  => $settings,
     'meta'      => array(
-        'echo'                => true, /* whether to output the HTML or return it */
-        'exclude'             => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
-        'empty'               => $show_empty, /* whether to show empty fields or not. Default is false */
-        'conditional'         => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
-        'show_title'          => $show_form_title, /* whether we should show the form title. Default to true */
-        'section_content'     => $show_section_content, /* whether we should include a section breaks content. Default to false */
-        'page_names'          => $show_page_names, /* whether we should show the form's page names. Default to false */
-        'html_field'          => $show_html, /* whether we should show the form's html fields. Default to false */
-        'individual_products' => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        'echo'                     => true, /* whether to output the HTML or return it */
+        'exclude'                  => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
+        'empty'                    => $show_empty, /* whether to show empty fields or not. Default is false */
+        'conditional'              => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
+        'show_title'               => $show_form_title, /* whether we should show the form title. Default to true */
+        'section_content'          => $show_section_content, /* whether we should include a section breaks content. Default to false */
+        'page_names'               => $show_page_names, /* whether we should show the form's page names. Default to false */
+        'html_field'               => $show_html, /* whether we should show the form's html fields. Default to false */
+        'individual_products'      => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        'enable_css_ready_classes' => true, /* Whether to enable or disable Gravity Forms CSS Ready Class support in your PDF */
     ),
 );
 

--- a/src/templates/focus-gravity.php
+++ b/src/templates/focus-gravity.php
@@ -283,15 +283,16 @@ $show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_
 $config = array(
     'settings' => $settings,
     'meta'     => array(
-        'echo'                => true, /* whether to output the HTML or return it */
-        'exclude'             => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
-        'empty'               => $show_empty, /* whether to show empty fields or not. Default is false */
-        'conditional'         => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
-        'show_title'          => $show_form_title, /* whether we should show the form title. Default to true */
-        'section_content'     => $show_section_content, /* whether we should include a section breaks content. Default to false */
-        'page_names'          => $show_page_names, /* whether we should show the form's page names. Default to false */
-        'html_field'          => $show_html, /* whether we should show the form's html fields. Default to false */
-        'individual_products' => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        'echo'                     => true, /* whether to output the HTML or return it */
+        'exclude'                  => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
+        'empty'                    => $show_empty, /* whether to show empty fields or not. Default is false */
+        'conditional'              => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
+        'show_title'               => $show_form_title, /* whether we should show the form title. Default to true */
+        'section_content'          => $show_section_content, /* whether we should include a section breaks content. Default to false */
+        'page_names'               => $show_page_names, /* whether we should show the form's page names. Default to false */
+        'html_field'               => $show_html, /* whether we should show the form's html fields. Default to false */
+        'individual_products'      => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        'enable_css_ready_classes' => true, /* Whether to enable or disable Gravity Forms CSS Ready Class support in your PDF */
     ),
 );
 

--- a/src/templates/rubix.php
+++ b/src/templates/rubix.php
@@ -273,15 +273,16 @@ $show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_
 $config = array(
     'settings' => $settings,
     'meta'     => array(
-        'echo'                => true, /* whether to output the HTML or return it */
-        'exclude'             => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
-        'empty'               => $show_empty, /* whether to show empty fields or not. Default is false */
-        'conditional'         => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
-        'show_title'          => $show_form_title, /* whether we should show the form title. Default to true */
-        'section_content'     => $show_section_content, /* whether we should include a section breaks content. Default to false */
-        'page_names'          => $show_page_names, /* whether we should show the form's page names. Default to false */
-        'html_field'          => $show_html, /* whether we should show the form's html fields. Default to false */
-        'individual_products' => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        'echo'                     => true, /* whether to output the HTML or return it */
+        'exclude'                  => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
+        'empty'                    => $show_empty, /* whether to show empty fields or not. Default is false */
+        'conditional'              => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
+        'show_title'               => $show_form_title, /* whether we should show the form title. Default to true */
+        'section_content'          => $show_section_content, /* whether we should include a section breaks content. Default to false */
+        'page_names'               => $show_page_names, /* whether we should show the form's page names. Default to false */
+        'html_field'               => $show_html, /* whether we should show the form's html fields. Default to false */
+        'individual_products'      => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        'enable_css_ready_classes' => true, /* Whether to enable or disable Gravity Forms CSS Ready Class support in your PDF */
     ),
 );
 

--- a/src/templates/zadani.php
+++ b/src/templates/zadani.php
@@ -231,15 +231,16 @@ $show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_
 $config = array(
     'settings' => $settings,
     'meta'     => array(
-        'echo'                => true, /* whether to output the HTML or return it */
-        'exclude'             => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
-        'empty'               => $show_empty, /* whether to show empty fields or not. Default is false */
-        'conditional'         => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
-        'show_title'          => $show_form_title, /* whether we should show the form title. Default to true */
-        'section_content'     => $show_section_content, /* whether we should include a section breaks content. Default to false */
-        'page_names'          => $show_page_names, /* whether we should show the form's page names. Default to false */
-        'html_field'          => $show_html, /* whether we should show the form's html fields. Default to false */
-        'individual_products' => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        'echo'                     => true, /* whether to output the HTML or return it */
+        'exclude'                  => true, /* whether we should exclude fields with a CSS value of 'exclude'. Default to true */
+        'empty'                    => $show_empty, /* whether to show empty fields or not. Default is false */
+        'conditional'              => $enable_conditional, /* whether we should skip fields hidden with conditional logic. Default to true. */
+        'show_title'               => $show_form_title, /* whether we should show the form title. Default to true */
+        'section_content'          => $show_section_content, /* whether we should include a section breaks content. Default to false */
+        'page_names'               => $show_page_names, /* whether we should show the form's page names. Default to false */
+        'html_field'               => $show_html, /* whether we should show the form's html fields. Default to false */
+        'individual_products'      => false, /* Whether to show individual fields in the entry. Default to false - they are grouped together at the end of the form */
+        'enable_css_ready_classes' => true, /* Whether to enable or disable Gravity Forms CSS Ready Class support in your PDF */
     ),
 );
 

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -5,6 +5,7 @@ namespace GFPDF\View;
 use GFPDF\Helper\Helper_Abstract_Model;
 use GFPDF\Helper\Helper_Abstract_View;
 use GFPDF\Helper\Helper_Field_Container;
+use GFPDF\Helper\Helper_Field_Container_Void;
 use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Abstract_Options;
@@ -309,7 +310,7 @@ class View_PDF extends Helper_Abstract_View {
 		$products     = new Field_Products( new GF_Field(), $entry, $this->gform, $this->misc );
 		$has_products = false;
 		$page_number  = 0;
-		$container    = new Helper_Field_Container();
+		$container    = ( isset( $config['meta']['enable_css_ready_classes'] ) && false === $config['meta']['enable_css_ready_classes'] ) ? new Helper_Field_Container_Void() : new Helper_Field_Container();
 
 		/* Allow the config to be changed through a filter */
 		$config['meta'] = ( isset( $config['meta'] ) ) ? $config['meta'] : array();


### PR DESCRIPTION
This allows developers more freedom to style the PDF as they see fit.
Ensure PDF templates have CSS Ready Class support enabled by default