### PR TITLE
Redirect to our update screen when the user updates to a new major or minor release

### DIFF
--- a/src/controller/Controller_Install.php
+++ b/src/controller/Controller_Install.php
@@ -211,7 +211,7 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 			$this->model->install_plugin();
 		}
 
-		if ( PDF_EXTENDED_VERSION != get_option( 'gfpdf_current_version' ) ) {
+		if ( PDF_EXTENDED_VERSION !== get_option( 'gfpdf_current_version' ) ) {
 			/* See https://gravitypdf.com/documentation/v4/gfpdf_version_changed/ for more details about this action */
 			do_action( 'gfpdf_version_changed', get_option( 'gfpdf_current_version' ), PDF_EXTENDED_VERSION );
 			update_option( 'gfpdf_current_version', PDF_EXTENDED_VERSION );

--- a/tests/phpunit/unit-tests/test-welcome-screen.php
+++ b/tests/phpunit/unit-tests/test-welcome-screen.php
@@ -7,6 +7,7 @@ use GFPDF\Model\Model_Welcome_Screen;
 use GFPDF\View\View_Welcome_Screen;
 
 use WP_UnitTestCase;
+use WP_UnitTest_Factory;
 
 /**
  * Test Gravity PDF Welcome Screen Functionality
@@ -73,6 +74,15 @@ class Test_Welcome_Screen extends WP_UnitTestCase {
 	public $view;
 
 	/**
+	 * An administrator user ID we included
+	 *
+	 * @var int
+	 *
+	 * @since 4.1
+	 */
+	public $user_id;
+
+	/**
 	 * The WP Unit Test Set up function
 	 *
 	 * @since 4.0
@@ -91,6 +101,41 @@ class Test_Welcome_Screen extends WP_UnitTestCase {
 
 		$this->controller = new Controller_Welcome_Screen( $this->model, $this->view, $gfpdf->log, $gfpdf->data, $gfpdf->options );
 		$this->controller->init();
+
+		/* Setup a new admin user */
+		$factory = new WP_UnitTest_Factory();
+		$this->user_id = $factory->user->create( array(
+			'role'   => 'administrator',
+		) );
+	}
+
+	/**
+	 * Get a mocked version of our welcome screen controller so we can test the redirect functionality
+	 *
+	 * @param int $executed_num Number of times our mocked method will be run
+	 *
+	 * @return \PHPUnit_Framework_MockObject_Builder_InvocationMocker
+	 *
+	 * @since 4.1
+	 */
+	private function get_mocked_controller( $executed_num ) {
+		global $gfpdf;
+
+		$controller = $this->getMockBuilder( '\GFPDF\Controller\Controller_Welcome_Screen' )
+		                   ->setConstructorArgs( [
+			                   $this->model,
+			                   $this->view,
+			                   $gfpdf->log,
+			                   $gfpdf->data,
+			                   $gfpdf->options,
+		                   ] )
+		                   ->setMethods( [ 'redirect' ] )
+		                   ->getMock();
+
+		$controller->expects( $this->exactly( $executed_num ) )
+		           ->method( 'redirect' );
+
+		return $controller;
 	}
 
 	/**
@@ -173,5 +218,78 @@ class Test_Welcome_Screen extends WP_UnitTestCase {
 		/* Test update screen */
 		$_GET['page'] = 'gfpdf-update';
 		$this->assertEquals( "What&#039;s new in Gravity PDF?", $this->model->add_page_title( 'Title' ) );
+	}
+
+	/**
+	 * @since 4.1
+	 */
+	public function test_welcome() {
+		global $gfpdf;
+
+		if( is_multisite() ) {
+			return;
+		}
+
+		/* Setup our test */
+		$controller = $this->get_mocked_controller( 2 );
+		update_option( 'gfpdf_current_version', '1.0' );
+		$gfpdf->data->is_installed = false;
+
+		$this->assertNull( $controller->welcome() );
+
+		/* ensure we are in the admin area */
+		set_current_screen('dashboard');
+		$this->assertNull( $controller->welcome() );
+
+		/* ensure the current user has the correct privilages */
+		wp_set_current_user( $this->user_id );
+		$controller->welcome();
+
+		/* Ensure if the versions are the same we get null */
+		update_option( 'gfpdf_current_version', PDF_EXTENDED_VERSION );
+		$this->assertNull( $controller->welcome() );
+
+		/* Try a different version number */
+		update_option( 'gfpdf_current_version', substr( PDF_EXTENDED_VERSION, 0, -4 ) . '.100.2' );
+		$controller->welcome();
+
+		/* If we are already on the getting started page we don't do the redirect */
+		$_GET['page'] = 'gfpdf-getting-started';
+		$this->assertNull( $controller->welcome() );
+	}
+
+	/**
+	 * Test that our update screen is correctly shown
+	 *
+	 * @since 4.1
+	 */
+	public function test_maybe_display_update_screen() {
+		global $gfpdf;
+
+		$controller = $this->get_mocked_controller( 2 );
+
+		update_option( 'gfpdf_current_version', PDF_EXTENDED_VERSION );
+		$controller->maybe_display_update_screen( PDF_EXTENDED_VERSION );
+
+		/* Check there's a failed attempt when the versions are exactly the same */
+		$this->assertNull( $controller->maybe_display_update_screen( PDF_EXTENDED_VERSION ) );
+
+		/* Check there's a failed attempt when we are just doing a patch update */
+		update_option( 'gfpdf_current_version', '2.0' );
+		$controller->maybe_display_update_screen( '2.0.1' );
+
+		update_option( 'gfpdf_current_version', '2.0.5' );
+		$controller->maybe_display_update_screen( '2.0.10' );
+
+		/* Check we are successful on major version updates */
+		update_option( 'gfpdf_current_version', '1.0' );
+		$controller->maybe_display_update_screen( '2.0' );
+
+		update_option( 'gfpdf_current_version', '1.0.5' );
+		$controller->maybe_display_update_screen( '1.2.5' );
+
+		/* Check it gets skipped when we disable the update screen option */
+		$gfpdf->options->update_option( 'update_screen_action', 'Disable' );
+		$controller->maybe_display_update_screen( '1.2.5' );
 	}
 }


### PR DESCRIPTION
Previously we restricted this to only show when updating to a minor release (4.x), but many missed out because we pushed our patches fairly quickly. That meant that even though they updated to a new minor release they didn't see the update message because they jumped straight to 4.x.x.

This patch resolves this issue by comparing the old and the new version numbers and seeing if they jumped to a new minor release.

It also prevents the update screen showing if they downgrade.

Resolves #514