### PR TITLE
Fix PHP ASP Tag / Underscore template tag conflict

### DIFF
--- a/src/assets/js/gfpdf-backbone.js
+++ b/src/assets/js/gfpdf-backbone.js
@@ -9,6 +9,21 @@
 	$(function() {
 
 		/**
+		 * To prevent problems with PHP's ASP Short tags (removed in PHP 7) we'll change Underscore's delimiters to be Handlebars-ish:
+		 * {{= }}, {{- }} or {{ }}
+		 *
+		 * @see https://github.com/GravityPDF/gravity-pdf/issues/417
+		 * @type {{interpolate: RegExp, evaluate: RegExp, escape: RegExp}}
+		 * @since 4.0.1
+		 */
+		var UnderscoreSettingsOverride = {
+			evaluate: /\{\{(.+?)\}\}/gim,
+			interpolate: /\{\{=(.+?)\}\}/gim,
+			escape: /\{\{-(.+?)\}\}/gim
+		};
+
+
+		/**
 		 * Handles our Font CRUD Feature
 		 * Allows URLs to TTF and OTF font files to be passed
 		 * to a specific custom font 'group' defined by the user.
@@ -314,10 +329,8 @@
 						this.addRender(font);
 					}, this);
 				} else {
-
 					/* Display getting started message to user */
-					this.$el.html( _.template( $( '#GravityPDFFontsEmpty' ).html() ) );
-
+					this.$el.html(_.template($( '#GravityPDFFontsEmpty' ).html(), UnderscoreSettingsOverride));
 				}
 
 				/* Return for chaining purposes */
@@ -425,7 +438,7 @@
 			render: function() {
 
 				/* Set up our Underscore template file */
-				this.template = _.template( $( this.template ).html() );
+				this.template = _.template($( this.template ).html(), UnderscoreSettingsOverride);
 
 				/* Set View Element HTML to our Underscore template, passing in our model */
 				this.$el.html(this.template({
@@ -1003,7 +1016,7 @@
 
 			render: function() {
 				/* set up out template */
-				this.template = _.template($(this.template).html());
+				this.template = _.template($(this.template).html(), UnderscoreSettingsOverride);
 
 				/* show the loading spinner */
 				this.showSpinner();

--- a/src/helper/abstract/Helper_Abstract_View.php
+++ b/src/helper/abstract/Helper_Abstract_View.php
@@ -97,6 +97,17 @@ abstract class Helper_Abstract_View extends Helper_Abstract_Model {
 	}
 
 	/**
+	 * Get the full path to the current view
+	 *
+	 * @return string The path
+	 *
+	 * @since 4.0.1
+	 */
+	final public function get_view_dir_path() {
+		return PDF_PLUGIN_DIR . 'src/view/html/' . $this->view_type . '/';
+	}
+
+	/**
 	 * Load a view file based on the filename and type
 	 *
 	 * @param  string  $filename The filename to load
@@ -108,7 +119,7 @@ abstract class Helper_Abstract_View extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	final protected function load( $filename, $args = array(), $output = true ) {
-		$path = PDF_PLUGIN_DIR . 'src/view/html/' . $this->view_type . '/' . $filename . '.php';
+		$path = $this->get_view_dir_path() . $filename . '.php';
 		$args = array_merge( $this->data_cache, $args );
 
 		if ( is_readable( $path ) ) {

--- a/src/view/html/Settings/help.php
+++ b/src/view/html/Settings/help.php
@@ -119,16 +119,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 </div><!-- close #pdfextended-settings -->
 
 <script type="text/template" id="GravityPDFSearchResultsDocumentation">
-	<% if(collection.length === 0) { %>
+	{{ if(collection.length === 0) { }}
 		<li><?php _e( "It doesn't look like there are any topics related to your issue.", 'gravity-forms-pdf-extended' ); ?></li>
-	<% } else { %>
+	{{ } else { }}
 		<li><h3><?php _e( 'Maybe one of these articles will help...', 'gravity-forms-pdf-extended' ); ?></h3></li>
-	<% } %>
+	{{ } }}
 
-	<% _.each(collection, function (model) { %>
+	{{ _.each(collection, function (model) { }}
 		<li>
-			<a href="<%= model.link %>"><%= model.title.rendered %></a>
-			<div class="except"><%= model.excerpt.rendered %></div>
+			<a href="{{= model.link }}">{{= model.title.rendered }}</a>
+			<div class="except">{{= model.excerpt.rendered }}</div>
 		</li>
-	<% }); %>
+	{{ }); }}
 </script>

--- a/src/view/html/Settings/tools.php
+++ b/src/view/html/Settings/tools.php
@@ -106,7 +106,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </script>
 
 <script type="text/template" id="GravityPDFFonts">
-	<a href="#" class="font-name"><i class="fa fa-angle-right"></i><span name="font_name"><%- model.get('font_name') %></span></a>
+	<a href="#" class="font-name"><i class="fa fa-angle-right"></i><span name="font_name">{{- model.get('font_name') }}</span></a>
 	<div class="font-settings" style="display: none">
 
 		<form method="post">
@@ -114,13 +114,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div class="font-selector">
 				<label><?php _e( 'Font Name', 'gravity-forms-pdf-extended' ); ?> <span class="gfield_required">*</span></label>
-				<input type="text" required="required" value="<%- model.get('font_name') %>" name="font_name" class="regular-text font-name-field">
+				<input type="text" required="required" value="{{- model.get('font_name') }}" name="font_name" class="regular-text font-name-field">
 				<span class="gf_settings_description"><label><?php _e( 'Only alphanumeric characters and spaces are accepted.', 'gravity-forms-pdf-extended' ); ?></label></span>
 			</div>
 
 			<div class="font-selector">
 				<label><?php _e( 'Regular', 'gravity-forms-pdf-extended' ); ?> <span class="gfield_required">*</span></label>
-				<input type="text" value="<%- model.get('regular') %>" required="required" name="regular" class="regular-text">
+				<input type="text" value="{{- model.get('regular') }}" required="required" name="regular" class="regular-text">
 				<span>
 					<input type="button"
 				             data-uploader-button-text="<?php _e( 'Select Font', 'gravity-forms-pdf-extended' ); ?>"
@@ -132,7 +132,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div class="font-selector">
 				<label><?php _e( 'Italics', 'gravity-forms-pdf-extended' ); ?></label>
-				<input type="text" value="<%- model.get('italics') %>" name="italics" class="regular-text">
+				<input type="text" value="{{- model.get('italics') }}" name="italics" class="regular-text">
 				<span>
 					<input type="button"
 					       data-uploader-button-text="<?php _e( 'Select Font', 'gravity-forms-pdf-extended' ); ?>"
@@ -144,7 +144,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div class="font-selector">
 				<label><?php _e( 'Bold', 'gravity-forms-pdf-extended' ); ?></label>
-				<input type="text" value="<%- model.get('bold') %>" name="bold" class="regular-text">
+				<input type="text" value="{{- model.get('bold') }}" name="bold" class="regular-text">
 				<span>
 					<input type="button"
 				             data-uploader-button-text="<?php _e( 'Select Font', 'gravity-forms-pdf-extended' ); ?>"
@@ -156,7 +156,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div class="font-selector">
 				<label><?php _e( 'Bold Italics', 'gravity-forms-pdf-extended' ); ?></label>
-				<input type="text" value="<%- model.get('bolditalics') %>" name="bolditalics" class="regular-text">
+				<input type="text" value="{{- model.get('bolditalics') }}" name="bolditalics" class="regular-text">
 				<span>
 					<input type="button"
 				             data-uploader-button-text="<?php _e( 'Select Font', 'gravity-forms-pdf-extended' ); ?>"

--- a/tests/phpunit/unit-tests/test-mvc-abstracts.php
+++ b/tests/phpunit/unit-tests/test-mvc-abstracts.php
@@ -131,11 +131,9 @@ class Test_MVC_Abstracts extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_abstract_view() {
-		/**
+		/*
 		 * Test our load function produces the correct output
 		 */
-
-		/* check we are loading data correctly  */
 		ob_start();
 		$results = $this->view->uninstaller( array() );
 		$string  = ob_get_clean();
@@ -147,5 +145,13 @@ class Test_MVC_Abstracts extends WP_UnitTestCase {
 		/* check for error */
 		$error = $this->view->load_none_existant_file( array() );
 		$this->assertTrue( is_wp_error( $error ) );
+
+		/*
+		 * Test our get_view_dir_path() string works correctly
+		 */
+		$results = $this->view->get_view_dir_path();
+
+		$this->assertFileExists( $results . 'general.php' );
+		$this->assertFileNotExists( $results . 'generic-file-that-isnt-included.php' );
 	}
 }


### PR DESCRIPTION
This issue occurred because PHP is parsing our underscore JS code as PHP because the PHP INI asp_tags setting is enabled.
The fix was to override the underscore template delimiters and replace them with something else. We chose Handlebars-ish syntax.

Resolves #417