### PR TITLE
Change Query Path Usage to use HTML5 Parser

### DIFF
--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -232,7 +232,8 @@ class Helper_Misc {
 
 		try {
 			/* Get the <img> from the DOM and extract required details */
-			$wrapper = htmlqp( $html );
+			$qp = new Helper_QueryPath();
+			$wrapper = $qp->html5( $html );
 
 			$images = $wrapper->find( 'img' );
 
@@ -260,7 +261,7 @@ class Helper_Misc {
 					}
 				}
 
-				return $wrapper->top( 'body' )->innerHTML5();
+				return $wrapper->top( 'html' )->innerHTML5();
 			}
 
 			return $html;

--- a/src/helper/Helper_QueryPath.php
+++ b/src/helper/Helper_QueryPath.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace GFPDF\Helper\Fields;
+namespace GFPDF\Helper;
 
-use GFPDF\Helper\Helper_QueryPath;
+use \Masterminds\HTML5;
+use \QueryPath\DOMQuery;
+use \QueryPath;
 
 /**
- * Gravity Forms Field
+ * Extends Query Path to make it more useful to us when using the HTML5 methods (which are UTF-8 compatible).
  *
  * @package     Gravity PDF
  * @copyright   Copyright (c) 2016, Blue Liquid Designs
@@ -39,40 +41,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 */
 
 /**
- * Controls the display and output of a Gravity Form field
- *
  * @since 4.0
  */
