### PR TITLE
Change verbiage from Activate to Select

### DIFF
--- a/src/assets/js/react/router/templateRouter.js
+++ b/src/assets/js/react/router/templateRouter.js
@@ -67,7 +67,7 @@ export const Routes = () => (
            templateHeaderText={GFPDF.installedPdfs}
 
            genericUploadErrorText={GFPDF.problemWithTheUpload}
-           activateText={GFPDF.activate}
+           activateText={GFPDF.select}
            addTemplateText={GFPDF.addNewTemplate}
            filenameErrorText={GFPDF.uploadInvalidNotZipFile}
            filesizeErrorText={GFPDF.uploadInvalidExceedsFileSizeLimit}
@@ -82,7 +82,7 @@ export const Routes = () => (
            ajaxNonce={GFPDF.ajaxNonce}
            pdfWorkingDirPath={GFPDF.pdfWorkingDir}
 
-           activateText={GFPDF.activate}
+           activateText={GFPDF.select}
            templateDeleteText={GFPDF.delete}
            templateConfirmDeleteText={GFPDF.doYouWantToDeleteTemplate}
            templateDeleteErrorText={GFPDF.couldNotDeleteTemplate}

--- a/src/helper/Helper_Data.php
+++ b/src/helper/Helper_Data.php
@@ -216,7 +216,7 @@ class Helper_Data {
 			'yes'             => esc_html__( 'Yes', 'gravity-forms-pdf-extended' ),
 			'standard'        => esc_html__( 'Standard', 'gravity-forms-pdf-extended' ),
 			'advanced'        => esc_html__( 'Advanced', 'gravity-forms-pdf-extended' ),
-			'activate'        => esc_html__( 'Activate', 'gravity-forms-pdf-extended' ),
+			'select'          => esc_html__( 'Select', 'gravity-forms-pdf-extended' ),
 			'version'         => esc_html__( 'Version', 'gravity-forms-pdf-extended' ),
 			'group'           => esc_html__( 'Group', 'gravity-forms-pdf-extended' ),
 			'tags'            => esc_html__( 'Tags', 'gravity-forms-pdf-extended' ),


### PR DESCRIPTION
Feedback showed "Activate" was an instant action. In fact, you pick the template and then need to "save". To account for this we have renamed Activate to Select.

Props to Adrian Gordon for the insight.