### PR TITLE
Allow subscriber access to PDF welcome screen

### DIFF
--- a/src/model/Model_Welcome_Screen.php
+++ b/src/model/Model_Welcome_Screen.php
@@ -54,7 +54,7 @@ class Model_Welcome_Screen extends Helper_Abstract_Model {
 	 *
 	 * @since 4.0
 	 */
-	public $minimum_capability = 'gravityforms_view_settings';
+	public $minimum_capability = 'read';
 
 	/**
 	 * @var string The welcome page title


### PR DESCRIPTION
The welcome screen doesn't need any protection. Give users full access to hidden page if they know direct link.
Only users with the 'activate_plugins' capability will be automatically redirected to page.