### PR TITLE
Add a {Name:pdf:ID} Merge tag

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -240,6 +240,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$this->gf_form_settings();
 		$this->pdf();
 		$this->shortcodes();
+		$this->mergetags();
 		$this->actions();
 		$this->template_manager();
 
@@ -863,6 +864,25 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$this->singleton->add_class( $class );
 		$this->singleton->add_class( $model );
 		$this->singleton->add_class( $view );
+	}
+
+	/**
+	 * Include PDF Mergetag functionality
+	 *
+	 * @since 4.1
+	 *
+	 * @return void
+	 */
+	public function mergetags() {
+
+		$model = new Model\Model_Mergetags( $this->options, $this->singleton->get_class( 'Model_PDF' ), $this->log, $this->misc );
+
+		$class = new Controller\Controller_Mergetags( $model );
+		$class->init();
+
+		/* Add to our singleton controller */
+		$this->singleton->add_class( $class );
+		$this->singleton->add_class( $model );
 	}
 
 	/**

--- a/src/controller/Controller_Mergetags.php
+++ b/src/controller/Controller_Mergetags.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use GFPDF\Helper\Helper_Abstract_Controller;
+use GFPDF\Helper\Helper_Abstract_Model;
+use GFPDF\Helper\Helper_Interface_Filters;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * PDF Merge tag Controller
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Controller_Mergetags
+ * Handles the PDF display and authentication
+ *
+ * @since 4.1
+ */
+class Controller_Mergetags extends Helper_Abstract_Controller implements Helper_Interface_Filters {
+
+	/**
+	 * Setup our class by injecting all our dependancies
+	 *
+	 * @param Helper_Abstract_Model|\GFPDF\Model\Model_Shortcodes $model Our Shortcodes Model the controller will manage
+	 *
+	 * @since 4.0
+	 */
+	public function __construct( Helper_Abstract_Model $model ) {
+
+		/* Load our model and view */
+		$this->model = $model;
+		$this->model->setController( $this );
+	}
+
+	/**
+	 * Initialise our class defaults
+	 *
+	 * @since 4.1
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->add_filters();
+	}
+
+	/**
+	 * Apply any filters needed for the settings page
+	 *
+	 * @since 4.1
+	 *
+	 * @return void
+	 */
+	public function add_filters() {
+		add_filter( 'gform_replace_merge_tags', [ $this->model, 'process_pdf_mergetags' ], 10, 4 );
+		add_filter( 'gform_custom_merge_tags', [ $this->model, 'add_pdf_mergetags' ], 10, 2 );
+	}
+}