-class Field_v3_Products extends Field_Products {
-
+class Helper_QueryPath extends QueryPath {
 
 	/**
-	 * Display the HTML version of this field
+	 * Parse HTML5 documents as strings
 	 *
-	 * @param string $value
-	 * @param bool   $label
+	 * This uses HTML5-PHP to parse the document. In actuality, this parser does
+	 * a fine job with pre-HTML5 documents in most cases, though really old HTML
+	 * (like 2.0) may have some substantial quirks.
 	 *
-	 * @return string
+	 * @param mixed  $html
+	 *   A document as a HTML string.
 	 *
-	 * @since 4.0
+	 * @param string $selector
+	 *   A CSS3 selector.
+	 *
+	 * @param array  $options
+	 *   An associative array of options, which is passed on into HTML5-PHP. Note
+	 *   that the standard QueryPath options may be ignored for this function,
+	 *   since it uses a different parser.
+	 *
+	 * @return QueryPath
+	 *
+	 * @since 4.0.3
 	 */
-	public function html( $value = '', $label = true ) {
-		$html = parent::html( $value, $label );
+	public function html5( $html = '', $selector = null, $options = [ ] ) {
+		$html5  = new HTML5();
+		$source = $html5->loadHTML( $html );
 
-		/* Format the order label correctly */
-		$label = apply_filters( 'gform_order_label', __( 'Order', 'gravityforms' ), $this->form->id );
-		$label = apply_filters( 'gform_order_label_' . $this->form->id, $label, $this->form->id );
-
-		$heading = '<h2 class="default entry-view-section-break">' . $label . '</h2>';
-
-		/* Pull out the .entry-products table from the HTML using querypath */
-		$qp = new Helper_QueryPath();
-		$table = $qp->html5( $html, 'div.inner-container' )->innerHTML5();
-
-		$html = $heading;
-		$html .= $table;
-
-		return $html;
+		return new DOMQuery( $source, $selector, $options );
 	}
-
 }

--- a/src/helper/fields/Field_Quiz.php
+++ b/src/helper/fields/Field_Quiz.php
@@ -3,6 +3,7 @@
 namespace GFPDF\Helper\Fields;
 
 use GFPDF\Helper\Helper_Abstract_Fields;
+use GFPDF\Helper\Helper_QueryPath;
 
 use GFFormsModel;
 
@@ -97,7 +98,8 @@ class Field_Quiz extends Helper_Abstract_Fields {
 		 * We'll try use our DOM reader to correctly process the HTML, otherwise use string replace
 		 */
 		try {
-			$value = htmlqp( $value, 'img' )->addClass( 'gf-quiz-img' )->top( 'body' )->innerHTML5();
+			$qp = new Helper_QueryPath();
+			$value = $qp->html5( $value, 'img' )->addClass( 'gf-quiz-img' )->top( 'html' )->innerHTML5();
 		} catch ( Exception $e ) {
 			$value = str_replace( '<img ', '<img class="gf-quiz-img" ', $value );
 		}

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -191,7 +191,7 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 				'<div id="header"><img src="my-image.jpg" alt="My Image" /></div>',
 			),
 			array(
-				'<span>Intro</span> <img src="my-image.jpg" alt="My Image" class="header-footer-img"><span>Outro</span>',
+				'<span>Intro</span> <img src="my-image.jpg" alt="My Image" class="header-footer-img"> <span>Outro</span>',
 				'<span>Intro</span> <img src="my-image.jpg" alt="My Image" /> <span>Outro</span>',
 			),
 			array(

--- a/tests/phpunit/unit-tests/test-query-path.php
+++ b/tests/phpunit/unit-tests/test-query-path.php
@@ -1,22 +1,18 @@
 <?php
 
-namespace GFPDF\Helper\Fields;
+namespace GFPDF\Tests;
 
 use GFPDF\Helper\Helper_QueryPath;
+use WP_UnitTestCase;
 
 /**
- * Gravity Forms Field
+ * Test Gravity PDF Helper_QueryPath class
  *
  * @package     Gravity PDF
  * @copyright   Copyright (c) 2016, Blue Liquid Designs
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since       4.0
  */
-
-/* Exit if accessed directly */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 
 /*
     This file is part of Gravity PDF.
@@ -39,40 +35,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 */
 
 /**
- * Controls the display and output of a Gravity Form field
- *
- * @since 4.0
+ * @since 4.0.3
+ * @group querypath
  */
-class Field_v3_Products extends Field_Products {
-
+class Test_QueryPath extends WP_UnitTestCase {
 
 	/**
-	 * Display the HTML version of this field
-	 *
-	 * @param string $value
-	 * @param bool   $label
-	 *
-	 * @return string
+	 * Ensure we get a QueryPath object returned
 	 *
 	 * @since 4.0
 	 */
-	public function html( $value = '', $label = true ) {
-		$html = parent::html( $value, $label );
-
-		/* Format the order label correctly */
-		$label = apply_filters( 'gform_order_label', __( 'Order', 'gravityforms' ), $this->form->id );
-		$label = apply_filters( 'gform_order_label_' . $this->form->id, $label, $this->form->id );
-
-		$heading = '<h2 class="default entry-view-section-break">' . $label . '</h2>';
-
-		/* Pull out the .entry-products table from the HTML using querypath */
+	public function test_QueryPath() {
 		$qp = new Helper_QueryPath();
-		$table = $qp->html5( $html, 'div.inner-container' )->innerHTML5();
-
-		$html = $heading;
-		$html .= $table;
-
-		return $html;
+		$this->assertEquals( 'QueryPath\DOMQuery', get_class( $qp->html5( '<div>Test</div>' ) ) );
 	}
 
+	public function test_utf8() {
+		$html = '<div>ã   Ã   ╚   ╔   ╩   ╦   ╠   ═   ╬   ¤</div>';
+
+		/* Check for UTF8 support using HTML5 module */
+		$qp = new Helper_QueryPath();
+		$this->assertEquals( 'ã   Ã   ╚   ╔   ╩   ╦   ╠   ═   ╬   ¤', $qp->html5( $html, 'div' )->innerHTML5() );
+
+		/* Using the standard HTML parser these characters will not be correctly displayed when output */
+		$this->assertNotEquals( 'ã   Ã   ╚   ╔   ╩   ╦   ╠   ═   ╬   ¤', htmlqp( $html, 'div' )->innerHTML5() );
+	}
 }


### PR DESCRIPTION
This change allows UTF-8 encoded strings to work correctly.

Instead of swapping from htmlqp() to html5qp() we have abstract the
html5qp() function to a Helper Class and forced it to always load HTML from
a string. This prevents issues with loading content that contains no HTML markup.

Resolves #452