### PR TITLE
Set the response codes during wp_die()

### DIFF
--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -944,8 +944,8 @@ class Helper_Misc {
 
 			$this->log->addWarning( 'Nonce Verification Failed' );
 
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
+			/* Unauthorized response */
+			wp_die( '401', 401 );
 		}
 
 		/* prevent unauthorized access */
@@ -957,8 +957,8 @@ class Helper_Misc {
 				'capability_needed' => $capability,
 			] );
 
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
+			/* Unauthorized response */
+			wp_die( '401', 401 );
 		}
 	}
 }

--- a/src/model/Model_Actions.php
+++ b/src/model/Model_Actions.php
@@ -328,8 +328,8 @@ class Model_Actions extends Helper_Abstract_Model {
 
 		/* Ensure multisite website */
 		if( ! is_multisite() ) {
-			header( 'HTTP/1.1 401 Unauthorized' );
-			wp_die( '401' );
+			/* Unauthorized response */
+			wp_die( '401', 401 );
 		}
 
 		/* User / CORS validation */
@@ -374,7 +374,8 @@ class Model_Actions extends Helper_Abstract_Model {
 		}
 
 		$log->addError( 'AJAX Endpoint Failed' );
-		header( 'HTTP/1.1 500 Internal Server Error' );
-		wp_die( '500' );
+
+		/* Internal Server Error */
+		wp_die( '500', 500 );
 	}
 }

--- a/src/model/Model_Form_Settings.php
+++ b/src/model/Model_Form_Settings.php
@@ -787,8 +787,8 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		$this->log->addError( 'AJAX Endpoint Failed', $errors );
 