--- a/src/model/Model_Mergetags.php
+++ b/src/model/Model_Mergetags.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace GFPDF\Model;
+
+use GFPDF\Helper\Helper_Abstract_Model;
+use GFPDF\Helper\Helper_Abstract_Options;
+use GFPDF\Helper\Helper_Misc;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * PDF Mergetags Model
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.1
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ *
+ * Handles all the PDF Mergetag logic
+ *
+ * @since 4.1
+ */
+class Model_Mergetags extends Helper_Abstract_Model {
+
+	/**
+	 * @var \GFPDF\Model\Model_PDF
+	 *
+	 * @since 4.1
+	 */
+	protected $pdf;
+
+	/**
+	 * Holds our Helper_Abstract_Options / Helper_Options_Fields object
+	 * Makes it easy to access global PDF settings and individual form PDF settings
+	 *
+	 * @var \GFPDF\Helper\Helper_Options_Fields
+	 *
+	 * @since 4.1
+	 */
+	protected $options;
+
+	/**
+	 * Holds our log class
+	 *
+	 * @var \Monolog\Logger|LoggerInterface
+	 *
+	 * @since 4.1
+	 */
+	protected $log;
+
+	/**
+	 * Holds our Helper_Misc object
+	 * Makes it easy to access common methods throughout the plugin
+	 *
+	 * @var \GFPDF\Helper\Helper_Misc
+	 *
+	 * @since 4.1
+	 */
+	protected $misc;
+
+	/**
+	 * Model_Mergetags constructor.
+	 *
+	 * @param Helper_Abstract_Options         $options
+	 * @param \GFPDF\Model\Model_PDF          $pdf
+	 * @param \Monolog\Logger|LoggerInterface $log
+	 *
+	 * @since    4.1
+	 */
+	public function __construct( Helper_Abstract_Options $options, Model_PDF $pdf, LoggerInterface $log, Helper_Misc $misc ) {
+
+		/* Assign our internal variables */
+		$this->pdf     = $pdf;
+		$this->log     = $log;
+		$this->options = $options;
+		$this->misc    = $misc;
+	}
+
+	/**
+	 * Add our PDF Merge tags to the merge tag selector
+	 * The PDF Merge tag format is {NAME:pdf:ID}
+	 *
+	 * The NAME is purely to help users identify what PDF the merge tag relates to
+	 * The ID is the PDF PID parameter
+	 *
+	 * @param array $tags    The current list of custom tags
+	 * @param int   $form_id The Gravity FOrm ID
+	 *
+	 * @return array
+	 *
+	 * @since 4.1
+	 */
+	public function add_pdf_mergetags( $tags, $form_id ) {
+
+		$pdfs = $this->options->get_form_pdfs( $form_id );
+
+		if ( is_wp_error( $pdfs ) ) {
+			return $tags;
+		}
+
+		/* Loop through the results and add all PDF URLs to the merge tags */
+		foreach ( $pdfs as $id => $pdf ) {
+			if ( $pdf['active'] === true ) {
+				$tags[] = [
+					'tag'   => sprintf( '{%s:pdf:%s}', $pdf['name'], $id ),
+					/* Format "PDF: %s" - we split it up like this so we didn't have to add another translation */
+					'label' => esc_html__( 'PDF', 'gravity-forms-pdf-extended' ) .
+					           ': ' .
+					           esc_html( $pdf['name'] ),
+				];
+			}
+		}
+
+		return $tags;
+	}
+
+	/**
+	 * Replace the Gravity PDF merge tag ({NAME:pdf:ID}) with the associated PDF URL
+	 *
+	 * @param string $text       The string to convert
+	 * @param array  $form       The Gravity Form array
+	 * @param array  $entry      The Gravity Forms entry array
+	 * @param bool   $url_encode Whether to encode the URL or not
+	 *
+	 * @return string
+	 *
+	 * @since 4.1
+	 */
+	public function process_pdf_mergetags( $text, $form, $entry, $url_encode ) {
+
+		/* Check if there are any PDF merge tags to process, otherwise exit early */
+		if ( strpos( $text, ':pdf:' ) === false ) {
+			return $text;
+		}
+
+		/* Match our PDF merge tags */
+		$results = preg_match_all( "/\{(.*?):pdf:(.*?)\}/", $text, $matches, PREG_SET_ORDER );
+
+		/* Verify we have a match */
+		if ( $results ) {
+
+			$this->log->addNotice( 'Converting PDF Mergetag', [
+				'form_id'  => $form['id'],
+				'entry_id' => $entry['id'],
+
+				'tags' => $matches,
+				'text' => $text,
+			] );
+
+			foreach ( $matches as $tag ) {
+
+				/* Get the PDF configuration */
+				$config = $this->options->get_pdf( $form['id'], $tag[2] );
+
+				/* Strip tag if config not valid, it isn't active or conditional logic is not met */
+				if ( is_wp_error( $config )
+				     || $config['active'] !== true
+				     || ( isset( $config['conditionalLogic'] ) && ! $this->misc->evaluate_conditional_logic( $config['conditionalLogic'], $entry ) )
+				) {
+					$this->log->addError( 'PDF Mergetag is not valid', [
+						'form_id'  => $form['id'],
+						'entry_id' => $entry['id'],
+						'tag'      => $tag,
+
+						/* include the error, or the actual config array */
+						'config'   => ( is_wp_error( $config ) ) ? $config->get_error_messages() : $config,
+					] );
+
+					/* Remove the tag and the new line if present (prevents any odd spacing issues) */
+					$text = str_replace( [ $tag[0] . '<br>', $tag[0] . '<br />', $tag[0] . "\n", $tag[0] ], '', $text );
+					continue;
+				}
+
+				/* Everything is valid so get the URL and display */
+				$url = $this->pdf->get_pdf_url( $tag[2], $entry['id'], false, false, $url_encode );
+
+				/* replace the merge tag */
+				$text = str_replace( $tag[0], $url, $text );
+			}
+		}
+
+		return $text;
+	}
+}

