### PR TITLE
Add four-column support in PDFs

### DIFF
--- a/src/helper/Helper_Field_Container.php
+++ b/src/helper/Helper_Field_Container.php
@@ -71,11 +71,15 @@ class Helper_Field_Container {
 	 * @since 4.0
 	 */
 	private $class_map = [
-		'gf_left_half'    => 50,
-		'gf_right_half'   => 50,
-		'gf_left_third'   => 33.3,
-		'gf_middle_third' => 33.3,
-		'gf_right_third'  => 33.3,
+		'gf_left_half'      => 50,
+		'gf_right_half'     => 50,
+		'gf_left_third'     => 33.3,
+		'gf_middle_third'   => 33.3,
+		'gf_right_third'    => 33.3,
+		'gf_first_quarter'  => 25,
+		'gf_second_quarter' => 25,
+		'gf_third_quarter'  => 25,
+		'gf_fourth_quarter' => 25,
 	];
 
 	/**

--- a/src/templates/blank-slate.php
+++ b/src/templates/blank-slate.php
@@ -43,12 +43,14 @@ if ( ! class_exists( 'GFForms' ) ) {
 
     .gf_left_half,
     .gf_left_third, .gf_middle_third,
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter,
     .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
         float: left;
     }
 
     .gf_right_half,
-    .gf_right_third {
+    .gf_right_third,
+    .gf_fourth_quarter {
         float: right;
     }
 
@@ -60,6 +62,10 @@ if ( ! class_exists( 'GFForms' ) ) {
     .gf_left_third, .gf_middle_third, .gf_right_third,
     .gf_list_3col li {
         width: 32.3%;
+    }
+
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter, .gf_fourth_quarter {
+        width: 24%;
     }
 
     .gf_list_4col li {
@@ -78,7 +84,11 @@ if ( ! class_exists( 'GFForms' ) ) {
         padding-right: 1.505%;
     }
 
-    .gf_right_half, .gf_right_third {
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter, .gf_fourth_quarter {
+        padding-right: 1.333%;
+    }
+
+    .gf_right_half, .gf_right_third, .gf_fourth_quarter {
         padding-right: 0;
     }
 

--- a/src/templates/focus-gravity.php
+++ b/src/templates/focus-gravity.php
@@ -50,16 +50,19 @@ $label_format = ( ! empty( $settings['focusgravity_label_format'] ) ) ? $setting
     /* Handle Gravity Forms CSS Ready Classes */
     .row-separator {
         clear: both;
+        padding: 1.25mm 0;
     }
 
     .gf_left_half,
     .gf_left_third, .gf_middle_third,
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter,
     .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
         float: left;
     }
 
     .gf_right_half,
