### PR TITLE
Fix CSS Ready Class Columns when field is hidden or empty

### DIFF
--- a/src/helper/Helper_Field_Container.php
+++ b/src/helper/Helper_Field_Container.php
@@ -181,6 +181,49 @@ class Helper_Field_Container {
 	}
 
 	/**
+	 * Will check if the current field will fit in the open row, or if a new row needs to be open
+	 * to accomidate the field.
+	 *
+	 * @param GF_Field $field The Gravity Form field currently being processed
+	 *
+	 * @return boolean
+	 *
+	 * @since 4.0
+	 */
+	public function does_fit_in_row( GF_Field $field ) {
+
+		if ( true === $this->currently_open ) {
+			$width = $this->get_field_width( $field->cssClass ); /* current field width */
+
+			/* Check if the new field will fit in the row */
+			if ( 100 >= ( $this->current_width + $width ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Output placeholder HTML if empty or hidden field is part of CSS Ready Class columns
+	 * and the row is currently open and the field will fit in that row without opening another row
+	 *
+	 * @param GF_Field $field The Gravity Form field currently being processed
+	 *
+	 * @return void
+	 */
+	public function maybe_display_faux_column( GF_Field $field ) {
+
+		/* Check if we should create a placeholder column */
+		if ( $this->does_fit_in_row( $field ) ) {
+			echo '<div id="field-' . $field->id . '" class="gfpdf-column-placeholder gfpdf-field ' . $field->cssClass . '"></div>';
+
+			/* Increase column width */
+			$this->increment_width( $field->cssClass );
+		}
+	}
+
+	/**
 	 * Open the container
 	 *
 	 * @param  GF_Field $field The Gravity Form field currently being processed
@@ -205,10 +248,9 @@ class Helper_Field_Container {
 	 * @since 4.0
 	 */
 	private function handle_open_container( GF_Field $field ) {
-		$width = $this->get_field_width( $field->cssClass ); /* current field width */
 
 		/* if the current field width is more than 100 we will close the container */
-		if ( 100 < ( $this->current_width + $width ) ) {
+		if ( false === $this->does_fit_in_row( $field ) ) {
 			$this->close();
 		} else {
 			$this->increment_width( $field->cssClass );

--- a/src/helper/Helper_Field_Container_Void.php
+++ b/src/helper/Helper_Field_Container_Void.php
@@ -65,4 +65,26 @@ class Helper_Field_Container_Void extends Helper_Field_Container {
 	public function close() {
 		/* Do nothing */
 	}
+
+	/**
+	 * Empty method easily disables Helper_Field_Container functionality
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	public function does_fit_in_row() {
+		/* Do nothing */
+	}
+
+	/**
+	 * Empty method easily disables Helper_Field_Container functionality
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	public function maybe_display_faux_column() {
+		/* Do nothing */
+	}
 }

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -332,42 +332,60 @@ class View_PDF extends Helper_Abstract_View {
 
 		/* Loop through the fields and output or skip if needed */
 		foreach ( $form['fields'] as $key => $field ) {
-
+			
 			/* Load our page name, if needed */
 			if ( $show_page_names === true && $field->pageNumber !== $page_number ) {
 				$this->display_page_name( $page_number, $form, $container );
 				$page_number++;
 			}
 
+			/*
+			 * @TODO Create middleware filter to check if the field should be skipped.
+			 * This will reduce code duplication and increase plugin flexibility
+			 */
+
 			/* Skip any fields with the css class 'exclude', if needed */
 			if ( $skip_marked_fields !== false && strpos( $field->cssClass, 'exclude' ) !== false )  {
+				/* To prevent display issues we will output the column markup needed */
+				$container->maybe_display_faux_column( $field );
+
 				continue;
 			}
 
 			/* Skip over any hidden fields (usually by conditional logic), if needed */
 			if ( $skip_conditional_fields === true && GFFormsModel::is_field_hidden( $form, $field, array(), $entry ) ) {
+				/* To prevent display issues we will output the column markup needed */
+				$container->maybe_display_faux_column( $field );
+
 				continue;
 			}
 
 			/* Skip over any product fields, if needed */
 			if ( $show_individual_product_fields === false && GFCommon::is_product_field( $field->type ) ) {
 				$has_products = true;
+
+				/* To prevent display issues we will output the column markup needed */
+				$container->maybe_display_faux_column( $field );
 				continue;
 			}
 
 			/* Skip HTML fields, if needed */
 			if ( $show_html_fields === false && $field->type == 'html' ) {
+				/* To prevent display issues we will output the column markup needed */
+				$container->maybe_display_faux_column( $field );
+
 				continue;
 			}
 
 			/* Skip over any fields we don't want to include */
 			if( in_array( $field->type, $blacklisted ) ) {
+				/* To prevent display issues we will output the column markup needed */
+				$container->maybe_display_faux_column( $field );
+
 				continue;
 			}
 
-			/**
-			 * Let's output our field
-			 */
+			/* Let's output our field */
 			$this->process_field( $field, $entry, $form, $config, $products, $container, $model );
 		}
 
@@ -425,10 +443,8 @@ class View_PDF extends Helper_Abstract_View {
 
 				echo ( $field->type !== 'section' ) ? $class->html() : $class->html( $show_section_description );
 			} else {
-				/**
-				 * Close our CSS Ready Class Row, if open
-				 */
-				$container->close();
+				/* To prevent display issues we will output the column markup needed */
+				$container->maybe_display_faux_column( $field );
 			}
 		} catch ( Exception $e ) {
 			$this->log->addError( 'PDF Generation Error', array(


### PR DESCRIPTION
Output placeholder HTML if empty or hidden field is part of CSS Ready Class columns and the row is currently open and the field will fit in that row without opening another row.
Set public methods to do nothing in our Container_Void class
Add unit tests for changes

Resolves #381