### PR TITLE
Swap wp_die() to exit right after outputting PDF

### DIFF
--- a/src/helper/Helper_PDF.php
+++ b/src/helper/Helper_PDF.php
@@ -304,13 +304,13 @@ class Helper_PDF {
 			case 'DISPLAY':
 				$this->prevent_caching();
 				$this->mpdf->Output( $this->filename, 'I' );
-				wp_die();
+				exit;
 			break;
 
 			case 'DOWNLOAD':
 				$this->prevent_caching();
 				$this->mpdf->Output( $this->filename, 'D' );
-				wp_die();
+				exit;
 			break;
 
 			case 'SAVE':


### PR DESCRIPTION
wp_die() changes the headers we set to correctly display the PDF. While our version of Mpdf has exit right after the PDF generation already, if another plugin ships Mpdf it causes issues.

The way around this is to ensure we correctly exit right after the PDF is output to the browser.