### PR TITLE
Fix issue with Advanced Template Manager opening in Safari

### DIFF
--- a/src/assets/js/react/components/TemplateButton.js
+++ b/src/assets/js/react/components/TemplateButton.js
@@ -52,17 +52,10 @@ const TemplateButton = React.createClass({
    * @since 4.1
    */
   handleClick(e) {
-    /*
-     * Handle weird bug in React where the button click event fires when enter is pressed
-     * on non-react components
-     */
-    if( document.activeElement && this.button === document.activeElement ) {
-      e.preventDefault()
-      e.stopPropagation()
+    e.preventDefault()
+    e.stopPropagation()
 
-      /* trigger router */
-      hashHistory.push('/template')
-    }
+    hashHistory.push('/template')
   },
 
   /**
@@ -71,6 +64,7 @@ const TemplateButton = React.createClass({
   render() {
     return (
       <button
+        type="button"
         id="fancy-template-selector"
         className="button gfpdf-button"
         onClick={this.handleClick}


### PR DESCRIPTION
Tracked this problem down to Safari's document.activeElement not pointing to the correct dom node when the button was clicked. IE also showed the template manager when enter is pressed on non-ReactJS managed compenents.

I discovered browsers will treat the first `<button>` tag as the submit if the type isn't explicitly set to "button". Once done, I could remove the activeElement checks and fix the problem.