### PR TITLE
Apply HTML escaping during value() method

### DIFF
--- a/src/helper/fields/Field_Address.php
+++ b/src/helper/fields/Field_Address.php
@@ -121,14 +121,10 @@ class Field_Address extends Helper_Abstract_Fields {
 			$address[] = $data['country'];
 		}
 
-		/* Apply sanitization to address */
-		$address = array_map( 'esc_html', $address );
-
 		/* display the address in the correct format */
 		$html = implode( '<br />', $address );
 
 		/* return the results */
-
 		return parent::html( $html );
 	}
 
@@ -152,12 +148,12 @@ class Field_Address extends Helper_Abstract_Fields {
 		}
 
 		$this->cache( array(
-			'street'  => trim( rgget( $this->field->id . '.1', $value ) ),
-			'street2' => trim( rgget( $this->field->id . '.2', $value ) ),
-			'city'    => trim( rgget( $this->field->id . '.3', $value ) ),
-			'state'   => trim( rgget( $this->field->id . '.4', $value ) ),
-			'zip'     => trim( rgget( $this->field->id . '.5', $value ) ),
-			'country' => trim( rgget( $this->field->id . '.6', $value ) ),
+			'street'  => esc_html( rgget( $this->field->id . '.1', $value ) ),
+			'street2' => esc_html( rgget( $this->field->id . '.2', $value ) ),
+			'city'    => esc_html( rgget( $this->field->id . '.3', $value ) ),
+			'state'   => esc_html( rgget( $this->field->id . '.4', $value ) ),
+			'zip'     => esc_html( rgget( $this->field->id . '.5', $value ) ),
+			'country' => esc_html( rgget( $this->field->id . '.6', $value ) ),
 		) );
 
 		return $this->cache();

