### PR TITLE
Correct the template path on installation

### DIFF
--- a/src/model/Model_Templates.php
+++ b/src/model/Model_Templates.php
@@ -166,10 +166,19 @@ class Model_Templates extends Helper_Abstract_Model {
 		}
 
 		/* Copy all the files to the active PDF working directory */
-		$results = $this->misc->copyr( $this->get_unzipped_dir_name( $zip_path ), $this->templates->get_template_path() );
+		$unzipped_dir_name = $this->get_unzipped_dir_name( $zip_path );
+		$template_path     = $this->templates->get_template_path();
+
+		$results = $this->misc->copyr( $unzipped_dir_name, $template_path );
 
 		/* Get the template headers now all the files are in the right location */
-		$headers = $this->get_template_info( glob( $this->get_unzipped_dir_name( $zip_path ) . '*.php' ) );
+		$headers = $this->get_template_info( glob( $unzipped_dir_name . '*.php' ) );
+
+		/* Fix template path */
+		$headers = array_map( function( $header ) use ( $unzipped_dir_name, $template_path ) {
+			$header['path'] = str_replace( $unzipped_dir_name, $template_path, $header['path'] );
+			return $header;
+		}, $headers );
 
 		/* Run PDF template SetUp method if required */
 		$this->maybe_run_template_setup( $headers );


### PR DESCRIPTION
On multisite installations I noticed the delete button wasn't showing up when a new PDF template is installed. I tracked the issue down to an incorrect path to the template file.