--- a/tests/phpunit/unit-tests/test-mergetags.php
+++ b/tests/phpunit/unit-tests/test-mergetags.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace GFPDF\Tests;
+
+use GFPDF\Controller\Controller_Mergetags;
+use GFPDF\Model\Model_Mergetags;
+
+use WP_UnitTestCase;
+use GPDFAPI;
+
+/**
+ * Test Gravity PDF Mergetag functionality
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.1
+ */
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Test the model / view / controller for the Shortcode MVC
+ *
+ * @since 4.1
+ * @group mergetags
+ */
+class Test_Mergetags extends WP_UnitTestCase {
+
+	/**
+	 * Our Controller
+	 *
+	 * @var \GFPDF\Controller\Controller_Shortcodes
+	 *
+	 * @since 4.1
+	 */
+	public $controller;
+
+	/**
+	 * Our Model
+	 *
+	 * @var \GFPDF\Model\Model_Shortcodes
+	 *
+	 * @since 4.1
+	 */
+	public $model;
+
+	/**
+	 * The WP Unit Test Set up function
+	 *
+	 * @since 4.1
+	 */
+	public function setUp() {
+		global $gfpdf;
+
+		/* run parent method */
+		parent::setUp();
+
+		/* Setup our test classes */
+		$this->model = new Model_Mergetags( $gfpdf->options, GPDFAPI::get_mvc_class( 'Model_PDF' ), $gfpdf->log, $gfpdf->misc );
+
+		$this->controller = new Controller_Mergetags( $this->model );
+		$this->controller->init();
+	}
+
+	/**
+	 * Test the appropriate filters are set up
+	 *
+	 * @since 4.1
+	 */
+	public function test_filters() {
+		$this->assertEquals( 10, has_filter( 'gform_replace_merge_tags', [ $this->model, 'process_pdf_mergetags' ] ) );
+		$this->assertEquals( 10, has_filter( 'gform_custom_merge_tags', [ $this->model, 'add_pdf_mergetags' ] ) );
+	}
+
+	/**
+	 * Check we correctly load the form's PDF mergetags in the correct format
+	 *
+	 * @since 4.1
+	 */
+	public function test_add_mergetags() {
+		$form = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+
+		$tags = $this->model->add_pdf_mergetags( [], $form['id'] );
+
+		$this->assertSame( 3, sizeof( $tags ) );
+
+		$this->assertEquals( 'PDF: My First PDF Template', $tags[0]['label'] );
+		$this->assertEquals( '{My First PDF Template:pdf:555ad84787d7e}', $tags[0]['tag'] );
+
+		$this->assertEquals( '{My First PDF Template (copy):pdf:556690c67856b}', $tags[1]['tag'] );
+	}
+
+	/**
+	 * Check we correctly convert our PDF mergetag
+	 *
+	 * @param string $expected
+	 * @param string $text
+	 * @param bool $encode
+	 *
+	 * @dataProvider provider_process_pdf_mergetags
+	 *
+	 * @since        4.1
+	 */
+	public function test_process_pdf_mergetags( $expected, $text, $encode = true ) {
+		$form  = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+
+		$results = $this->model->process_pdf_mergetags( $text, $form, $entry, $encode );
+
+		$this->assertEquals( $expected, $results );
+	}
+
+	/**
+	 * Data provider for test_process_pdf_mergetags
+	 *
+	 * @return array
+	 */
+	public function provider_process_pdf_mergetags() {
+		return [
+
+			/* Valid single tag */
+			[
+				'expected' => 'http://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1',
+				'text'     => '{My First PDF Template (Copy):pdf:556690c67856b}',
+			],
+
+			[
+				'expected' => 'http://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1',
+				'text'     => '{:pdf:556690c67856b}',
+			],
+
+			[
+				'expected' => 'This is my content<br> It is awesome<br><br>http://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1',
+				'text'     => 'This is my content<br> It is awesome<br><br>{:pdf:556690c67856b}',
+			],
+
+			[
+				'expected' => 'This is my content<br> It is awesome<br><br>http://example.org/?gpdf=1&pid=556690c67856b&lid=1',
+				'text'     => 'This is my content<br> It is awesome<br><br>{:pdf:556690c67856b}',
+				'encode'   => false,
+			],
+
+			[
+				'expected' => "This is my content\n It is awesome\n\nhttp://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1",
+				'text'     => "This is my content\n It is awesome\n\n{:pdf:556690c67856b}",
+			],
+
+			/* Invalid format */
+			[
+				'expected' => ':pdf:556690c67856b}',
+				'text'     => ':pdf:556690c67856b}',
+			],
+
+			[
+				'expected' => '{:pdf:556690c67856b',
+				'text'     => '{:pdf:556690c67856b',
+			],
+
+			[
+				'expected' => ':pdf:556690c67856b',
+				'text'     => ':pdf:556690c67856b',
+			],
+
+			/* PDF Config not active */
+			[
+				'expected' => '',
+				'text'     => '{Not Active:pdf:556690c8d7f82}',
+			],
+
+			[
+				'expected' => 'My content ',
+				'text'     => 'My content {Not Active:pdf:556690c8d7f82}',
+			],
+
+			[
+				'expected' => 'My content<br><br>Other Stuff',
+				'text'     => 'My content<br><br>{Not Active:pdf:556690c8d7f82}<br>Other Stuff',
+			],
+
+			[
+				'expected' => 'My content<br /><br>Other Stuff',
+				'text'     => 'My content<br /><br>{Not Active:pdf:556690c8d7f82}<br>Other Stuff',
+			],
+
+			[
+				'expected' => "My content\n\nOther Stuff",
+				'text'     => "My content\n\n{Not Active:pdf:556690c8d7f82}\nOther Stuff",
+			],
+
+			/* Conditional logic failed */
+			[
+				'expected' => '',
+				'text'     => '{Conditional Failed:pdf:555ad84787d7e}',
+			],
+
+			/* Multiple tags */
+			[
+				'expected' => "My Content goes here\n\nhttp://example.org/?gpdf=1&#038;pid=556690c67856b&#038;lid=1\n",
+				'text'     => "My Content goes here\n\n{Not Active:pdf:556690c8d7f82}\n{My First PDF Template (Copy):pdf:556690c67856b}\n{Conditional Failed:pdf:555ad84787d7e}",
+			],
+		];
+	}
+}


### PR DESCRIPTION
In certain circumstances it's useful to just get the Gravity PDF URL which is the purpose of the new {Name:pdf:ID} mergetag. It will function much like the [gravitypdf] shortcode in that it validates a PDF config before displaying the URL. If it isn't valid the merge tag is stripped and an error is placed in the log (Requires the Gravity Forms Logging plugin).

Resolves #404