-    .gf_right_third {
+    .gf_right_third,
+    .gf_fourth_quarter {
         float: right;
     }
 
@@ -71,6 +74,10 @@ $label_format = ( ! empty( $settings['focusgravity_label_format'] ) ) ? $setting
     .gf_left_third, .gf_middle_third, .gf_right_third,
     .gf_list_3col li {
         width: 32.3%;
+    }
+
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter, .gf_fourth_quarter {
+        width: 24%;
     }
 
     .gf_list_4col li {
@@ -89,7 +96,11 @@ $label_format = ( ! empty( $settings['focusgravity_label_format'] ) ) ? $setting
         padding-right: 1.505%;
     }
 
-    .gf_right_half, .gf_right_third {
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter, .gf_fourth_quarter {
+        padding-right: 1.333%;
+    }
+
+    .gf_right_half, .gf_right_third, .gf_fourth_quarter {
         padding-right: 0;
     }
 

--- a/src/templates/rubix.php
+++ b/src/templates/rubix.php
@@ -47,16 +47,19 @@ $contrast = $misc->get_background_and_border_contrast( $container_background_col
     /* Handle Gravity Forms CSS Ready Classes */
     .row-separator {
         clear: both;
+        padding: 1.25mm 0;
     }
 
     .gf_left_half,
     .gf_left_third, .gf_middle_third,
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter,
     .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
         float: left;
     }
 
     .gf_right_half,
-    .gf_right_third {
+    .gf_right_third,
+    .gf_fourth_quarter {
         float: right;
     }
 
@@ -68,6 +71,10 @@ $contrast = $misc->get_background_and_border_contrast( $container_background_col
     .gf_left_third, .gf_middle_third, .gf_right_third,
     .gf_list_3col li {
         width: 32.3%;
+    }
+
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter, .gf_fourth_quarter {
+        width: 24%;
     }
 
     .gf_list_4col li {
@@ -86,7 +93,11 @@ $contrast = $misc->get_background_and_border_contrast( $container_background_col
         padding-right: 1.505%;
     }
 
-    .gf_right_half, .gf_right_third {
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter, .gf_fourth_quarter {
+        padding-right: 1.333%;
+    }
+
+    .gf_right_half, .gf_right_third, .gf_fourth_quarter {
         padding-right: 0;
     }
 

--- a/src/templates/zadani.php
+++ b/src/templates/zadani.php
@@ -48,12 +48,14 @@ $value_border_colour = ( ! empty( $settings['zadani_border_colour'] ) ) ? $setti
 
     .gf_left_half,
     .gf_left_third, .gf_middle_third,
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter,
     .gf_list_2col li, .gf_list_3col li, .gf_list_4col li, .gf_list_5col li {
         float: left;
     }
 
     .gf_right_half,
-    .gf_right_third {
+    .gf_right_third,
+    .gf_fourth_quarter {
         float: right;
     }
 
@@ -65,6 +67,10 @@ $value_border_colour = ( ! empty( $settings['zadani_border_colour'] ) ) ? $setti
     .gf_left_third, .gf_middle_third, .gf_right_third,
     .gf_list_3col li {
         width: 32.3%;
+    }
+
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter, .gf_fourth_quarter {
+        width: 24%;
     }
 
     .gf_list_4col li {
@@ -83,7 +89,11 @@ $value_border_colour = ( ! empty( $settings['zadani_border_colour'] ) ) ? $setti
         padding-right: 1.505%;
     }
 
-    .gf_right_half, .gf_right_third {
+    .gf_first_quarter, .gf_second_quarter, .gf_third_quarter, .gf_fourth_quarter {
+        padding-right: 1.333%;
+    }
+
+    .gf_right_half, .gf_right_third, .gf_fourth_quarter {
         padding-right: 0;
     }
 

--- a/tests/phpunit/unit-tests/test-field-container.php
+++ b/tests/phpunit/unit-tests/test-field-container.php
@@ -192,6 +192,44 @@ class Test_Field_Container extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check that four-columns give the correct output
+	 *
+	 * @since 4.1
+	 */
+	public function test_four_columns() {
+
+		$field           = new GF_Field();
+		$field->cssClass = 'gf_first_quarter';
+
+		/* Check it opens correctly */
+		$this->assertEquals( '<div class="row-separator odd">', $this->generate( $field ) );
+
+		$field           = new GF_Field();
+		$field->cssClass = 'gf_second_quarter';
+
+		/* Check it does nothing */
+		$this->assertEquals( '', $this->generate( $field ) );
+
+		$field           = new GF_Field();
+		$field->cssClass = 'gf_third_quarter';
+
+		/* Check it does nothing */
+		$this->assertEquals( '', $this->generate( $field ) );
+
+		$field           = new GF_Field();
+		$field->cssClass = 'gf_fourth_quarter';
+
+		/* Check it does nothing */
+		$this->assertEquals( '', $this->generate( $field ) );
+
+		/* Check the row closes / opens new row correctly */
+		$this->assertEquals( '</div><div class="row-separator even">', $this->generate( $field ) );
+
+		/* Check it now closes correctly */
+		$this->assertEquals( '</div>', $this->close() );
+	}
+
+	/**
 	 * Check that two and three column layouts can intermingle
 	 *
 	 * @since 4.0


### PR DESCRIPTION
By default Gravity Forms only supports single, two and three columns layouts. However, this four-column CSS code https://gist.github.com/WebEndevSnippets/5555354 has become prominent. With that in mind, we've added support for these custom class types.