### PR TITLE
Fix rewrite rules issue with PDF

### DIFF
--- a/src/controller/Controller_Activation.php
+++ b/src/controller/Controller_Activation.php
@@ -75,21 +75,36 @@ class Controller_Activation {
 			return null;
 		}
 
-		/**
+		/*
 		 * Remove our rewrite rules
 		 * As deactivation hook fires much earlier than flush_rewrite_rules() can be called we'll manually remove our rules from the database
 		 */
 		$data  = GPDFAPI::get_data_class();
 		$rules = get_option( 'rewrite_rules' );
 
-		if ( false !== $rules && isset( $rules[ $data->permalink ] ) ) {
-			unset( $rules[ $data->permalink ] );
-			update_option( 'rewrite_rules', $rules );
+		if ( false !== $rules ) {
+			global $wp_rewrite;
+
+			/* Create two regex rules to account for users with "index.php" in the URL */
+			$query = [
+				'^' . $data->permalink,
+				'^' . $wp_rewrite->root . $data->permalink,
+			];
+
+			$match = false;
+			foreach ( $query as $rule ) {
+				if ( isset( $rules[ $rule ] ) ) {
+					unset( $rules[ $rule ] );
+					$match = true;
+				}
+			}
+
+			if( $match ) {
+				update_option( 'rewrite_rules', $rules );
+			}
 		}
 
-		/**
-		 * Remove our scheduled tasks
-		 */
+		/* Remove our scheduled tasks */
 		wp_clear_scheduled_hook( 'gfpdf_cleanup_tmp_dir' );
 	}
 }

--- a/tests/phpunit/unit-tests/test-installer.php
+++ b/tests/phpunit/unit-tests/test-installer.php
@@ -271,9 +271,9 @@ class Test_Installer extends WP_UnitTestCase {
 	public function test_register_rewrite_rules() {
 		global $wp_rewrite, $gfpdf;
 
-		$this->assertEquals( 'index.php?gpdf=1&pid=$matches[1]&lid=$matches[2]&action=$matches[3]', $wp_rewrite->extra_rules_top[ $gfpdf->data->permalink ] );
+		$this->assertEquals( 'index.php?gpdf=1&pid=$matches[1]&lid=$matches[2]&action=$matches[3]', $wp_rewrite->extra_rules_top[ '^' . $gfpdf->data->permalink ] );
+		$this->assertEquals( 'index.php?gpdf=1&pid=$matches[1]&lid=$matches[2]&action=$matches[3]', $wp_rewrite->extra_rules_top[ '^' . $wp_rewrite->root . $gfpdf->data->permalink ] );
 	}
-
 
 	/**
 	 * Check we are uninstalling correctly


### PR DESCRIPTION
User with index.php in the URL was having issues viewing the PDF. I mimicked the rewrite code from the WP-JSON API to resolve the problem.

This needs further hands on testing and unit testing before committing.