### PR TITLE
Fix address lookup in is_empty()

### DIFF
--- a/src/helper/fields/Field_Address.php
+++ b/src/helper/fields/Field_Address.php
@@ -149,7 +149,7 @@ class Field_Address extends Helper_Abstract_Fields {
 		foreach( $field->inputs as $item ) {
 			if ( ! isset( $item['isHidden'] ) || false === $item['isHidden'] ) {
 				/* Now we know item isn't hidden, go through the values and check if there's data */
-				$item_value = trim( rgget( $item['id'], $value ) );
+				$item_value = trim( rgget( (string) $item['id'], $value ) );
 				if ( ! empty( $item_value ) ) {
 					return false;
 				}


### PR DESCRIPTION
When the address field input IDs are an interger / float it was
putting off our address lookup in is_empty(). Case the ID as a string
 to correct the problem.

 Fixes #429