### PR TITLE
Allow Radio and Checkbox values to show HTML in PDFs

### DIFF
--- a/src/helper/fields/Field_Checkbox.php
+++ b/src/helper/fields/Field_Checkbox.php
@@ -137,8 +137,8 @@ class Field_Checkbox extends Helper_Abstract_Fields {
 			$html = '<ul class="bulleted checkbox">';
 			$i    = 1;
 			foreach ( $items as $item ) {
-				$sanitized_value  = $item['value'];
-				$sanitized_option = ( $value ) ? $sanitized_value : $item['label'];
+				$sanitized_option = ( $value ) ? $item['value'] : $item['label'];
+				$sanitized_option = wp_kses_post( wp_specialchars_decode( $sanitized_option, ENT_QUOTES ) );
 
 				$html .= '<li id="field-' . $this->field->id . '-option-' . $i . '">' . $sanitized_option . '</li>';
 				$i++;

--- a/src/helper/fields/Field_Radio.php
+++ b/src/helper/fields/Field_Radio.php
@@ -89,7 +89,39 @@ class Field_Radio extends Helper_Abstract_Fields {
 		$data   = $this->value();
 		$output = ( $value ) ? $data['value'] : $data['label'];
 
+		/* Allow HTML if the radio value isn't the "other" option */
+		if ( ! $this->is_user_defined_value( $data['value'] ) ) {
+			$output = wp_kses_post( wp_specialchars_decode( $output, ENT_QUOTES ) );
+		}
+
 		return parent::html( $output );
+	}
+
+	/**
+	 * Checks if the selected Radio button value is defined by the site owner (standard radio options)
+	 * or by the end user (through the "other" option).
+	 *
+	 * @param string $value The user-selected radio button value
+	 *
+	 * @return bool Returns true if value is user-defined, or false otherwise
+	 *
+	 * @since 4.0.1
+	 */
+	protected function is_user_defined_value( $value ) {
+
+		/* Check if the field has the "Other" choice enabled */
+		if ( ! isset( $this->field->enableOtherChoice ) || true !== $this->field->enableOtherChoice ) {
+			return false;
+		}
+
+		/* Loop through the values and check if we have a match */
+		foreach ( $this->field->choices as $item ) {
+			if ( wp_specialchars_decode( $value, ENT_QUOTES ) === $item['value'] ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
This is because these fields are set by the site owner and not the end user so it's presumed to be trusted. The exception to this is user-defined values in Radio fields which allows the "other" option.

With that said, all HTML is run through wp_kses_post() to prevent any nasty surprises.

Resolves #415