### PR TITLE
Resolve string to array conversion issues for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ matrix:
     env: WP_VERSION=4.3 WP_MULTISITE=0
   - php: 5.4
     env: WP_VERSION=4.2 WP_MULTISITE=0
-  allow_failures:
-    - php: 7.1
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != 7.1 ]]; then phpenv config-rm xdebug.ini; fi

--- a/src/helper/abstract/Helper_Abstract_Options.php
+++ b/src/helper/abstract/Helper_Abstract_Options.php
@@ -188,10 +188,6 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	 * @return  void
 	 */
 	public function set_plugin_settings() {
-		if ( false == get_option( 'gfpdf_settings' ) ) {
-			add_option( 'gfpdf_settings' );
-		}
-
 		/* assign our settings */
 		$this->settings = $this->get_settings();
 	}
@@ -306,15 +302,14 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		 *
 		 * We'll check if the transient exists and use it, otherwise get the main plugin settings from the options table
 		 */
-		$tempSettings = get_transient( 'gfpdf_settings_user_data' );
-		$is_temp      = ( $tempSettings !== false ) ? true : false;
+		$tmp_settings = get_transient( 'gfpdf_settings_user_data' );
+		$is_temp      = ( $tmp_settings !== false ) ? true : false;
 
 		if ( $is_temp ) {
-			$settings = $tempSettings;
 			delete_transient( 'gfpdf_settings_user_data' );
-		} else {
-			$settings = ( is_array( get_option( 'gfpdf_settings' ) ) ) ? get_option( 'gfpdf_settings' ) : array();
 		}
+
+		$settings = ( $is_temp ) ? (array) $tmp_settings : get_option( 'gfpdf_settings', array() );
 
 		/* See https://gravitypdf.com/documentation/v4/gfpdf_get_settings/ for more details about this filter */
 		return apply_filters( 'gfpdf_get_settings', $settings, $is_temp );
@@ -714,7 +709,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		}
 
 		/* First let's grab the current settings */
-		$options = get_option( 'gfpdf_settings' );
+		$options = get_option( 'gfpdf_settings', array() );
 
 		/* See https://gravitypdf.com/documentation/v4/gfpdf_update_option/ for more details about these filters */
 		$value = apply_filters( 'gfpdf_update_option', $value, $key );
@@ -758,7 +753,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		}
 
 		// First let's grab the current settings
-		$options = get_option( 'gfpdf_settings' );
+		$options = get_option( 'gfpdf_settings', array() );
 
 		// Next let's try to update the value
 		if ( isset( $options[ $key ] ) ) {

--- a/src/model/Model_Shortcodes.php
+++ b/src/model/Model_Shortcodes.php
@@ -312,6 +312,7 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function add_shortcode_attr( $code, $attr, $value ) {
+
 		/* if the attribute doesn't already exist... */
 		if ( ! isset( $code['attr'][ $attr ] ) ) {
 
@@ -412,10 +413,12 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 			if ( ! empty( $matches ) && isset( $matches[2] ) ) {
 				foreach ( $matches[2] as $key => $code ) {
 					if ( $code == $shortcode ) {
+						$attr = shortcode_parse_atts( $matches[3][ $key ] );
+
 						$shortcodes[] = array(
 							'shortcode' => $matches[0][ $key ],
 							'attr_raw'  => $matches[3][ $key ],
-							'attr'      => shortcode_parse_atts( $matches[3][ $key ] ),
+							'attr'      => ( is_array( $attr ) ) ? $attr: array(),
 						);
 					}
 				}

--- a/tests/phpunit/unit-tests/test-installer.php
+++ b/tests/phpunit/unit-tests/test-installer.php
@@ -337,6 +337,7 @@ class Test_Installer extends WP_UnitTestCase {
 		}
 
 		wp_set_current_user( $user_id );
+		update_option( 'gfpdf_settings', 'test' );
 
 		$this->controller->check_install_status();
 

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -122,9 +122,9 @@ class Test_Options_API extends WP_UnitTestCase {
 		 * Check our transient user data is loaded
 		 * Used in settings_sanitize() when there are errors the user has to fix
 		 */
-		set_transient( 'gfpdf_settings_user_data', 'testing', 30 );
+		set_transient( 'gfpdf_settings_user_data', array('testing'), 30 );
 
-		$this->assertEquals( 'testing', $this->options->get_settings() );
+		$this->assertEquals( array('testing'), $this->options->get_settings() );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-shortcodes.php
+++ b/tests/phpunit/unit-tests/test-shortcodes.php
@@ -338,7 +338,7 @@ class Test_Shortcode extends WP_UnitTestCase {
 
 		$this->assertEquals( '[gravitypdf]', $shortcodes[0]['shortcode'] );
 		$this->assertEquals( '', $shortcodes[0]['attr_raw'] );
-		$this->assertEquals( '', $shortcodes[0]['attr'] );
+		$this->assertEquals( array(), $shortcodes[0]['attr'] );
 
 		$this->assertEquals( '[gravitypdf id="1231241221" text="View PDF" type="view"]', $shortcodes[1]['shortcode'] );
 		$this->assertEquals( ' id="1231241221" text="View PDF" type="view"', $shortcodes[1]['attr_raw'] );


### PR DESCRIPTION
These problems were flagged by our automated tests. There may be more and we'll do further tests when WordPress adds full support for PHP7.1 (currently PHP notices showing).

Resolves #495