### PR TITLE
Resolve PHP error when no products completed in the table

### DIFF
--- a/src/helper/fields/Field_Products.php
+++ b/src/helper/fields/Field_Products.php
@@ -58,11 +58,16 @@ class Field_Products extends Helper_Abstract_Fields {
 	 * @since 4.0.2
 	 */
 	public function is_empty() {
+
+		/* Set up the form / lead information */
 		$form = $this->form;
-		foreach ( $form['fields'] as $field ) {
-			if ( GFCommon::is_product_field( $field->type ) ) {
-				return false;
-			}
+		$lead = $this->entry;
+
+		/* Get all products for this field */
+		$products = GFCommon::get_product_fields( $form, $lead, true );
+
+		if ( sizeof( $products['products'] ) > 0 ) {
+			return false; /* not empty */
 		}
 
 		return true;


### PR DESCRIPTION
The foreach loop threw an error when the products array is empty. This is because our `is_empty()` check was only seeing if there WERE product fields in the form and not IF those fields were filled in.

Fixes #523