### PR TITLE
Don't apply sanitization on input of rich text editor settings

### DIFF
--- a/src/helper/abstract/Helper_Abstract_Options.php
+++ b/src/helper/abstract/Helper_Abstract_Options.php
@@ -1430,6 +1430,16 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 
 		switch ( $settings['type'] ) {
 			case 'rich_editor':
+				/**
+				 * Don't do any sanitization on input, which was causing problems with merge tags in HTML attributes.
+				 * See https://github.com/GravityPDF/gravity-pdf/issues/492 for more details.
+				 *
+				 * @internal Devs should run the field through wp_kses_post() on output to correctly sanitize
+				 * @since 4.0.6
+				 */
+				return $value;
+			break;
+
 			case 'textarea':
 				return wp_kses_post( $value );
 			break;

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -962,7 +962,7 @@ class Test_Options_API extends WP_UnitTestCase {
 			array(
 				'rich_editor',
 				'<strong>Test</strong> <script>console.log("test");</script>',
-				'<strong>Test</strong> console.log("test");',
+				'<strong>Test</strong> <script>console.log("test");</script>',
 			),
 			array(
 				'textarea',


### PR DESCRIPTION
This allows users to use merge tags in attributes in the Header / Footer rich text editors (and any others).

Note: Devs should run the field through wp_kses_post() on output to correctly sanitize

Resolves #492