-		header( 'HTTP/1.1 500 Internal Server Error' );
-		wp_die( '500' );
+		/* Internal Server Error */
+		wp_die( '500', 500 );
 	}
 
 	/**
@@ -849,8 +849,8 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			'WP_Error_Code'    => $config->get_error_code(),
 		] );
 
-		header( 'HTTP/1.1 500 Internal Server Error' );
-		wp_die( '500' );
+		/* Internal Server Error */
+		wp_die( '500', 500 );
 	}
 
 	/**
@@ -905,8 +905,8 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			'WP_Error_Code'    => $config->get_error_code(),
 		] );
 
-		header( 'HTTP/1.1 500 Internal Server Error' );
-		wp_die( '500' );
+		/* Internal Server Error */
+		wp_die( '500', 500 );
 	}
 
 	/**

--- a/src/model/Model_Settings.php
+++ b/src/model/Model_Settings.php
@@ -499,8 +499,6 @@ class Model_Settings extends Helper_Abstract_Model {
 			}
 		}
 
-		header( 'HTTP/1.1 400 Bad Request' );
-
 		$return = [
 			'error' => esc_html__( 'Could not delete Gravity PDF font correctly. Please try again.', 'gravity-forms-pdf-extended' ),
 		];
@@ -508,7 +506,9 @@ class Model_Settings extends Helper_Abstract_Model {
 		$this->log->addError( 'AJAX Endpoint Error', $return );
 
 		echo json_encode( $return );
-		wp_die();
+
+		/* Bad Request */
+		wp_die( '', 400 );
 	}
 
 	/**
@@ -530,8 +530,6 @@ class Model_Settings extends Helper_Abstract_Model {
 		     strlen( $font['font_name'] ) === 0 || strlen( $font['regular'] ) === 0
 		) {
 
-			header( 'HTTP/1.1 400 Bad Request' );
-
 			$return = [
 				'error' => esc_html__( 'Required fields have not been included.', 'gravity-forms-pdf-extended' ),
 			];
@@ -539,15 +537,15 @@ class Model_Settings extends Helper_Abstract_Model {
 			$this->log->addWarning( 'Validation Failed.', $return );
 
 			echo json_encode( $return );
-			wp_die();
+
+			/* Bad Request */
+			wp_die( '', 400 );
 		}
 
 		/* Check we have a valid font name */
 		$name = $font['font_name'];
 
 		if ( ! $this->is_font_name_valid( $name ) ) {
-
-			header( 'HTTP/1.1 400 Bad Request' );
 
 			$return = [
 				'error' => esc_html__( 'Font name is not valid. Only alphanumeric characters and spaces are accepted.', 'gravity-forms-pdf-extended' ),
@@ -556,7 +554,9 @@ class Model_Settings extends Helper_Abstract_Model {
 			$this->log->addWarning( 'Validation Failed.', $return );
 
 			echo json_encode( $return );
-			wp_die();
+
+			/* Bad Request */
+			wp_die( '', 400 );
 		}
 
 		/* Check the font name is unique */
@@ -565,8 +565,6 @@ class Model_Settings extends Helper_Abstract_Model {
 
 		if ( ! $this->is_font_name_unique( $shortname, $id ) ) {
 
-			header( 'HTTP/1.1 400 Bad Request' );
-
 			$return = [
 				'error' => esc_html__( 'A font with the same name already exists. Try a different name.', 'gravity-forms-pdf-extended' ),
 			];
@@ -574,7 +572,9 @@ class Model_Settings extends Helper_Abstract_Model {
 			$this->log->addWarning( 'Validation Failed.', $return );
 
 			echo json_encode( $return );
-			wp_die();
+
+			/* Bad Request */
+			wp_die( '', 400 );
 		}
 
 		/* Move fonts to our Gravity PDF font folder */
@@ -583,8 +583,6 @@ class Model_Settings extends Helper_Abstract_Model {
 		/* Check if any errors occured installing the fonts */
 		if ( isset( $installation['errors'] ) ) {
 
-			header( 'HTTP/1.1 400 Bad Request' );
-
 			$return = [
 				'error' => $installation,
 			];
@@ -592,7 +590,9 @@ class Model_Settings extends Helper_Abstract_Model {
 			$this->log->addWarning( 'Validation Failed.', $return );
 
 			echo json_encode( $return );
-			wp_die();
+
+			/* Bad Request */
+			wp_die( '', 400 );
 		}
 
 		/* If we got here the installation was successful so return the data */

--- a/src/model/Model_Templates.php
+++ b/src/model/Model_Templates.php
@@ -141,8 +141,8 @@ class Model_Templates extends Helper_Abstract_Model {
 				'error' => $e->getMessage(),
 			] );
 
-			header( 'HTTP/1.1 400 Bad Request' );
-			wp_die( '400' );
+			/* Bad Request */
+			wp_die( '400', 400 );
 		}
 
 		/* Unzip and check the PDF templates look valid */
@@ -156,13 +156,13 @@ class Model_Templates extends Helper_Abstract_Model {
 				'error' => $e->getMessage(),
 			] );
 
-			header( 'HTTP/1.1 400 Bad Request' );
 			header( 'Content-Type: application/json' );
 			echo json_encode( [
 				'error' => $e->getMessage(),
 			] );
 
-			wp_die();
+			/* Bad Response */
+			wp_die( '', 400 );
 		}
 
 		/* Copy all the files to the active PDF working directory */
@@ -187,18 +187,18 @@ class Model_Templates extends Helper_Abstract_Model {
 		$this->cleanup_template_files( $zip_path );
 
 		if ( is_wp_error( $results ) ) {
-			header( 'HTTP/1.1 500 Internal Server Error' );
-			wp_die( '500' );
+			/* Internal Server Error */
+			wp_die( '500', 500 );
 		}
 
 		/* Return newly-installed template headers */
-		header( 'HTTP/1.1 200 OK' );
 		header( 'Content-Type: application/json' );
 		echo json_encode( [
 			'templates' => $headers,
 		] );
 
-		wp_die();
+		/* Okay Response */
+		wp_die( '', 200 );
 	}
 
 	/**
@@ -237,14 +237,15 @@ class Model_Templates extends Helper_Abstract_Model {
 		try {
 			$this->delete_template( $template_id );
 		} catch ( Exception $e ) {
-			header( 'HTTP/1.1 400 Bad Request' );
-			wp_die('400');
+			/* Bad Request */
+			wp_die( '400', 400 );
 		}
 
-		header( 'HTTP/1.1 200 OK' );
 		header( 'Content-Type: application/json' );
 		echo json_encode( true );
-		wp_die();
+
+		/* Okay Response */
+		wp_die( '', 200 );
 	}
 
 	/**
@@ -294,10 +295,11 @@ class Model_Templates extends Helper_Abstract_Model {
 		$templates = $template_settings['options'];
 		$value     = $options_class->get_form_value( $template_settings );
 
-		header( 'HTTP/1.1 200 OK' );
 		header( 'Content-Type: application/text' );
 		echo $options_class->build_options_for_select( $templates, $value );
-		wp_die();
+
+		/* Okay Response */
+		wp_die( '', 200 );
 	}
 
 	/**


### PR DESCRIPTION
`wp_die()` was overriding the header response codes we were manually setting during AJAX calls. Remove all `header()` response codes and include them in `wp_die()` instead.