### PR TITLE
Resolve mime-issues with WordPress 4.7.1 by disabling check for TTF files

### DIFF
--- a/src/controller/Controller_Settings.php
+++ b/src/controller/Controller_Settings.php
@@ -357,7 +357,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 	 * @since 4.0
 	 */
 	public function allow_font_uploads( $mime_types = [] ) {
-		$mime_types['ttf'] = 'application/octet-stream';
+		$mime_types['ttf'] = 'application/x-font-ttf';
 
 		return $mime_types;
 	}

--- a/tests/phpunit/unit-tests/test-settings.php
+++ b/tests/phpunit/unit-tests/test-settings.php
@@ -247,7 +247,7 @@ class Test_Settings extends WP_UnitTestCase {
 	 */
 	public function test_allow_font_uploads() {
 		$results = $this->controller->allow_font_uploads();
-		$this->assertEquals( 'application/octet-stream', $results['ttf'] );
+		$this->assertEquals( 'application/x-font-ttf', $results['ttf'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #570