### PR TITLE
Standardise all AJAX authentication to prevent repeat code

### DIFF
--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -657,6 +657,7 @@
 
           var data = {
             'action': 'gfpdf_get_template_fields',
+            'nonce': GFPDF.ajaxNonce,
             'template': $(this).val(),
             'type': $(this).attr('id'),
             'id': $('#gform_id').val(),

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -925,6 +925,8 @@ class Helper_Misc {
 	 * @param string|bool $capability The capability name the logged in user is required to run this endpoint, or false if no authentation needed
 	 * @param string $nonce_name The name of the Nonce our $_POST['nonce'] should be checked against
 	 *
+	 * @todo move this to an abstract class when we refractor the AJAX code into classes
+	 *
 	 * @since 4.1
 	 */
 	public function handle_ajax_authentication( $endpoint_desc, $capability = 'gravityforms_edit_settings', $nonce_name = 'gfpdf_ajax_nonce' ) {

--- a/src/model/Model_Form_Settings.php
+++ b/src/model/Model_Form_Settings.php
@@ -755,39 +755,14 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	 */
 	public function delete_gf_pdf_setting() {
 
-		$this->log->addNotice( 'Running AJAX Endpoint', [
-			'type' => 'Delete PDF Settings',
-		] );
-
-		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-
-			$this->log->addCritical( 'Lack of User Capabilities.', [
-				'user'      => wp_get_current_user(),
-				'user_meta' => get_user_meta( get_current_user_id() ),
-			] );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-
-		/*
-         * Validate Endpoint
-         */
-		$nonce = ( isset( $_POST['nonce'] ) ) ? $_POST['nonce'] : '';
-		$fid   = ( isset( $_POST['fid'] ) ) ? (int) $_POST['fid'] : 0;
-		$pid   = ( isset( $_POST['pid'] ) ) ? $_POST['pid'] : '';
-
+		$fid      = ( isset( $_POST['fid'] ) ) ? (int) $_POST['fid'] : 0;
+		$pid      = ( isset( $_POST['pid'] ) ) ? $_POST['pid'] : '';
 		$nonce_id = "gfpdf_delete_nonce_{$fid}_{$pid}";
 
-		if ( ! wp_verify_nonce( $nonce, $nonce_id ) ) {
+		/* User / CORS validation */
+		$this->misc->handle_ajax_authentication( 'Delete PDF Settings', 'gravityforms_edit_settings', $nonce_id );
 
-			$this->log->addWarning( 'Nonce Verification Failed.' );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-
+		/* Delete PDF settings */
 		$results = $this->options->delete_pdf( $fid, $pid );
 
 		if ( $results && ! is_wp_error( $results ) ) {
@@ -829,39 +804,15 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	 */
 	public function duplicate_gf_pdf_setting() {
 
-		$this->log->addNotice( 'Running AJAX Endpoint', [
-			'type' => 'Duplicate PDF Settings',
-		] );
-
-		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-
-			$this->log->addCritical( 'Lack of User Capabilities.', [
-				'user'      => wp_get_current_user(),
-				'user_meta' => get_user_meta( get_current_user_id() ),
-			] );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-
-		/*
-         * Validate Endpoint
-         */
-		$nonce = ( isset( $_POST['nonce'] ) ) ? $_POST['nonce'] : '';
 		$fid   = ( isset( $_POST['fid'] ) ) ? (int) $_POST['fid'] : 0;
 		$pid   = ( isset( $_POST['pid'] ) ) ? $_POST['pid'] : '';
 
 		$nonce_id = "gfpdf_duplicate_nonce_{$fid}_{$pid}";
 
-		if ( ! wp_verify_nonce( $nonce, $nonce_id ) ) {
+		/* User / CORS validation */
+		$this->misc->handle_ajax_authentication( 'Duplicate PDF Settings', 'gravityforms_edit_settings', $nonce_id );
 
-			$this->log->addWarning( 'Nonce Verification Failed.' );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-
+		/* Duplicate PDF config */
 		$config = $this->options->get_pdf( $fid, $pid );
 
 		if ( ! is_wp_error( $config ) ) {
@@ -874,6 +825,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			if ( $results ) {
 				$this->log->addNotice( 'AJAX Endpoint Successful' );
 
+				/* @todo just use the same nonce for all requests since WP nonces aren't one-time user (time based) */
 				$dup_nonce   = wp_create_nonce( "gfpdf_duplicate_nonce_{$fid}_{$config['id']}" );
 				$del_nonce   = wp_create_nonce( "gfpdf_delete_nonce_{$fid}_{$config['id']}" );
 				$state_nonce = wp_create_nonce( "gfpdf_state_nonce_{$fid}_{$config['id']}" );
@@ -914,38 +866,14 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	 */
 	public function change_state_pdf_setting() {
 
-		$this->log->addNotice( 'Running AJAX Endpoint', [
-			'type' => 'Change PDF Settings State',
-		] );
-
-		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-
-			$this->log->addCritical( 'Lack of User Capabilities.', [
-				'user'      => wp_get_current_user(),
-				'user_meta' => get_user_meta( get_current_user_id() ),
-			] );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-
-		/*
-         * Validate Endpoint
-         */
-		$nonce    = ( isset( $_POST['nonce'] ) ) ? $_POST['nonce'] : '';
 		$fid      = ( isset( $_POST['fid'] ) ) ? (int) $_POST['fid'] : 0;
 		$pid      = ( isset( $_POST['pid'] ) ) ? $_POST['pid'] : '';
 		$nonce_id = "gfpdf_state_nonce_{$fid}_{$pid}";
 
-		if ( ! wp_verify_nonce( $nonce, $nonce_id ) ) {
+		/* User / CORS validation */
+		$this->misc->handle_ajax_authentication( 'Change PDF Settings State', 'gravityforms_edit_settings', $nonce_id );
 
-			$this->log->addWarning( 'Nonce Verification Failed.' );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-
+		/* Change the PDF state */
 		$config = $this->options->get_pdf( $fid, $pid );
 
 		if ( ! is_wp_error( $config ) ) {
@@ -992,21 +920,8 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	 */
 	public function render_template_fields() {
 
-		$this->log->addNotice( 'Running AJAX Endpoint', [
-			'type' => 'Render Template Custom Fields',
-		] );
-
-		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-
-			$this->log->addCritical( 'Lack of User Capabilities.', [
-				'user'      => wp_get_current_user(),
-				'user_meta' => get_user_meta( get_current_user_id() ),
-			] );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
+		/* User / CORS validation */
+		$this->misc->handle_ajax_authentication( 'Render Template Custom Fields', 'gravityforms_edit_settings' );
 
 		/* get the current template */
 		$template = ( isset( $_POST['template'] ) ) ? $_POST['template'] : '';

--- a/src/model/Model_Settings.php
+++ b/src/model/Model_Settings.php
@@ -441,43 +441,6 @@ class Model_Settings extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * Check a user is authorized to make modifications via this endpoint and
-	 * that there is a valid nonce
-	 *
-	 * @return void
-	 *
-	 * @since  4.0
-	 */
-	private function ajax_font_validation() {
-
-		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-			/* fail */
-			$this->log->addCritical( 'Lack of User Capabilities.', [
-				'user'      => wp_get_current_user(),
-				'user_meta' => get_user_meta( get_current_user_id() ),
-			] );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-
-		/*
-         * Validate Endpoint
-         */
-		$nonce    = ( isset( $_POST['nonce'] ) ) ? $_POST['nonce'] : '';
-		$nonce_id = 'gfpdf_font_nonce';
-
-		if ( ! wp_verify_nonce( $nonce, $nonce_id ) ) {
-			/* fail */
-			$this->log->addWarning( 'Nonce Verification Failed.' );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-	}
-
-	/**
 	 * AJAX Endpoint for saving the custom font
 	 *
 	 * @return void
@@ -486,12 +449,8 @@ class Model_Settings extends Helper_Abstract_Model {
 	 */
 	public function save_font() {
 
-		$this->log->addNotice( 'Running AJAX Endpoint', [
-			'type' => 'Save Font',
-		] );
-
-		/* prevent unauthorized access */
-		$this->ajax_font_validation();
+		/* User / CORS validation */
+		$this->misc->handle_ajax_authentication( 'Save Font', 'gravityforms_edit_settings', 'gfpdf_font_nonce' );
 
 		/* Handle the validation and saving of the font */
 		$payload = isset( $_POST['payload'] ) ? $_POST['payload'] : '';
@@ -515,12 +474,8 @@ class Model_Settings extends Helper_Abstract_Model {
 	 */
 	public function delete_font() {
 
-		$this->log->addNotice( 'Running AJAX Endpoint', [
-			'type' => 'Delete Font',
-		] );
-
-		/* prevent unauthorized access */
-		$this->ajax_font_validation();
+		/* User / CORS validation */
+		$this->misc->handle_ajax_authentication( 'Delete Font', 'gravityforms_edit_settings', 'gfpdf_font_nonce' );
 
 		/* Get the required details for deleting fonts */
 		$id    = ( isset( $_POST['id'] ) ) ? $_POST['id'] : '';
@@ -656,31 +611,8 @@ class Model_Settings extends Helper_Abstract_Model {
 	 */
 	public function check_tmp_pdf_security() {
 
-		/* prevent unauthorized access */
-		if ( ! $this->gform->has_capability( 'gravityforms_view_settings' ) ) {
-			/* fail */
-			$this->log->addCritical( 'Lack of User Capabilities.', [
-				'user'      => wp_get_current_user(),
-				'user_meta' => get_user_meta( get_current_user_id() ),
-			] );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
-
-		/**
-		 * Verify our nonce is valid before doing anything
-		 */
-		$nonce    = ( isset( $_POST['nonce'] ) ) ? $_POST['nonce'] : '';
-		$nonce_id = 'gfpdf-direct-pdf-protection';
-
-		if ( ! wp_verify_nonce( $nonce, $nonce_id ) ) {
-			/* fail */
-			$this->log->addWarning( 'Nonce Verification Failed.' );
-
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
-		}
+		/* User / CORS validation */
+		$this->misc->handle_ajax_authentication( 'Check Tmp Directory', 'gravityforms_view_settings', 'gfpdf-direct-pdf-protection' );
 
 		/* Create our tmp file and do our actual check */
 		echo json_encode( $this->test_public_tmp_directory_access() );

--- a/tests/phpunit/unit-tests/test-ajax.php
+++ b/tests/phpunit/unit-tests/test-ajax.php
@@ -182,6 +182,106 @@ class Test_PDF_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Ensure we correctly authorise the end user
+	 *
+	 * @class Model_Actions
+	 *
+	 * @since 4.1
+	 */
+	public function test_multsite_v3_migration() {
+
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		/* Check for authentication failure */
+		try {
+			$this->_handleAjax( 'multisite_v3_migration' );
+		} catch ( WPAjaxDieStopException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$this->assertEquals( '401', $e->getMessage() );
+
+		/* become super admin */
+		$this->_setRole( 'administrator' );
+		grant_super_admin( get_current_user_id() );
+		$_POST['blog_id'] = 1;
+
+		/* Check for nonce failure */
+		try {
+			$this->_handleAjax( 'multisite_v3_migration' );
+		} catch ( WPAjaxDieStopException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$this->assertEquals( '401', $e->getMessage() );
+
+		/* Check for missing v3 configuration file failure */
+		$_POST['nonce'] = wp_create_nonce( "gfpdf_multisite_migration" );
+
+		try {
+			$this->_handleAjax( 'multisite_v3_migration' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		/* Get the response */
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertArrayHasKey( 'results', $response );
+		$this->assertArrayHasKey( 'error', $response['results'] );
+	}
+
+	/**
+	 * Ensure we correctly authorise the end user
+	 *
+	 * @class Model_Form_Settings
+	 *
+	 * @since 4.1
+	 */
+	public function test_render_template_fields() {
+
+		/* Check for authentication failure */
+		try {
+			$this->_handleAjax( 'gfpdf_get_template_fields' );
+		} catch ( WPAjaxDieStopException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$this->assertEquals( '401', $e->getMessage() );
+
+		/* become admin */
+		$this->_setRole( 'administrator' );
+
+		/* Check for nonce failure */
+		try {
+			$this->_handleAjax( 'gfpdf_get_template_fields' );
+		} catch ( WPAjaxDieStopException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$this->assertEquals( '401', $e->getMessage() );
+
+		/* Check for missing v3 configuration file failure */
+		$_POST['nonce'] = wp_create_nonce( "gfpdf_ajax_nonce" );
+
+		try {
+			$this->_handleAjax( 'gfpdf_get_template_fields' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		/* Get the response */
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertArrayHasKey( 'fields', $response );
+		$this->assertArrayHasKey( 'editors', $response );
+		$this->assertArrayHasKey( 'editor_init', $response );
+		$this->assertArrayHasKey( 'template_type', $response );
+	}
+
+	/**
 	 * Test our Gravity Forms PDF Settings configuration duplication functionality
 	 *
 	 * @class Model_Form_Settings


### PR DESCRIPTION
We're now using Helper_Misc::handle_ajax_authentication for all AJAX authentication which checks user capabilities and does an Nonce check (prevents CORS).

We also adding missing unit tests for AJAX endpoints and fixed up an endpoint that didn't have an nonce.

Resolves #515