### PR TITLE
Explicitly set a forward slash after the home_url()

### DIFF
--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -695,7 +695,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		/* Check if permalinks are enabled, otherwise fall back to our ugly link structure for 4.0 (not the same as our v3 links) */
 		if ( $wp_rewrite->using_permalinks() ) {
-			$url = home_url( '/' ) . $wp_rewrite->root; /* Handle "almost pretty" permalinks - fix for IIS servers without modrewrite  */
+			$url = home_url() . '/' . $wp_rewrite->root; /* Handle "almost pretty" permalinks - fix for IIS servers without modrewrite  */
 			$url .= 'pdf/' . $pid . '/' . $id . '/';
 
 			if ( $download ) {


### PR DESCRIPTION
Instead of passing the forward slash directly (might be causing problems for some users - see https://wordpress.org/support/topic/found-v4-0-5-bug/), we are hard coding it after the home_url() function.

This matches the setup we used in Gravity PDF 4.0.4 so should hopefully resolve any conflicts with missing slashes in the URL.