### PR TITLE
Show generic PDF install /update message on PDF Template Dropzone

### DIFF
--- a/src/assets/js/react/components/ShowMessage.js
+++ b/src/assets/js/react/components/ShowMessage.js
@@ -164,7 +164,7 @@ const showMessage = React.createClass({
         <div ref={(message) => this._message = message} className={classes}>
           <p>{text}</p>
         </div>
-      ) : <span />
+      ) : <div />
   }
 })
 

--- a/src/assets/js/react/components/TemplateList.js
+++ b/src/assets/js/react/components/TemplateList.js
@@ -82,6 +82,7 @@ export const TemplateList = React.createClass({
             filesizeErrorText={this.props.route.filesizeErrorText}
             installSuccessText={this.props.route.installSuccessText}
             installUpdatedText={this.props.route.installUpdatedText}
+            templateSuccessfullyInstalledUpdated={this.props.route.templateSuccessfullyInstalledUpdated}
             templateInstallInstructions={this.props.route.templateInstallInstructions}
           />
 

--- a/src/assets/js/react/components/TemplateUploader.js
+++ b/src/assets/js/react/components/TemplateUploader.js
@@ -71,6 +71,7 @@ export const TemplateUploader = React.createClass({
     filesizeErrorText: React.PropTypes.string,
     installSuccessText: React.PropTypes.string,
     installUpdatedText: React.PropTypes.string,
+    templateSuccessfullyInstalledUpdated: React.PropTypes.string,
     templateInstallInstructions: React.PropTypes.string,
 
     addNewTemplate: React.PropTypes.func,
@@ -101,6 +102,7 @@ export const TemplateUploader = React.createClass({
         this.setState({
           ajax: true,
           error: '',
+          message: '',
         })
 
         /* POST the PDF template to our endpoint for processing */
@@ -189,9 +191,10 @@ export const TemplateUploader = React.createClass({
       }
     })
 
-    /* Stop our AJAX spinner */
+    /* Mark as success and stop AJAX spinner */
     this.setState({
       ajax: false,
+      message: this.props.templateSuccessfullyInstalledUpdated
     })
   },
 
@@ -207,6 +210,17 @@ export const TemplateUploader = React.createClass({
     this.setState({
       error: (error.response.body && error.response.body.error !== undefined) ? error.response.body.error : this.props.genericUploadErrorText,
       ajax: false
+    })
+  },
+
+  /**
+   * Remove message from state once the timeout has finished
+   *
+   * @since 4.1
+   */
+  removeMessage() {
+    this.setState( {
+      message: ''
     })
   },
 
@@ -235,6 +249,7 @@ export const TemplateUploader = React.createClass({
           <div className="theme-screenshot"><span /></div>
 
           {this.state.error !== '' ? <ShowMessage text={this.state.error} error={true}/> : null}
+          {this.state.message !== '' ? <ShowMessage text={this.state.message} dismissable={true} dismissableCallback={this.removeMessage} /> : null}
 
           <h2 className="theme-name">{this.props.addTemplateText}</h2>
         </a>

--- a/src/assets/js/react/router/templateRouter.js
+++ b/src/assets/js/react/router/templateRouter.js
@@ -73,6 +73,7 @@ export const Routes = () => (
            filesizeErrorText={GFPDF.uploadInvalidExceedsFileSizeLimit}
            installSuccessText={GFPDF.templateSuccessfullyInstalled}
            installUpdatedText={GFPDF.templateSuccessfullyUpdated}
+           templateSuccessfullyInstalledUpdated={GFPDF.templateSuccessfullyInstalledUpdated}
            templateInstallInstructions={GFPDF.templateInstallInstructions}
     />
 

--- a/src/helper/Helper_Data.php
+++ b/src/helper/Helper_Data.php
@@ -245,6 +245,7 @@ class Helper_Data {
 			'uploadInvalidExceedsFileSizeLimit'          => esc_html__( 'Upload exceeds the 2MB limit.', 'gravity-forms-pdf-extended' ),
 			'templateSuccessfullyInstalled'              => esc_html__( 'Template successfully installed', 'gravity-forms-pdf-extended' ),
 			'templateSuccessfullyUpdated'                => esc_html__( 'Template successfully updated', 'gravity-forms-pdf-extended' ),
+			'templateSuccessfullyInstalledUpdated'       => esc_html__( 'PDF Template(s) Successfully Installed / Updated', 'gravity-forms-pdf-extended' ),
 			'problemWithTheUpload'                       => esc_html__( 'There was a problem with the upload. Reload the page and try again.', 'gravity-forms-pdf-extended' ),
 			'doYouWantToDeleteTemplate'                  => sprintf( esc_html__( "Do you really want to delete this PDF template?%sClick 'Cancel' to go back, 'OK' to confirm the delete.", 'gravity-forms-pdf-extended' ), "\n\n" ),
 			'couldNotDeleteTemplate'                     => esc_html__( 'Could not delete template.', 'gravity-forms-pdf-extended' ),


### PR DESCRIPTION
This allows for better visibility when PDF templates are updated, as the existing templates don't move in the list automatically so it can be hard to see if anything happened.