### PR TITLE
Rename check_wordpress() to is_compatible_wordpress_version()

### DIFF
--- a/pdf.php
+++ b/pdf.php
@@ -156,7 +156,7 @@ class GFPDF_Major_Compatibility_Checks {
 	public function plugins_loaded() {
 
 		/* Check minimum requirements are met */
-		$this->check_wordpress();
+		$this->is_compatible_wordpress_version();
 		$this->check_gravity_forms();
 		$this->check_php();
 		$this->check_mb_string();
@@ -182,7 +182,7 @@ class GFPDF_Major_Compatibility_Checks {
 	 *
 	 * @since 4.0
 	 */
-	public function check_wordpress() {
+	public function is_compatible_wordpress_version() {
 		global $wp_version;
 
 		/* WordPress version not compatible */

--- a/tests/phpunit/unit-tests/test-pre-checks.php
+++ b/tests/phpunit/unit-tests/test-pre-checks.php
@@ -108,7 +108,7 @@ class Test_Pre_Checks extends WP_UnitTestCase {
 		$this->gravitypdf->required_wp_version = $min_version;
 
 		/* run our test */
-		$this->assertEquals( $expected, $this->gravitypdf->check_wordpress() );
+		$this->assertEquals( $expected, $this->gravitypdf->is_compatible_wordpress_version() );
 	}
 
 	/**


### PR DESCRIPTION
This should hopefully fix the false positive in the ConfigServer exploit Scanner software.

Fixes #500