--- a/src/helper/fields/Field_Checkbox.php
+++ b/src/helper/fields/Field_Checkbox.php
@@ -137,8 +137,8 @@ class Field_Checkbox extends Helper_Abstract_Fields {
 			$html = '<ul class="bulleted checkbox">';
 			$i    = 1;
 			foreach ( $items as $item ) {
-				$sanitized_value  = esc_html( $item['value'] );
-				$sanitized_option = ( $value ) ? $sanitized_value : esc_html( $item['label'] );
+				$sanitized_value  = $item['value'];
+				$sanitized_option = ( $value ) ? $sanitized_value : $item['label'];
 
 				$html .= '<li id="field-' . $this->field->id . '-option-' . $i . '">' . $sanitized_option . '</li>';
 				$i++;
@@ -176,8 +176,8 @@ class Field_Checkbox extends Helper_Abstract_Fields {
 		$items = array();
 
 		foreach ( $value as $key => $item ) {
-			$label = GFCommon::selection_display( $item, $this->field, '', true );
-			$value = GFCommon::selection_display( $item, $this->field );
+			$label = esc_html( GFCommon::selection_display( $item, $this->field, '', true ) );
+			$value = esc_html( GFCommon::selection_display( $item, $this->field ) );
 
 			$items[] = array(
 				'value' => $value,

--- a/src/helper/fields/Field_Coupon.php
+++ b/src/helper/fields/Field_Coupon.php
@@ -85,7 +85,7 @@ class Field_Coupon extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -102,7 +102,7 @@ class Field_Coupon extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Creditcard.php
+++ b/src/helper/fields/Field_Creditcard.php
@@ -86,12 +86,7 @@ class Field_CreditCard extends Helper_Abstract_Fields {
 	 */
 	public function html( $value = '', $label = true ) {
 		$data = array_filter( $this->value() ); /* remove any empty fields from the array */
-
-		/* Sanitize data */
-		array_filter( $data, function( &$item ) {
-			$item = esc_html( $item );
-		} );
-
+		
 		$value = implode( '<br>', $data );
 
 		return parent::html( $value );
@@ -112,8 +107,8 @@ class Field_CreditCard extends Helper_Abstract_Fields {
 		$value = $this->get_value();
 
 		$this->cache( array(
-			'type'   => rgget( $this->field->id . '.4', $value ),
-			'number' => rgget( $this->field->id . '.1', $value ),
+			'type'   => esc_html( rgget( $this->field->id . '.4', $value ) ),
+			'number' => esc_html( rgget( $this->field->id . '.1', $value ) ),
 		) );
 
 		return $this->cache();

--- a/src/helper/fields/Field_Date.php
+++ b/src/helper/fields/Field_Date.php
@@ -86,7 +86,7 @@ class Field_Date extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -103,7 +103,9 @@ class Field_Date extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( GFCommon::date_display( $this->get_value(), $this->field->dateFormat ) );
+		$value = esc_html( GFCommon::date_display( $this->get_value(), $this->field->dateFormat ) );
+
+		$this->cache( $value );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Default.php
+++ b/src/helper/fields/Field_Default.php
@@ -77,7 +77,7 @@ class Field_Default extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Email.php
+++ b/src/helper/fields/Field_Email.php
@@ -87,7 +87,7 @@ class Field_Email extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$value = $this->value();
 
-		$output = ( is_email( $value ) ) ? '<a href="mailto:' . $value . '">' . esc_html( $value ) . '</a>' : esc_html( $value );
+		$output = ( is_email( $value ) ) ? '<a href="mailto:' . $value . '">' . $value . '</a>' : $value;
 
 		return parent::html( $output );
 	}
@@ -104,7 +104,7 @@ class Field_Email extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Hidden.php
+++ b/src/helper/fields/Field_Hidden.php
@@ -85,7 +85,7 @@ class Field_Hidden extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -102,7 +102,7 @@ class Field_Hidden extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Html.php
+++ b/src/helper/fields/Field_Html.php
@@ -84,8 +84,7 @@ class Field_Html extends Helper_Abstract_Fields {
 	public function form_data() {
 
 		$data = array();
-
-		$html = wpautop( wp_kses_post( $this->value() ) );
+		$html = $this->value();
 
 		$data['html'][]                      = $html;
 		$data['html_id'][ $this->field->id ] = $html;
@@ -104,7 +103,7 @@ class Field_Html extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$html = wp_kses_post( $this->value() ); /* allow the same HTML as per the post editor */
+		$html = $this->value(); /* allow the same HTML as per the post editor */
 
 		return parent::html( $html, false );
 	}
@@ -121,7 +120,9 @@ class Field_Html extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->field->content );
+		$value = ( isset( $this->field->content ) ) ? wpautop( wp_kses_post( $this->field->content ) ) : '';
+
+		$this->cache( $value );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Likert.php
+++ b/src/helper/fields/Field_Likert.php
@@ -134,7 +134,7 @@ class Field_Likert extends Helper_Abstract_Fields {
          * Get the column names
          */
 		foreach ( $this->field->choices as $column ) {
-			$likert['col'][ $column['value'] ] = $column['text'];
+			$likert['col'][ $column['value'] ] = esc_html( $column['text'] );
 		}
 
 		/**

--- a/src/helper/fields/Field_List.php
+++ b/src/helper/fields/Field_List.php
@@ -214,19 +214,20 @@ class Field_List extends Helper_Abstract_Fields {
 		/* If single list field */
 		if ( ! is_array( $list[0] ) ) {
 			$list = array_filter( $list );
+			$list = array_map( 'esc_html', $list );
 		} else {
 
 			/* Loop through the multi-column list */
-			foreach ( $list as $id => $row ) {
+			foreach ( $list as $id => &$row ) {
 
 				$empty = true;
 
 				foreach ( $row as &$col ) {
 
 					/* Check if there is data and if so break the loop */
-					if ( trim( strlen( $col ) > 0 ) ) {
+					if ( strlen( trim( $col ) ) > 0 ) {
+						$col = esc_html( $col );
 						$empty = false;
-						break;
 					}
 				}
 

--- a/src/helper/fields/Field_Multiselect.php
+++ b/src/helper/fields/Field_Multiselect.php
@@ -137,8 +137,8 @@ class Field_Multiselect extends Helper_Abstract_Fields {
 			$html = '<ul class="bulleted multiselect">';
 
 			foreach ( $items as $item ) {
-				$sanitized_value  = esc_html( $item['value'] );
-				$sanitized_option = ( $value ) ? $sanitized_value : esc_html( $item['label'] );
+				$sanitized_value  = $item['value'];
+				$sanitized_option = ( $value ) ? $sanitized_value : $item['label'];
 
 				$html .= '<li id="field-' . $this->field->id . '-option-' . $i . '">' . $sanitized_option . '</li>';
 				$i++;
@@ -175,8 +175,8 @@ class Field_Multiselect extends Helper_Abstract_Fields {
 		/* loop through array and get the correct selection display value */
 		$items = array();
 		foreach ( $value as $item ) {
-			$label = GFCommon::selection_display( $item, $this->field, '', true );
-			$value = GFCommon::selection_display( $item, $this->field );
+			$label = esc_html( GFCommon::selection_display( $item, $this->field, '', true ) );
+			$value = esc_html( GFCommon::selection_display( $item, $this->field ) );
 
 			$items[] = array(
 				'value' => $value,

--- a/src/helper/fields/Field_Name.php
+++ b/src/helper/fields/Field_Name.php
@@ -87,7 +87,7 @@ class Field_Name extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$data = array_filter( $this->value() ); /* remove any empty fields from the array */
 
-		$value = esc_html( implode( ' ', $data ) );
+		$value = implode( ' ', $data );
 
 		return parent::html( $value );
 	}
@@ -108,17 +108,21 @@ class Field_Name extends Helper_Abstract_Fields {
 
 		/* backwards compatible - check if the returned results are an array otherwise set to cache and return */
 		if ( ! is_array( $value ) ) {
-			$this->cache( $value );
+			$this->cache( esc_html( $value ) );
 			return $this->cache();
 		}
 
-		$this->cache( array(
+		$value = array(
 			'prefix' => rgget( $this->field->id . '.2', $value ),
 			'first'  => rgget( $this->field->id . '.3', $value ),
 			'middle' => rgget( $this->field->id . '.4', $value ),
 			'last'   => rgget( $this->field->id . '.6', $value ),
 			'suffix' => rgget( $this->field->id . '.8', $value ),
-		) );
+		);
+
+		$value = array_map( 'esc_html', $value );
+
+		$this->cache( $value );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Number.php
+++ b/src/helper/fields/Field_Number.php
@@ -86,7 +86,7 @@ class Field_Number extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -103,7 +103,9 @@ class Field_Number extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( GFCommon::format_number( $this->get_value(), $this->field->numberFormat ) );
+		$value = esc_html( GFCommon::format_number( $this->get_value(), $this->field->numberFormat ) );
+
+		$this->cache( $value );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Phone.php
+++ b/src/helper/fields/Field_Phone.php
@@ -85,7 +85,7 @@ class Field_Phone extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -102,7 +102,7 @@ class Field_Phone extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Post_Category.php
+++ b/src/helper/fields/Field_Post_Category.php
@@ -196,12 +196,14 @@ class Field_Post_Category extends Helper_Abstract_Fields {
 			if ( isset( $val['label'] ) ) {
 				$label        = GFCommon::prepare_post_category_value( $val['label'], $this->field );
 				$val['label'] = ( is_array( $label ) && isset( $label[0] ) ) ? $label[0] : $label;
+				$val['label'] = esc_html( $val['label'] );
 			}
 
 			/* process the category value */
 			if ( isset( $val['value'] ) ) {
 				$id           = GFCommon::prepare_post_category_value( $val['value'], $this->field, 'conditional_logic' );
 				$val['value'] = ( is_array( $id ) && isset( $id[0] ) ) ? $id[0] : $id;
+				$val['value'] = esc_html( $val['value'] );
 			}
 		}
 

--- a/src/helper/fields/Field_Post_Excerpt.php
+++ b/src/helper/fields/Field_Post_Excerpt.php
@@ -85,7 +85,7 @@ class Field_Post_Excerpt extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -102,7 +102,7 @@ class Field_Post_Excerpt extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Post_Image.php
+++ b/src/helper/fields/Field_Post_Image.php
@@ -89,20 +89,20 @@ class Field_Post_Image extends Helper_Abstract_Fields {
 		$value = $this->value();
 
 		/* Start building image link */
-		$html = '<a href="' . esc_url( $value['url'] ) . '" target="_blank">';
-		$html .= '<img width="150" src="' . esc_url( $value['url'] ) . '" />';
+		$html = '<a href="' . $value['url'] . '" target="_blank">';
+		$html .= '<img width="150" src="' . $value['url'] . '" />';
 
 		/* Include title / caption / description if needed */
 		if ( ! empty( $value['title'] ) ) {
-			$html .= '<div class="gfpdf-post-image-title">' . esc_html( $value['title'] ) . '</div>';
+			$html .= '<div class="gfpdf-post-image-title">' . $value['title'] . '</div>';
 		}
 
 		if ( ! empty( $value['caption'] ) ) {
-			$html .= '<div class="gfpdf-post-image-caption">' . esc_html( $value['caption'] ) . '</div>';
+			$html .= '<div class="gfpdf-post-image-caption">' . $value['caption'] . '</div>';
 		}
 
 		if ( ! empty( $value['description'] ) ) {
-			$html .= '<div class="gfpdf-post-image-description">' . esc_html( $value['description'] ) . '</div>';
+			$html .= '<div class="gfpdf-post-image-description">' . $value['description'] . '</div>';
 		}
 
 		$html .= '</a>';
@@ -154,11 +154,11 @@ class Field_Post_Image extends Helper_Abstract_Fields {
 		if ( strlen( $value ) > 0 ) {
 			$value = explode( '|:|', $this->get_value() );
 
-			$img['url']         = ( isset( $value[0] ) ) ? $value[0] : '';
-			$img['path']        = ( isset( $value[0] ) ) ? $value[0] : '';
-			$img['title']       = ( isset( $value[1] ) ) ? $value[1] : '';
-			$img['caption']     = ( isset( $value[2] ) ) ? $value[2] : '';
-			$img['description'] = ( isset( $value[3] ) ) ? $value[3] : '';
+			$img['url']         = ( isset( $value[0] ) ) ? esc_url( $value[0] ) : '';
+			$img['path']        = ( isset( $value[0] ) ) ? esc_url( $value[0] ) : '';
+			$img['title']       = ( isset( $value[1] ) ) ? esc_html( $value[1] ) : '';
+			$img['caption']     = ( isset( $value[2] ) ) ? esc_html( $value[2] ) : '';
+			$img['description'] = ( isset( $value[3] ) ) ? esc_html( $value[3] ) : '';
 
 			$path = ( isset( $value[0] ) ) ? $this->misc->convert_url_to_path( $value[0] ) : '';
 			if ( $path != $img['url'] ) {

--- a/src/helper/fields/Field_Post_Tags.php
+++ b/src/helper/fields/Field_Post_Tags.php
@@ -126,7 +126,8 @@ class Field_Post_Tags extends Helper_Abstract_Fields {
 		}
 
 		$value = explode( ',', $this->get_value() ); /* get tags and turn into array */
-		$value = array_map( 'trim', $value ); /* apply trim callback to all array elements */
+		$value = array_map( 'trim', $value );
+		$value = array_map( 'esc_html', $value );
 
 		$this->cache( $value );
 

--- a/src/helper/fields/Field_Post_Title.php
+++ b/src/helper/fields/Field_Post_Title.php
@@ -85,7 +85,7 @@ class Field_Post_Title extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -102,7 +102,7 @@ class Field_Post_Title extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Product.php
+++ b/src/helper/fields/Field_Product.php
@@ -88,7 +88,10 @@ class Field_Product extends Helper_Abstract_Fields {
 		switch ( $field->type ) {
 			case 'product':
 				$name  = ( isset( $value['name'] ) && isset( $value['price'] ) ) ? $value['name'] . " ({$value['price']})" : '';
+				$name  = esc_html( $name );
+
 				$price = ( isset( $value['price_unformatted'] ) ) ? $value['price_unformatted'] : '';
+				$price = esc_html( $price );
 			break;
 
 			case 'option':
@@ -116,14 +119,14 @@ class Field_Product extends Helper_Abstract_Fields {
 				$name = array_map( function( $value ) use ( $field ) {
 					$option_info = GFCommon::get_option_info( $value, $field, false );
 
-					return $option_info['name'];
+					return esc_html( $option_info['name'] );
 				}, $option_value );
 
 				/* Get the field value (the price) */
 				$price = array_map( function( $value ) use ( $field ) {
 					$option_info = GFCommon::get_option_info( $value, $field, false );
 
-					return $option_info['price'];
+					return esc_html( $option_info['price'] );
 				}, $option_value );
 
 				/**
@@ -139,7 +142,10 @@ class Field_Product extends Helper_Abstract_Fields {
 
 			case 'shipping':
 				$name  = ( isset( $value['shipping_name'] ) ) ? $value['shipping_name'] . " ({$value['shipping_formatted']})" : '';
+				$name  = esc_html( $name );
+
 				$price = ( isset( $value['shipping'] ) ) ? $value['shipping'] : '';
+				$price = esc_html( $price );
 			break;
 
 			case 'quantity':
@@ -184,7 +190,7 @@ class Field_Product extends Helper_Abstract_Fields {
 		switch ( $this->field->type ) {
 			case 'product':
 				if ( isset( $value['name'] ) ) {
-					$html .= $value['name'] . ' - ' . $value['price'];
+					$html .= esc_html( $value['name'] . ' - ' . $value['price'] );
 					$html .= $this->get_option_html( $value['options'] );
 				}
 			break;
@@ -196,7 +202,7 @@ class Field_Product extends Helper_Abstract_Fields {
 			break;
 
 			case 'quantity':
-				$html .= $value;
+				$html .= esc_html( $value );
 			break;
 
 			case 'shipping':
@@ -230,7 +236,7 @@ class Field_Product extends Helper_Abstract_Fields {
 			$html .= '<ul class="product_options">';
 
 			foreach ( $options as $option ) {
-				$html .= '<li>' . $option['option_name'] . ' - ' . $option['price_formatted'] . '</li>';
+				$html .= '<li>' . esc_html( $option['option_name'] . ' - ' . $option['price_formatted'] ) . '</li>';
 			}
 
 			$html .= '</ul>';
@@ -271,17 +277,17 @@ class Field_Product extends Helper_Abstract_Fields {
 		/* Filter out the shipping field */
 		if ( $this->field->type == 'shipping' && isset( $data['products_totals']['shipping'] ) ) {
 			return array(
-				'shipping'           => $data['products_totals']['shipping'],
-				'shipping_formatted' => $data['products_totals']['shipping_formatted'],
-				'shipping_name'      => $data['products_totals']['shipping_name'],
+				'shipping'           => esc_html( $data['products_totals']['shipping'] ),
+				'shipping_formatted' => esc_html( $data['products_totals']['shipping_formatted'] ),
+				'shipping_name'      => esc_html( $data['products_totals']['shipping_name'] ),
 			);
 		}
 
 		/* Filter out the total field */
 		if ( $this->field->type == 'total' && isset( $data['products_totals']['total'] ) ) {
 			return array(
-				'total'           => $data['products_totals']['total'],
-				'total_formatted' => $data['products_totals']['total_formatted'],
+				'total'           => esc_html( $data['products_totals']['total'] ),
+				'total_formatted' => esc_html( $data['products_totals']['total_formatted'] ),
 			);
 		}
 

--- a/src/helper/fields/Field_Products.php
+++ b/src/helper/fields/Field_Products.php
@@ -282,8 +282,9 @@ class Field_Products extends Helper_Abstract_Fields {
 				'shipping_name'      => ( isset( $products['shipping']['name'] ) ) ? preg_replace( '/(.+?) \((.+?)\)/', '$2', $products['shipping']['name'] ) : '',
 				'total'              => $order_total,
 				'total_formatted'    => GFCommon::format_number( $order_total, 'currency' ),
-
 			);
+
+			$form_array['products_totals'] = array_map( 'esc_html', $form_array['products_totals'] );
 		}
 
 		/* Save the array into the cache */

--- a/src/helper/fields/Field_Quiz.php
+++ b/src/helper/fields/Field_Quiz.php
@@ -125,7 +125,7 @@ class Field_Quiz extends Helper_Abstract_Fields {
 			foreach ( $this->field->choices as $choice ) {
 				if ( $choice['value'] == $item ) {
 					$formatted[] = array(
-						'text'      => $choice['text'],
+						'text'      => esc_html( $choice['text'] ),
 						'isCorrect' => $choice['gquizIsCorrect'],
 						'weight'    => ( isset( $choice['gquizWeight'] ) ) ? $choice['gquizWeight'] : '',
 					);

--- a/src/helper/fields/Field_Radio.php
+++ b/src/helper/fields/Field_Radio.php
@@ -88,7 +88,6 @@ class Field_Radio extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$data   = $this->value();
 		$output = ( $value ) ? $data['value'] : $data['label'];
-		$output = esc_html( $output );
 
 		return parent::html( $output );
 	}
@@ -131,8 +130,8 @@ class Field_Radio extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$label = trim( GFCommon::selection_display( $this->get_value(), $this->field, '', true ) );
-		$value = trim( GFCommon::selection_display( $this->get_value(), $this->field ) );
+		$label = esc_html( GFCommon::selection_display( $this->get_value(), $this->field, '', true ) );
+		$value = esc_html( GFCommon::selection_display( $this->get_value(), $this->field ) );
 
 
 		/* return value / label as an array */

--- a/src/helper/fields/Field_Rank.php
+++ b/src/helper/fields/Field_Rank.php
@@ -105,7 +105,7 @@ class Field_Rank extends Helper_Abstract_Fields {
 			/* Loop through the total choices */
 			foreach ( $this->field->choices as $choice ) {
 				if ( trim( $choice['value'] ) == trim( $rating ) ) {
-					$value[] = $choice['text'];
+					$value[] = esc_html( $choice['text'] );
 					break; /* exit inner loop as soon as found */
 				}
 			}

--- a/src/helper/fields/Field_Rating.php
+++ b/src/helper/fields/Field_Rating.php
@@ -105,7 +105,7 @@ class Field_Rating extends Helper_Abstract_Fields {
 			/* Loop through the total choices */
 			foreach ( $this->field->choices as $choice ) {
 				if ( trim( $choice['value'] ) == trim( $rating ) ) {
-					$value[] = $choice['text'];
+					$value[] = esc_html( $choice['text'] );
 					break; /* exit inner loop as soon as found */
 				}
 			}

--- a/src/helper/fields/Field_Section.php
+++ b/src/helper/fields/Field_Section.php
@@ -119,10 +119,10 @@ class Field_Section extends Helper_Abstract_Fields {
 		$section = $this->value(); /* allow the same HTML as per the post editor */
 
 		$html = '<div id="field-' . $this->field->id . '" class="gfpdf-section-title gfpdf-field">';
-		$html .= '<h3>' . esc_html( $section['title'] ) . '</h3>';
+		$html .= '<h3>' . $section['title'] . '</h3>';
 
 		if ( ! empty( $value ) ) {
-			$html .= '<div id="field-' . $this->field->id . '-desc" class="gfpdf-section-description gfpdf-field">' . wp_kses_post( $section['description'] ) . '</div>';
+			$html .= '<div id="field-' . $this->field->id . '-desc" class="gfpdf-section-description gfpdf-field">' . $section['description'] . '</div>';
 		}
 
 		$html .= '</div>';
@@ -143,8 +143,8 @@ class Field_Section extends Helper_Abstract_Fields {
 		}
 
 		$this->cache( array(
-			'title'       => $this->field->label,
-			'description' => $this->field->description,
+			'title'       => esc_html( $this->field->label ),
+			'description' => wp_kses_post( $this->field->description ),
 		) );
 
 		return $this->cache();

--- a/src/helper/fields/Field_Select.php
+++ b/src/helper/fields/Field_Select.php
@@ -116,7 +116,6 @@ class Field_Select extends Helper_Abstract_Fields {
 		$data = $this->value();
 
 		$output = ( $value ) ? $data['value'] : $data['label'];
-		$output = esc_html( $output );
 
 		return parent::html( $output );
 	}
@@ -133,8 +132,8 @@ class Field_Select extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$label = trim( GFCommon::selection_display( $this->get_value(), $this->field, '', true ) );
-		$value = trim( GFCommon::selection_display( $this->get_value(), $this->field ) );
+		$label = esc_html( GFCommon::selection_display( $this->get_value(), $this->field, '', true ) );
+		$value = esc_html( GFCommon::selection_display( $this->get_value(), $this->field ) );
 
 		/* return value / label as an array */
 		$this->cache( array(

--- a/src/helper/fields/Field_Survey.php
+++ b/src/helper/fields/Field_Survey.php
@@ -143,7 +143,7 @@ class Field_Survey extends Helper_Abstract_Fields {
 
 				/* Overriding survey radio values with name */
 				array_walk( $data['field'], function ( &$item, $key, $value ) {
-					$item = $value;
+					$item = esc_html( $value );
 				}, $value );
 
 				break;
@@ -155,7 +155,7 @@ class Field_Survey extends Helper_Abstract_Fields {
 				foreach ( $this->field->choices as $choice ) {
 
 					if ( ( $key = array_search( $choice['value'], $value ) ) !== false ) {
-						$value[ $key ] = $choice['text'];
+						$value[ $key ] = esc_html( $choice['text'] );
 					}
 				}
 

--- a/src/helper/fields/Field_Text.php
+++ b/src/helper/fields/Field_Text.php
@@ -85,7 +85,7 @@ class Field_Text extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -102,7 +102,7 @@ class Field_Text extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Time.php
+++ b/src/helper/fields/Field_Time.php
@@ -85,7 +85,7 @@ class Field_Time extends Helper_Abstract_Fields {
 	 * @since 4.0
 	 */
 	public function html( $value = '', $label = true ) {
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		return parent::html( $value );
 	}
@@ -102,7 +102,7 @@ class Field_Time extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_Tos.php
+++ b/src/helper/fields/Field_Tos.php
@@ -87,7 +87,7 @@ class Field_Tos extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 
 		$terms = wp_kses_post( nl2br( $this->field->gwtermsofservice_terms ) );
-		$value = esc_html( $this->value() );
+		$value = $this->value();
 
 		$html = "
 			<div class='terms-of-service-text'>$terms</div>
@@ -110,7 +110,7 @@ class Field_Tos extends Helper_Abstract_Fields {
 		}
 
 		$value_array = $this->get_value();
-		$value = $value_array[ $this->field->id . '.1' ];
+		$value       = esc_html( $value_array[ $this->field->id . '.1' ] );
 
 		$this->cache( $value );
 

--- a/src/helper/fields/Field_Website.php
+++ b/src/helper/fields/Field_Website.php
@@ -88,7 +88,7 @@ class Field_Website extends Helper_Abstract_Fields {
 	public function html( $value = '', $label = true ) {
 		$value = $this->value();
 
-		$output = ( GFCommon::is_valid_url( $value ) ) ? '<a href="' . esc_url( $value ) . '" target="_blank">' . esc_html( $value ) . '</a>' : esc_html( $value );
+		$output = ( GFCommon::is_valid_url( $value ) ) ? '<a href="' . $value . '" target="_blank">' . $value . '</a>' : $value;
 
 		return parent::html( $output );
 	}
@@ -105,7 +105,7 @@ class Field_Website extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$this->cache( $this->get_value() );
+		$this->cache( esc_html( $this->get_value() ) );
 
 		return $this->cache();
 	}

--- a/src/helper/fields/Field_v3_List.php
+++ b/src/helper/fields/Field_v3_List.php
@@ -78,7 +78,7 @@ class Field_v3_List extends Field_List {
 
 		<ul class="bulleted single-column-list">
 			<?php foreach ( $value as $item ) : ?>
-				<li><?php echo esc_html( $item ); ?></li>
+				<li><?php echo $item; ?></li>
 			<?php endforeach; ?>
 		</ul>
 		<?php

--- a/src/helper/fields/Field_v3_Section.php
+++ b/src/helper/fields/Field_v3_Section.php
@@ -57,10 +57,10 @@ class Field_v3_Section extends Field_Section {
 		/* sanitize the HTML */
 		$section = $this->value(); /* allow the same HTML as per the post editor */
 
-		$html = '<h2 class="default entry-view-section-break" id="field-' . $this->field->id . '">' . esc_html( $section['title'] ) . '</h2>';
+		$html = '<h2 class="default entry-view-section-break" id="field-' . $this->field->id . '">' . $section['title'] . '</h2>';
 
 		if ( ! empty( $value ) ) {
-			$html .= '<div class="default entry-view-section-break entry-view-section-break-content">' . wp_kses_post( $section['description'] ) . '</div>';
+			$html .= '<div class="default entry-view-section-break entry-view-section-break-content">' . $section['description'] . '</div>';
 		}
 
 		return $html;

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -1575,7 +1575,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 					/* Check if this is the correct field */
 					if ( isset( $choice['gquizIsCorrect'] ) && $choice['gquizIsCorrect'] == 1 ) {
-						$results['field_data'][ $field->id ]['misc']['correct_option_name'][] = $choice['text'];
+						$results['field_data'][ $field->id ]['misc']['correct_option_name'][] = esc_html( $choice['text'] );
 					}
 				}
 			}


### PR DESCRIPTION
Instead of applying esc_html() during the html() method, we're going to apply it at the value() method so the $form_data array is appropriately protected as well.
This does break backwards compatibility and make it more difficult for users to apply conditional logic in custom templates (as there's encoded characters to consider - < > ' " &) but we'll note this in the developer documentation and upgrade guide.

Resolves #385