### PR TITLE
Fix GF Sticky List conflict with [gravitypdf] shortcode on confirmation page

### DIFF
--- a/src/controller/Controller_Shortcodes.php
+++ b/src/controller/Controller_Shortcodes.php
@@ -108,8 +108,8 @@ class Controller_Shortcodes extends Helper_Abstract_Controller implements Helper
 	 */
 	public function add_filters() {
 
-		add_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_confirmation' ], 10, 3 );
-		add_filter( 'gform_notification', [ $this->model, 'gravitypdf_notification' ], 10, 3 );
+		add_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_confirmation' ], 100, 3 );
+		add_filter( 'gform_notification', [ $this->model, 'gravitypdf_notification' ], 100, 3 );
 		add_filter( 'gform_admin_pre_render', [ $this->model, 'gravitypdf_redirect_confirmation' ] );
 
 		/* Basic GravityView Support */

--- a/tests/phpunit/unit-tests/test-shortcodes.php
+++ b/tests/phpunit/unit-tests/test-shortcodes.php
@@ -97,8 +97,8 @@ class Test_Shortcode extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_filters() {
-		$this->assertEquals( 10, has_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_confirmation' ] ) );
-		$this->assertEquals( 10, has_filter( 'gform_notification', [ $this->model, 'gravitypdf_notification' ] ) );
+		$this->assertEquals( 100, has_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_confirmation' ] ) );
+		$this->assertEquals( 100, has_filter( 'gform_notification', [ $this->model, 'gravitypdf_notification' ] ) );
 		$this->assertEquals( 10, has_filter( 'gform_admin_pre_render', [
 			$this->model,
 			'gravitypdf_redirect_confirmation',


### PR DESCRIPTION
Sticky List taps into the `gform_confirmation` filter and manipulates the confirmation message. Unfortunately, in some cases it actually overrides the confirmation message entirely which means any filters like ours which run before it get overridden. 

Change out filter to run at "100" for `gform_confirmation`. Also did the same for `gform_notification` to pre-empt a similar conflict in future. 