### PR TITLE
Add the add-on and licensing infrastructure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     		"GFPDF\\Model\\": "src/model/",
     		"GFPDF\\View\\": "src/view/",
     		"GFPDF\\Helper\\": ["src/helper/", "src/helper/abstract/", "src/helper/interface/"],
+    		"GFPDF\\Helper\\Licensing\\": "src/helper/licensing/",
     		"GFPDF\\Helper\\Fields\\": "src/helper/fields/",
     		"GFPDF\\Test\\": "tests/unit-tests/"
     	}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,12 +3,13 @@ var gulp = require('gulp'),
   cleanCSS = require('gulp-clean-css'),
   rename = require('gulp-rename'),
   wpPot = require('gulp-wp-pot'),
-  sort = require('gulp-sort')
+  sort = require('gulp-sort'),
+  watch = require('gulp-watch')
 
 /* Minify our CSS */
 gulp.task('minify', function () {
-  return gulp.src([ 'src/assets/css/*.css' ])
-    .pipe(cleanCSS( { target: 'dist/assets/css'}))
+  return gulp.src('src/assets/css/*.css')
+    .pipe(cleanCSS({target: 'dist/assets/css'}))
     .pipe(rename({
       suffix: '.min'
     }))
@@ -16,8 +17,8 @@ gulp.task('minify', function () {
 })
 
 /* Minify our non-react JS (handled by webpack) */
-gulp.task('compress', function() {
-  return gulp.src(['src/assets/js/*.js'])
+gulp.task('compress', function () {
+  return gulp.src('src/assets/js/*.js')
     .pipe(uglify())
     .pipe(rename({
       suffix: '.min'
@@ -35,6 +36,11 @@ gulp.task('language', function () {
       package: 'gravity-forms-pdf-extended'
     }))
     .pipe(gulp.dest('src/assets/languages'))
+})
+
+gulp.task('watch', function () {
+  watch('src/assets/js/*.js', function () { gulp.start('compress') })
+  watch('src/assets/css/*.css', function () { gulp.start('minify') })
 })
 
 gulp.task('default', function () {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-rename": "~1.2.2",
     "gulp-sort": "^2.0.0",
     "gulp-uglify": "^2.0.0",
+    "gulp-watch": "^4.3.11",
     "gulp-wp-pot": "^1.2.2",
     "jquery": "^3.1.1",
     "json-loader": "^0.5.4",

--- a/src/assets/css/gfpdf-styles.css
+++ b/src/assets/css/gfpdf-styles.css
@@ -142,6 +142,17 @@ box-shadow: 1px 1px 5px 1px rgba(0,0,0,0.15);
     margin-left: 5px;
 }
 
+/*
+ * License page
+ */
+#pdf-license .fa-exclamation-circle {
+    color: red;
+}
+
+#pdf-license .fa-check {
+    color: green;
+}
+
 /**
  * Tools Settings Page
  */

--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -79,6 +79,9 @@
 
         /* Setup our template loader, if needed */
         this.setupDynamicTemplateFields()
+
+        /* Setup license deactivation, if needed */
+        this.setupLicenseDeactivation()
       }
 
       /**
@@ -716,6 +719,57 @@
               self.toggleFontAppearance(response.template_type)
             }
           })
+        })
+      }
+
+      /**
+       * Handles individual add-on license key deactivation via AJAX
+       * @since 4.2
+       */
+      this.setupLicenseDeactivation = function () {
+        $('.gfpdf-deactivate-license').click(function () {
+          /* Do AJAX call so user can deactivate license */
+          var $container = $(this).parent()
+          $container.find('.gf_settings_description label').html('')
+
+          /* Add spinner */
+          var $spinner = $('<img alt="' + GFPDF.spinnerAlt + '" src="' + GFPDF.spinnerUrl + '" class="gfpdf-spinner" />')
+
+          /* Add our spinner */
+          $(this).append($spinner)
+
+          /* Set up ajax data */
+          var slug = $(this).data('addon-name')
+
+          var data = {
+            'action': 'gfpdf_deactivate_license',
+            'addon_name': slug,
+            'license': $(this).data('license'),
+            'nonce': $(this).data('nonce'),
+          }
+
+          /* Do ajax call */
+          self.ajax(data, function (response) {
+
+            /* Remove our loading spinner */
+            $spinner.remove()
+
+            if (response.success) {
+              /* cleanup inputs */
+              $('#gfpdf_settings\\[license_' + slug + '\\]').val('')
+              $('#gfpdf_settings\\[license_' + slug + '_message\\]').val('')
+              $('#gfpdf_settings\\[license_' + slug + '_status\\]').val('')
+              $container.find('i').remove()
+              $container.find('a').remove()
+
+              $container.find('.gf_settings_description label').html(response.success)
+            } else {
+              /* Show error message */
+              $container.find('.gf_settings_description label').html(response.error)
+            }
+          })
+
+          return false
         })
       }
 

--- a/src/controller/Controller_Settings.php
+++ b/src/controller/Controller_Settings.php
@@ -194,7 +194,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		add_action( 'wp_ajax_gfpdf_font_save', [ $this->model, 'save_font' ] );
 		add_action( 'wp_ajax_gfpdf_font_delete', [ $this->model, 'delete_font' ] );
 		add_action( 'wp_ajax_gfpdf_has_pdf_protection', [ $this->model, 'check_tmp_pdf_security' ] );
-
+		add_action( 'wp_ajax_gfpdf_deactivate_license', [ $this->model, 'process_license_deactivation' ] );
 	}
 
 	/**
@@ -225,6 +225,10 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 
 		/* allow TTF uploads */
 		add_filter( 'upload_mimes', [ $this, 'allow_font_uploads' ] );
+
+		/* Register add-ons for licensing page */
+		add_filter( 'gfpdf_settings_licenses', [ $this->model, 'register_addons_for_licensing' ] );
+		add_filter( 'gfpdf_settings_license_sanitize', [ $this->model, 'maybe_active_licenses' ] );
 	}
 
 	/**
@@ -245,6 +249,14 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 
 			case 'tools':
 				$this->view->tools();
+			break;
+
+			case 'license':
+				$this->view->license();
+			break;
+
+			case 'extensions':
+				$this->view->extensions();
 			break;
 
 			case 'help':

--- a/src/helper/Helper_Data.php
+++ b/src/helper/Helper_Data.php
@@ -50,7 +50,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @property string  $memory_limit                    The current PHP memory limit
  * @property string  $upload_dir                      The current path to the WP upload directory
  * @property string  $upload_dir_url                  The current URL to the WP upload directory
+ * @property string  $store_url                       The URL of our online store
  * @property array   $form_settings                   A cache of the current form's PDF settings
+ * @property array   $addon                           An array of current active / registered add-ons
  * @property string  $template_location               The current path to the PDF working directory
  * @property string  $template_location_url           The current URL to the PDF working directory
  * @property string  $template_font_location          The current path to the PDF font directory
@@ -144,15 +146,6 @@ class Helper_Data {
 	}
 
 	/**
-	 * Set up addon array for use tracking active addons
-	 *
-	 * @since  3.8
-	 */
-	public function set_addon_details() {
-		$this->addon = [];
-	}
-
-	/**
 	 * Set up any default data that should be stored
 	 *
 	 * @return void
@@ -161,6 +154,7 @@ class Helper_Data {
 	 */
 	public function init() {
 		$this->set_plugin_titles();
+		$this->set_addon_details();
 	}
 
 	/**
@@ -174,6 +168,41 @@ class Helper_Data {
 		$this->short_title = esc_html__( 'PDF', 'gravity-forms-pdf-extended' );
 		$this->title       = esc_html__( 'Gravity PDF', 'gravity-forms-pdf-extended' );
 		$this->slug        = 'pdf';
+	}
+
+	/**
+	 * Set up addon array for use tracking active addons
+	 *
+	 * @since 3.8
+	 */
+	public function set_addon_details() {
+		$this->store_url = 'https://gravitypdf.com';
+		$this->addon = [];
+	}
+
+	/**
+	 * Gravity PDF add-ons should register their details with this method so we can handle the licensing centrally
+	 *
+	 * @param Helper_Abstract_Addon $class The plugin bootstrap class
+	 *
+	 * @since 4.2
+	 */
+	public function add_addon( Helper_Abstract_Addon $class ) {
+		$this->addon[ $class->get_slug() ] = $class;
+	}
+
+	public function addon_license_responses( $addon_name ) {
+		return [
+			'expired'             => __( 'Your license key expired on %s.', 'gravity-forms-pdf-extended' ),
+			'revoked'             => __( 'Your license key has been disabled', 'gravity-forms-pdf-extended' ),
+			'missing'             => __( 'Invalid license key provided', 'gravity-forms-pdf-extended' ),
+			'invalid'             => __( 'Your license is not active for this URL', 'gravity-forms-pdf-extended' ),
+			'site_inactive'       => __( 'Your license is not active for this URL', 'gravity-forms-pdf-extended' ),
+			'item_name_mismatch'  => sprintf( __( 'This appears to be an invalid license key for %s', 'gravity-forms-pdf-extended' ), $addon_name ),
+			'no_activations_left' => __( 'Your license key has reached its activation limit', 'gravity-forms-pdf-extended' ),
+			'default'             => __( 'An error occurred, please try again', 'gravity-forms-pdf-extended' ),
+			'generic'             => __( 'An error occurred during activation, please try again', 'gravity-forms-pdf-extended' ),
+		];
 	}
 
 	/**

--- a/src/helper/Helper_Logger.php
+++ b/src/helper/Helper_Logger.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace GFPDF\Helper;
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\NullHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Monolog\Processor\IntrospectionProcessor;
+use Monolog\Processor\MemoryPeakUsageProcessor;
+
+use DateTimeZone;
+use GFLogging;
+use GFFormsModel;
+
+/**
+ * Abstract Helper Logger
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * An abstract class to assist with logging
+ */
+class Helper_Logger {
+
+	/**
+	 * @var string
+	 *
+	 * @since 4.2
+	 */
+	protected $slug;
+
+	/**
+	 * @var string
+	 *
+	 * @since 4.2
+	 */
+	protected $name;
+
+	/**
+	 * Holds our log class
+	 *
+	 * @var \Monolog\Logger
+	 *
+	 * @since 4.2
+	 */
+	protected $log;
+
+	/**
+	 * Helper_Logger constructor.
+	 *
+	 * @param string $slug
+	 * @param string $name
+	 *
+	 * @since 4.2
+	 */
+	public function __construct( $slug, $name ) {
+		$this->slug = $slug;
+		$this->name = $name;
+	}
+
+	/**
+	 * Returns the logger instance, and initiates it if needed
+	 *
+	 * @return Logger
+	 *
+	 * @since 4.2
+	 */
+	public function get_logger() {
+
+		if ( ! $this->log instanceof Logger ) {
+			$this->setup_logger();
+			add_filter( 'gform_logging_supported', [ $this, 'register_logger_with_gf' ] );
+		}
+
+		return $this->log;
+	}
+
+	/**
+	 * Register our plugin with Gravity Form's Logger
+	 *
+	 * @param array $loggers
+	 *
+	 * @return array
+	 *
+	 * @since 4.2
+	 */
+	public function register_logger_with_gf( $loggers ) {
+		$loggers[ $this->slug ] = $this->name;
+
+		return $loggers;
+	}
+
+	/**
+	 * Initialise our logging class (we're using Monolog instead of Gravity Form's KLogger)
+	 * and set up appropriate handlers based on the logger settings
+	 *
+	 * @return void
+	 *
+	 * @since 4.2
+	 */
+	protected function setup_logger() {
+		static $timezone;
+
+		/* Set the logger timezone once (if needed) */
+		if ( ! $timezone ) {
+			$offset = get_option( 'gmt_offset' );
+			if ( $offset != 0 ) {
+				Logger::setTimezone( new DateTimeZone( ( $offset > 0 ) ? '+' . $offset : $offset ) );
+			}
+			$timezone = true;
+		}
+
+		/* Initialise our logger */
+		$this->log = new Logger( $this->slug );
+
+		/* Setup our Gravity Forms local file logger, if enabled */
+		$this->setup_gravityforms_logging();
+
+		/* Check if we have a handler pushed and add our Introspection and Memory Peak usage processors */
+		if ( count( $this->log->getHandlers() ) > 0 && substr( php_sapi_name(), 0, 3 ) !== 'cli' ) {
+			$this->log->pushProcessor( new IntrospectionProcessor );
+			$this->log->pushProcessor( new MemoryPeakUsageProcessor );
+
+			return;
+		}
+
+		/* Disable logging if using CLI, or if Gravity Forms logging isn't enabled */
+		$this->log->pushHandler( new NullHandler( Logger::INFO ) ); /* throw logs away */
+	}
+
+	/**
+	 * Setup Gravity Forms logging, if currently enabled by the user
+	 *
+	 * @return void
+	 *
+	 * @since 4.2
+	 */
+	protected function setup_gravityforms_logging() {
+
+		/* Check if Gravity Forms logging is enabled and push stream logging */
+		if ( class_exists( 'GFLogging' ) ) {
+
+			/*
+			 * Get the current plugin logger settings and check if it's enabled
+			 * The new version of the logger uses the add-on storage method, while the old one stores it in gf_logging_settings
+			 * so we'll test which settings we should use and get the appropriate log level
+			 */
+			if ( ! get_option( 'gform_enable_logging' ) && ( ! defined( 'GF_LOGGING_VERSION' ) || version_compare( GF_LOGGING_VERSION, '1.1', '<' ) ) ) {
+				$settings = get_option( 'gf_logging_settings' );
+
+				$log_level    = (int) rgar( $settings, $this->slug );
+				$log_filename = GFFormsModel::get_upload_root() . 'logs/' . $this->slug . '.txt';
+			} else {
+				$gf_logger          = GFLogging::get_instance();
+				$gf_logger_settings = $gf_logger->get_plugin_settings();
+
+				if ( isset( $gf_logger_settings[ $this->slug ]['enable'] ) && $gf_logger_settings[ $this->slug ]['enable'] ) {
+					$log_level    = ( isset( $gf_logger_settings[ $this->slug ]['log_level'] ) ) ? (int) $gf_logger_settings[ $this->slug ]['log_level'] : 0;
+					$log_filename = ( get_option( 'gform_enable_logging' ) ) ? $gf_logger->get_log_file_name( $this->slug ) : $gf_logger::get_log_file_name( $this->slug );
+				}
+			}
+
+			/* Enable logging if not equivalent to 0 or non-existant and not level 6 (which is apprently off in GF world) */
+			if ( ! empty( $log_level ) && $log_level !== 6 ) {
+
+				/* Convert Gravity Forms log levels to the appropriate Monolog level */
+				$monolog_level = ( $log_level === 4 ) ? Logger::ERROR : Logger::INFO;
+
+				/* Setup our stream and change the format to more-suit Gravity Forms */
+				$formatter = new LineFormatter( "%datetime% - %level_name% --> %message% %context% %extra%\n" );
+				$stream    = new StreamHandler( $log_filename, $monolog_level );
+				$stream->setFormatter( $formatter );
+
+				/* Add our log file stream */
+				$this->log->pushHandler( $stream );
+			}
+		}
+	}
+}

--- a/src/helper/abstract/Helper_Abstract_Addon.php
+++ b/src/helper/abstract/Helper_Abstract_Addon.php
@@ -1,0 +1,501 @@
+<?php
+
+namespace GFPDF\Helper;
+
+/**
+ * Abstract Helper Addon
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * An abstract class to assist with addon licensing
+ */
+abstract class Helper_Abstract_Addon {
+
+	/**
+	 * @var string The add-on slug (usually the name with the spaces substituted for hyphens)
+	 *
+	 * @since 4.2
+	 */
+	private $slug;
+
+	/**
+	 * @var string The add-on name (should match the name/title used in EDD)
+	 *
+	 * @since 4.2
+	 */
+	private $name;
+
+	/**
+	 * @var string The add-on author
+	 *
+	 * @since 4.2
+	 */
+	private $author;
+
+	/**
+	 * @var string The add-on version
+	 *
+	 * @since 4.2
+	 */
+	private $version;
+
+	/**
+	 * @var string The add-on mail file path
+	 *
+	 * @since 4.2
+	 */
+	private $addon_path_main_plugin_file;
+
+	/**
+	 * Holds our registred objects
+	 *
+	 * @var Helper_Singleton
+	 *
+	 * @since 4.2
+	 */
+	public $singleton;
+
+	/**
+	 * Holds our Helper_Data object
+	 * which we can autoload with any data needed
+	 *
+	 * @var Helper_Data
+	 *
+	 * @since 4.2
+	 */
+	protected $data;
+
+	/**
+	 * Holds our Helper_Abstract_Options / Helper_Options_Fields object
+	 * Makes it easy to access global PDF settings and individual form PDF settings
+	 *
+	 * @var Helper_Options_Fields
+	 *
+	 * @since 4.2
+	 */
+	protected $options;
+
+	/**
+	 * Holds our log class
+	 *
+	 * @var \Monolog\Logger
+	 *
+	 * @since 4.2
+	 */
+	protected $log;
+
+	/**
+	 * Give easy access to our notice helper
+	 *
+	 * @var Helper_Notices
+	 *
+	 * @since 4.2
+	 */
+	protected $notices;
+
+	/**
+	 * Helper_Abstract_Addon constructor.
+	 *
+	 * @param string                $addon_slug
+	 * @param string                $addon_name
+	 * @param string                $author
+	 * @param string                $version
+	 * @param string                $path_to_main_plugin_file
+	 * @param Helper_Data           $data
+	 * @param Helper_Options_Fields $options
+	 * @param Helper_Singleton      $singleton
+	 * @param Helper_Logger         $log
+	 * @param Helper_Notices        $notices
+	 *
+	 * @since 4.2
+	 */
+	public function __construct( $addon_slug, $addon_name, $author, $version, $path_to_main_plugin_file, Helper_Data $data, Helper_Options_Fields $options, Helper_Singleton $singleton, Helper_Logger $log, Helper_Notices $notices ) {
+		$this->slug                        = $addon_slug;
+		$this->name                        = $addon_name;
+		$this->author                      = $author;
+		$this->version                     = $version;
+		$this->addon_path_main_plugin_file = $path_to_main_plugin_file;
+
+		$this->data      = $data;
+		$this->options   = $options;
+		$this->singleton = $singleton;
+		$this->log       = $log->get_logger();
+
+		$this->notices = $notices;
+		$this->notices->init();
+	}
+
+	/**
+	 * @return string Return the plugin slug
+	 *
+	 * @since 4.2
+	 */
+	final public function get_slug() {
+		return $this->slug;
+	}
+
+	/**
+	 * @return string Return the plugin name
+	 *
+	 * @since 4.2
+	 */
+	final public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * @return string Return the plugin version
+	 *
+	 * @since 4.2
+	 */
+	final public function get_version() {
+		return $this->version;
+	}
+
+	/**
+	 * @return string Return the plugin author
+	 *
+	 * @since 4.2
+	 */
+	final public function get_author() {
+		return $this->author;
+	}
+
+	/**
+	 * @return string Return the plugin main file path
+	 *
+	 * @since 4.2
+	 */
+	final public function get_main_plugin_file() {
+		return $this->addon_path_main_plugin_file;
+	}
+
+	/**
+	 * Setup the add-on licensing and initialise any classes
+	 *
+	 * @param array $classes
+	 *
+	 * @since 4.2
+	 */
+	public function init( $classes = [] ) {
+
+		/*
+		 * Register our plugin updater on the admin initialisation action
+		 *
+		 * @Internal Due to WordPress.org rules we cannot initialisation the updater code in the core plugin
+		 *           Add-ons have to initialise this functionality via GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater
+		 */
+		add_action( 'admin_init', [ $this, 'plugin_updater' ] );
+
+		/*
+		 * Automatically register our addon with the main plugin to enable license management in the UI
+		 */
+		$this->register_addon();
+
+		/*
+		 * Register add-on fields (if any) when class uses our extension interface
+		 */
+		if( $this instanceof Helper_Interface_Extension_Settings ) {
+			add_filter( 'gfpdf_settings_extensions', [ $this, 'register_addon_fields'] );
+		}
+
+		/*
+		 * Automatically schedule license checks weekly
+		 */
+		add_action( 'admin_init', [ $this, 'maybe_schedule_license_check' ] );
+		add_action( 'gfpdf_' . $this->get_slug() . '_license_check', [ $this, 'schedule_license_check' ] );
+
+		/*
+		 * Run the init() method (if it exists) for the add-on classes and register them with our internal singleton
+		 */
+		array_walk( $classes, function( $class ) {
+			if ( method_exists( $class, 'init' ) ) {
+				$class->init();
+			}
+
+			$this->singleton->add_class( $class );
+		} );
+
+		$this->log->notice( sprintf( '%s plugin fully loaded', $this->get_name() ) );
+	}
+
+	/**
+	 * This method handles the add-on update code
+	 *
+	 * Due to WordPress.org rules we cannot initialisation the updater code in the core plugin so add-ons that utilise
+	 * this class need to handle that code themselves.
+	 *
+	 * Official Gravity PDF add-ons should initialise the GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater class
+	 * when the add-on license status is set to "active". You can check the status of the plugin
+	 * using the following:
+	 *
+	 * $license_info = $this->get_license_info();
+	 * if ( $license_info['status'] !== 'active' ) {
+	 *    return;
+	 * }
+	 *
+	 * The EDD_SL_Plugin_Updater should be initialised as follows:
+	 *
+	 * new EDD_SL_Plugin_Updater(
+	 *     $this->data->store_url,
+	 *   $this->get_main_plugin_file(),
+	 *   [
+	 *      'version'   => $this->get_version(),
+	 *      'license'   => $license_info['license'],
+	 *      'item_name' => $this->get_addon_name(),
+	 *      'author'    => $this->get_version(),
+	 *      'beta'      => false,
+	 *   ]
+	 * );
+	 *
+	 * @since 4.2
+	 *
+	 * @return void
+	 */
+	public abstract function plugin_updater();
+
+	/**
+	 * Register the add-on with Gravity PDF
+	 *
+	 * @Internal If you don't want the add-on licensing handled automatically in the UI override this method
+	 *
+	 * @since    4.2
+	 */
+	protected function register_addon() {
+		$this->data->add_addon( $this );
+	}
+
+	/**
+	 * When Helper_Interface_Extension_Settings is used we'll auto-register any
+	 * settings the add-on includes
+	 *
+	 * @param array $settings
+	 *
+	 * @return array
+	 *
+	 * @since 4.2
+	 */
+	final public function register_addon_fields( $settings ) {
+		/*
+		 * Because this method is called via a filter it needs to be public
+		 * so we'll check the class impliments the correct interface before
+		 * doing anything.
+		 */
+		if( ! $this instanceof Helper_Interface_Extension_Settings ) {
+			return $settings;
+		}
+
+		$registered_fields = $this->get_global_addon_fields();
+
+		/* Add plugin heading before fields are included */
+		return array_merge( $settings, [
+			$this->get_slug() . '_heading' => [
+				'id'   => $this->get_slug() . '_heading',
+				'type' => 'descriptive_text',
+				'desc' => '<h4 class="section-title">' . $this->get_name() . '</h4>',
+				'class' => 'gfpdf-no-padding',
+			],
+		], $registered_fields );
+	}
+
+	/**
+	 * Get the add-on license information stored in the database (if any)
+	 *
+	 * @Internal If you don't want the add-on licensing handled automatically in the UI override this method
+	 *
+	 * @since    4.2
+	 */
+	public function get_license_info() {
+		$settings = $this->options->get_settings();
+
+		$slug    = $this->get_slug();
+		$license = ( isset( $settings["license_$slug"] ) ) ? $settings["license_$slug"] : '';
+		$status  = ( isset( $settings["license_{$slug}_status"] ) ) ? $settings["license_{$slug}_status"] : '';
+		$message = ( isset( $settings["license_{$slug}_message"] ) ) ? $settings["license_{$slug}_message"] : '';
+
+		$license_details = [
+			'license' => $license,
+			'status'  => $status,
+			'message' => $message,
+		];
+
+		$this->log->notice( 'Get plugin license details', $license_details );
+
+		return $license_details;
+	}
+
+	/**
+	 * Update the add-on license information stored in the database
+	 *
+	 * @param array $license_info
+	 *
+	 * @Internal If you don't want the add-on licensing handled automatically in the UI override this method
+	 *
+	 * @since    4.2
+	 */
+	public function update_license_info( $license_info ) {
+		$settings = $this->options->get_settings();
+		$slug     = $this->get_slug();
+
+		$settings["license_$slug"]           = $license_info['license'];
+		$settings["license_{$slug}_status"]  = $license_info['status'];
+		$settings["license_{$slug}_message"] = $license_info['message'];
+
+		$this->log->notice( 'Update plugin license details', $license_info );
+
+		$this->options->update_settings( $settings );
+	}
+
+	/**
+	 * Remove the license info and keys from the settings
+	 *
+	 * @since 4.2
+	 */
+	public function delete_license_info() {
+		$settings = $this->options->get_settings();
+		$slug     = $this->get_slug();
+
+		unset( $settings["license_$slug"] );
+		unset( $settings["license_{$slug}_status"] );
+		unset( $settings["license_{$slug}_message"] );
+
+		$this->log->notice( 'Delete plugin license details' );
+
+		$this->options->update_settings( $settings );
+	}
+
+	/**
+	 * @return string Returns the current add-on license key
+	 *
+	 * @since 4.2
+	 */
+	final public function get_license_key() {
+		return $this->get_license_info()['license'];
+	}
+
+	/**
+	 * @return string Returns the currenct add-on license status
+	 *
+	 * @since 4.2
+	 */
+	final public function get_license_status() {
+		return $this->get_license_info()['status'];
+	}
+
+	/**
+	 * @return string Returns the current add-on license message
+	 *
+	 * @since 4.2
+	 */
+	final public function get_license_message() {
+		return $this->get_license_info()['message'];
+	}
+
+	/**
+	 * Register our license check event one week into the future.
+	 *
+	 * @Internal Using wp_schedule_single_event() means we don't need to 1. Add a weekly internval to wp_schedule_event()
+	 *           and 2. Need to clear the scheduled hook when the plugin is deactivated
+	 *
+	 * @since    4.2
+	 */
+	final public function maybe_schedule_license_check() {
+		if ( ! wp_next_scheduled( 'gfpdf_' . $this->get_slug() . '_license_check' ) ) {
+			wp_schedule_single_event( strtotime( '+ 1 week' ), 'gfpdf_' . $this->get_slug() . '_license_check' );
+		}
+	}
+
+	/**
+	 * Makes an API call to check the status of the license and updates the license settings
+	 *
+	 * @Internal If you don't want the add-on licensing handled automatically in the UI override this method
+	 *
+	 * @since    4.2
+	 */
+	public function schedule_license_check() {
+		$this->log->notice( 'Check status of plugin license details' );
+
+		$license_info = $this->get_license_info();
+
+		$response = wp_remote_post( $this->data->store_url, [
+			'timeout'   => 15,
+			'sslverify' => false,
+			'body'      => [
+				'edd_action' => 'check_license',
+				'license'    => $license_info['license'],
+				'item_name'  => urlencode( $this->get_name() ),
+				'url'        => home_url(),
+			],
+		] );
+
+		/* If there was a problem with the request we'll try again in an hour */
+		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+			$this->log->error( 'Failed to contact remote API for license status check. Rescheduling.' );
+			wp_schedule_single_event( strtotime( '+ 1 hour' ), 'gfpdf_' . $this->get_slug() . '_license_check' );
+
+			return false;
+		}
+
+		$license_check = json_decode( wp_remote_retrieve_body( $response ) );
+
+		/* License still valid, no need to do anything */
+		if ( isset( $license_check->license ) && $license_check->license === 'valid' ) {
+			$this->log->notice( 'License key still valid.' );
+
+			return false;
+		}
+
+		/* Error occured. Update status and message in the license settings */
+		$possible_responses = $this->data->addon_license_responses( $this->get_name() );
+
+		/* Ensure we have a known error */
+		if ( ! isset( $license_check->error ) || ! isset( $possible_responses[ $license_check->error ] ) ) {
+			$this->log->error( 'Unknown license status returned from remote API' );
+
+			return false;
+		}
+
+		$license_info['status']  = $license_check->error;
+		$license_info['message'] = $possible_responses[ $license_check->error ];
+
+		/* Include the expiry date if license expired */
+		if ( $license_check->error === 'expired' ) {
+			$license_info['message'] = sprintf( $license_info['message'], date_i18n( get_option( 'date_format' ), strtotime( $license_check->expires, current_time( 'timestamp' ) ) ) );
+		}
+
+		$this->log->notice( 'License key no longer valid', $license_info );
+		$this->update_license_info( $license_info );
+
+		return true;
+	}
+}

--- a/src/helper/interface/Helper_Interface_Extension_Settings.php
+++ b/src/helper/interface/Helper_Interface_Extension_Settings.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace GFPDF\Helper;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * A simple interface to standardise how actions and filters should be applied in classes
+ *
+ * @since 4.2
+ */
+interface Helper_Interface_Extension_Settings {
+
+	/**
+	 * Return an array of fields that should be registered in the addon. See Helper_OPtions_Fields for examples of
+	 * defining fields
+	 *
+	 * @Internal All fields should be prefixed with the add-on slug.
+	 *
+	 * @since 4.2
+	 *
+	 * @return array
+	 */
+	public function get_global_addon_fields();
+}

--- a/src/helper/licensing/EDD_SL_Plugin_Updater.php
+++ b/src/helper/licensing/EDD_SL_Plugin_Updater.php
@@ -1,0 +1,522 @@
+<?php
+
+namespace GFPDF\Helper\Licensing;
+
+/**
+ * @package     Gravity PDF
+ * @author      Easy Digital Downloads
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Allows plugins to use their own update API.
+ *
+ * @version 1.6.12
+ */
+class EDD_SL_Plugin_Updater {
+
+	private $api_url = '';
+	private $api_data = [];
+	private $name = '';
+	private $slug = '';
+	private $version = '';
+	private $wp_override = false;
+	private $cache_key = '';
+
+	/**
+	 * Class constructor.
+	 *
+	 * @uses plugin_basename()
+	 * @uses hook()
+	 *
+	 * @param string $_api_url     The URL pointing to the custom API endpoint.
+	 * @param string $_plugin_file Path to the plugin file.
+	 * @param array  $_api_data    Optional data to send with API calls.
+	 */
+	public function __construct( $_api_url, $_plugin_file, $_api_data = null ) {
+
+		global $edd_plugin_data;
+
+		$this->api_url     = trailingslashit( $_api_url );
+		$this->api_data    = $_api_data;
+		$this->name        = plugin_basename( $_plugin_file );
+		$this->slug        = basename( $_plugin_file, '.php' );
+		$this->version     = $_api_data['version'];
+		$this->wp_override = isset( $_api_data['wp_override'] ) ? (bool) $_api_data['wp_override'] : false;
+		$this->beta        = ! empty( $this->api_data['beta'] ) ? true : false;
+		$this->cache_key   = md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) );
+
+		$edd_plugin_data[ $this->slug ] = $this->api_data;
+
+		// Set up hooks.
+		$this->init();
+
+	}
+
+	/**
+	 * Set up WordPress filters to hook into WP's update process.
+	 *
+	 * @uses add_filter()
+	 *
+	 * @return void
+	 */
+	public function init() {
+
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
+		add_filter( 'plugins_api', [ $this, 'plugins_api_filter' ], 10, 3 );
+		remove_action( 'after_plugin_row_' . $this->name, 'wp_plugin_update_row', 10 );
+		add_action( 'after_plugin_row_' . $this->name, [ $this, 'show_update_notification' ], 10, 2 );
+		add_action( 'admin_init', [ $this, 'show_changelog' ] );
+
+	}
+
+	/**
+	 * Check for Updates at the defined API endpoint and modify the update array.
+	 *
+	 * This function dives into the update API just when WordPress creates its update array,
+	 * then adds a custom API call and injects the custom plugin data retrieved from the API.
+	 * It is reassembled from parts of the native WordPress plugin update code.
+	 * See wp-includes/update.php line 121 for the original wp_update_plugins() function.
+	 *
+	 * @uses api_request()
+	 *
+	 * @param array $_transient_data Update array build by WordPress.
+	 *
+	 * @return array Modified update array with custom plugin data.
+	 */
+	public function check_update( $_transient_data ) {
+
+		global $pagenow;
+
+		if ( ! is_object( $_transient_data ) ) {
+			$_transient_data = new stdClass;
+		}
+
+		if ( 'plugins.php' == $pagenow && is_multisite() ) {
+			return $_transient_data;
+		}
+
+		if ( ! empty( $_transient_data->response ) && ! empty( $_transient_data->response[ $this->name ] ) && false === $this->wp_override ) {
+			return $_transient_data;
+		}
+
+		$version_info = $this->get_cached_version_info();
+
+		if ( false === $version_info ) {
+			$version_info = $this->api_request( 'plugin_latest_version', [
+				'slug' => $this->slug,
+				'beta' => $this->beta,
+			] );
+
+			$this->set_version_info_cache( $version_info );
+
+		}
+
+		if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
+
+			if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
+
+				$_transient_data->response[ $this->name ] = $version_info;
+
+			}
+
+			$_transient_data->last_checked           = current_time( 'timestamp' );
+			$_transient_data->checked[ $this->name ] = $this->version;
+
+		}
+
+		return $_transient_data;
+	}
+
+	/**
+	 * show update nofication row -- needed for multisite subsites, because WP won't tell you otherwise!
+	 *
+	 * @param string $file
+	 * @param array  $plugin
+	 */
+	public function show_update_notification( $file, $plugin ) {
+
+		if ( is_network_admin() ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			return;
+		}
+
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		if ( $this->name != $file ) {
+			return;
+		}
+
+		// Remove our filter on the site transient
+		remove_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ], 10 );
+
+		$update_cache = get_site_transient( 'update_plugins' );
+
+		$update_cache = is_object( $update_cache ) ? $update_cache : new stdClass();
+
+		if ( empty( $update_cache->response ) || empty( $update_cache->response[ $this->name ] ) ) {
+
+			$version_info = $this->get_cached_version_info();
+
+			if ( false === $version_info ) {
+				$version_info = $this->api_request( 'plugin_latest_version', [
+					'slug' => $this->slug,
+					'beta' => $this->beta,
+				] );
+
+				$this->set_version_info_cache( $version_info );
+			}
+
+			if ( ! is_object( $version_info ) ) {
+				return;
+			}
+
+			if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
+
+				$update_cache->response[ $this->name ] = $version_info;
+
+			}
+
+			$update_cache->last_checked           = current_time( 'timestamp' );
+			$update_cache->checked[ $this->name ] = $this->version;
+
+			set_site_transient( 'update_plugins', $update_cache );
+
+		} else {
+
+			$version_info = $update_cache->response[ $this->name ];
+
+		}
+
+		// Restore our filter
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_update' ] );
+
+		if ( ! empty( $update_cache->response[ $this->name ] ) && version_compare( $this->version, $version_info->new_version, '<' ) ) {
+
+			// build a plugin list row, with update notification
+			$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
+			# <tr class="plugin-update-tr"><td colspan="' . $wp_list_table->get_column_count() . '" class="plugin-update colspanchange">
+			echo '<tr class="plugin-update-tr" id="' . $this->slug . '-update" data-slug="' . $this->slug . '" data-plugin="' . $this->slug . '/' . $file . '">';
+			echo '<td colspan="3" class="plugin-update colspanchange">';
+			echo '<div class="update-message notice inline notice-warning notice-alt">';
+
+			$changelog_link = self_admin_url( 'index.php?edd_sl_action=view_plugin_changelog&plugin=' . $this->name . '&slug=' . $this->slug . '&TB_iframe=true&width=772&height=911' );
+
+			if ( empty( $version_info->download_link ) ) {
+				printf(
+					__( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s.', 'easy-digital-downloads' ),
+					esc_html( $version_info->name ),
+					'<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
+					esc_html( $version_info->new_version ),
+					'</a>'
+				);
+			} else {
+				printf(
+					__( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s or %5$supdate now%6$s.', 'easy-digital-downloads' ),
+					esc_html( $version_info->name ),
+					'<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
+					esc_html( $version_info->new_version ),
+					'</a>',
+					'<a href="' . esc_url( wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $this->name, 'upgrade-plugin_' . $this->name ) ) . '">',
+					'</a>'
+				);
+			}
+
+			do_action( "in_plugin_update_message-{$file}", $plugin, $version_info );
+
+			echo '</div></td></tr>';
+		}
+	}
+
+	/**
+	 * Updates information on the "View version x.x details" page with custom data.
+	 *
+	 * @uses api_request()
+	 *
+	 * @param mixed  $_data
+	 * @param string $_action
+	 * @param object $_args
+	 *
+	 * @return object $_data
+	 */
+	public function plugins_api_filter( $_data, $_action = '', $_args = null ) {
+
+		if ( $_action != 'plugin_information' ) {
+
+			return $_data;
+
+		}
+
+		if ( ! isset( $_args->slug ) || ( $_args->slug != $this->slug ) ) {
+
+			return $_data;
+
+		}
+
+		$to_send = [
+			'slug'   => $this->slug,
+			'is_ssl' => is_ssl(),
+			'fields' => [
+				'banners' => [],
+				'reviews' => false,
+			],
+		];
+
+		$cache_key = 'edd_api_request_' . md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) );
+
+		// Get the transient where we store the api request for this plugin for 24 hours
+		$edd_api_request_transient = $this->get_cached_version_info( $cache_key );
+
+		//If we have no transient-saved value, run the API, set a fresh transient with the API value, and return that value too right now.
+		if ( empty( $edd_api_request_transient ) ) {
+
+			$api_response = $this->api_request( 'plugin_information', $to_send );
+
+			// Expires in 3 hours
+			$this->set_version_info_cache( $api_response, $cache_key );
+
+			if ( false !== $api_response ) {
+				$_data = $api_response;
+			}
+
+		} else {
+			$_data = $edd_api_request_transient;
+		}
+
+		// Convert sections into an associative array, since we're getting an object, but Core expects an array.
+		if ( isset( $_data->sections ) && ! is_array( $_data->sections ) ) {
+			$new_sections = [];
+			foreach ( $_data->sections as $key => $value ) {
+				$new_sections[ $key ] = $value;
+			}
+
+			$_data->sections = $new_sections;
+		}
+
+		// Convert banners into an associative array, since we're getting an object, but Core expects an array.
+		if ( isset( $_data->banners ) && ! is_array( $_data->banners ) ) {
+			$new_banners = [];
+			foreach ( $_data->banners as $key => $value ) {
+				$new_banners[ $key ] = $value;
+			}
+
+			$_data->banners = $new_banners;
+		}
+
+		return $_data;
+	}
+
+	/**
+	 * Disable SSL verification in order to prevent download update failures
+	 *
+	 * @param array  $args
+	 * @param string $url
+	 *
+	 * @return object $array
+	 */
+	public function http_request_args( $args, $url ) {
+		// If it is an https request and we are performing a package download, disable ssl verification
+		if ( strpos( $url, 'https://' ) !== false && strpos( $url, 'edd_action=package_download' ) ) {
+			$args['sslverify'] = false;
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Calls the API and, if successfull, returns the object delivered by the API.
+	 *
+	 * @uses get_bloginfo()
+	 * @uses wp_remote_post()
+	 * @uses is_wp_error()
+	 *
+	 * @param string $_action The requested action.
+	 * @param array  $_data   Parameters for the API action.
+	 *
+	 * @return false|object
+	 */
+	private function api_request( $_action, $_data ) {
+
+		global $wp_version;
+
+		$data = array_merge( $this->api_data, $_data );
+
+		if ( $data['slug'] != $this->slug ) {
+			return;
+		}
+
+		if ( $this->api_url == trailingslashit( home_url() ) ) {
+			return false; // Don't allow a plugin to ping itself
+		}
+
+		$api_params = [
+			'edd_action' => 'get_version',
+			'license'    => ! empty( $data['license'] ) ? $data['license'] : '',
+			'item_name'  => isset( $data['item_name'] ) ? $data['item_name'] : false,
+			'item_id'    => isset( $data['item_id'] ) ? $data['item_id'] : false,
+			'version'    => isset( $data['version'] ) ? $data['version'] : false,
+			'slug'       => $data['slug'],
+			'author'     => $data['author'],
+			'url'        => home_url(),
+			'beta'       => ! empty( $data['beta'] ),
+		];
+
+		$request = wp_remote_post( $this->api_url, [ 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ] );
+
+		if ( ! is_wp_error( $request ) ) {
+			$request = json_decode( wp_remote_retrieve_body( $request ) );
+		}
+
+		if ( $request && isset( $request->sections ) ) {
+			$request->sections = maybe_unserialize( $request->sections );
+		} else {
+			$request = false;
+		}
+
+		if ( $request && isset( $request->banners ) ) {
+			$request->banners = maybe_unserialize( $request->banners );
+		}
+
+		if ( ! empty( $request->sections ) ) {
+			foreach ( $request->sections as $key => $section ) {
+				$request->$key = (array) $section;
+			}
+		}
+
+		return $request;
+	}
+
+	public function show_changelog() {
+
+		global $edd_plugin_data;
+
+		if ( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' != $_REQUEST['edd_sl_action'] ) {
+			return;
+		}
+
+		if ( empty( $_REQUEST['plugin'] ) ) {
+			return;
+		}
+
+		if ( empty( $_REQUEST['slug'] ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			wp_die( __( 'You do not have permission to install plugin updates', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), [ 'response' => 403 ] );
+		}
+
+		$data         = $edd_plugin_data[ $_REQUEST['slug'] ];
+		$beta         = ! empty( $data['beta'] ) ? true : false;
+		$cache_key    = md5( 'edd_plugin_' . sanitize_key( $_REQUEST['plugin'] ) . '_' . $beta . '_version_info' );
+		$version_info = $this->get_cached_version_info( $cache_key );
+
+		if ( false === $version_info ) {
+
+			$api_params = [
+				'edd_action' => 'get_version',
+				'item_name'  => isset( $data['item_name'] ) ? $data['item_name'] : false,
+				'item_id'    => isset( $data['item_id'] ) ? $data['item_id'] : false,
+				'slug'       => $_REQUEST['slug'],
+				'author'     => $data['author'],
+				'url'        => home_url(),
+				'beta'       => ! empty( $data['beta'] ),
+			];
+
+			$request = wp_remote_post( $this->api_url, [
+				'timeout'   => 15,
+				'sslverify' => false,
+				'body'      => $api_params,
+			] );
+
+			if ( ! is_wp_error( $request ) ) {
+				$version_info = json_decode( wp_remote_retrieve_body( $request ) );
+			}
+
+
+			if ( ! empty( $version_info ) && isset( $version_info->sections ) ) {
+				$version_info->sections = maybe_unserialize( $version_info->sections );
+			} else {
+				$version_info = false;
+			}
+
+			if ( ! empty( $version_info ) ) {
+				foreach ( $version_info->sections as $key => $section ) {
+					$version_info->$key = (array) $section;
+				}
+			}
+
+			$this->set_version_info_cache( $version_info, $cache_key );
+
+		}
+
+		if ( ! empty( $version_info ) && isset( $version_info->sections['changelog'] ) ) {
+			echo '<div style="background:#fff;padding:10px;">' . $version_info->sections['changelog'] . '</div>';
+		}
+
+		exit;
+	}
+
+	public function get_cached_version_info( $cache_key = '' ) {
+
+		if ( empty( $cache_key ) ) {
+			$cache_key = $this->cache_key;
+		}
+
+		$cache = get_option( $cache_key );
+
+		if ( empty( $cache['timeout'] ) || current_time( 'timestamp' ) > $cache['timeout'] ) {
+			return false; // Cache is expired
+		}
+
+		return json_decode( $cache['value'] );
+
+	}
+
+	public function set_version_info_cache( $value = '', $cache_key = '' ) {
+
+		if ( empty( $cache_key ) ) {
+			$cache_key = $this->cache_key;
+		}
+
+		$data = [
+			'timeout' => strtotime( '+3 hours', current_time( 'timestamp' ) ),
+			'value'   => json_encode( $value ),
+		];
+
+		update_option( $cache_key, $data );
+
+	}
+
+}

--- a/src/view/View_Settings.php
+++ b/src/view/View_Settings.php
@@ -200,12 +200,34 @@ class View_Settings extends Helper_Abstract_View {
 			],
 		];
 
+		/* Add License tab if necessary */
+		if ( count( $this->data->addon ) > 0 ) {
+			$navigation[10] = [
+				'name' => esc_html__( 'License', 'gravity-forms-pdf-extended' ),
+				'id'   => 'license',
+			];
+		}
+
+		/* Add Extensions tab if necessary */
+		$settings = $this->options->get_registered_fields();
+		if ( count( $settings['extensions'] ) > 0 ) {
+			$navigation[20] = [
+				'name' => esc_html__( 'Extensions', 'gravity-forms-pdf-extended' ),
+				'id'   => 'extensions',
+			];
+		}
+
 		/**
 		 * Allow additional navigation to be added to the settings page
 		 *
 		 * @since 3.8
 		 */
-		return apply_filters( 'gfpdf_settings_navigation', $navigation );
+		$navigation = apply_filters( 'gfpdf_settings_navigation', $navigation );
+
+		/* sort the navigation by the array key */
+		ksort( $navigation, SORT_NUMERIC );
+
+		return $navigation;
 	}
 
 	/**
@@ -250,6 +272,39 @@ class View_Settings extends Helper_Abstract_View {
 
 		/* load the system status view */
 		$this->load( 'general', $vars );
+	}
+
+	/**
+	 * Pull the license details and displays
+	 *
+	 * @return void
+	 *
+	 * @since 4.2
+	 */
+	public function license() {
+
+		$vars = [
+			'edit_cap'    => $this->gform->has_capability( 'gravityforms_edit_settings' ),
+		];
+
+		/* load the system status view */
+		$this->load( 'license', $vars );
+	}
+
+	/**
+	 * Display the extensions settings page
+	 *
+	 * @return void
+	 *
+	 * @since 4.2
+	 */
+	public function extensions() {
+		$vars = [
+			'edit_cap'    => $this->gform->has_capability( 'gravityforms_edit_settings' ),
+		];
+
+		/* load the system status view */
+		$this->load( 'extensions', $vars );
 	}
 
 	/**

--- a/src/view/html/Settings/extensions.php
+++ b/src/view/html/Settings/extensions.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Extensions Settings View
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+?>
+
+<?php $this->tabs(); ?>
+
+
+<div id="pdfextended-settings">
+	<h3>
+		<span>
+		    <i class="fa fa-cogs"></i>
+			<?php esc_html_e( 'Extensions Settings', 'gravity-forms-pdf-extended' ); ?>
+		</span>
+	</h3>
+
+	<form method="post" action="options.php">
+		<?php settings_fields( 'gfpdf_settings' ); ?>
+
+		<table id="pdf-extensions" class="form-table">
+			<?php do_settings_fields( 'gfpdf_settings_extensions', 'gfpdf_settings_extensions' ); ?>
+		</table>
+
+		<?php
+			if ( $args['edit_cap'] ) {
+				submit_button();
+			}
+		?>
+	</form>
+
+	<?php
+	/* @TODO */
+	do_action( 'gfpdf_post_extensions_settings_page' );
+	?>
+</div>

--- a/src/view/html/Settings/license.php
+++ b/src/view/html/Settings/license.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * License Settings View
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+?>
+
+<?php $this->tabs(); ?>
+
+<div id="pdfextended-settings">
+	<h3>
+		<span>
+		    <i class="fa fa-key"></i>
+			<?php esc_html_e( 'Licensing', 'gravity-forms-pdf-extended' ); ?>
+		</span>
+	</h3>
+
+	<form method="post" action="options.php">
+		<?php settings_fields( 'gfpdf_settings' ); ?>
+
+        <p>
+			<?php esc_html_e( 'To take advantage of automatic updates for your Graivty PDF add-ons, enter your license key(s) below.', 'gravity-forms-pdf-extended' ); ?>
+			<?php esc_html_e( 'Your license key is located in your Purchase Confirmation email you received after you bought the add-on.', 'gravity-forms-pdf-extended' ); ?>
+        </p>
+
+		<table id="pdf-license" class="form-table">
+			<?php do_settings_fields( 'gfpdf_settings_licenses', 'gfpdf_settings_licenses' ); ?>
+		</table>
+
+		<?php
+			if ( $args['edit_cap'] ) {
+				submit_button();
+			}
+		?>
+	</form>
+
+	<em>
+        – <?php esc_html_e( 'By saving your license key(s) you are giving permission for us to poll GravityPDF.com periodically for your current license status and any new plugin updates.', 'gravity-forms-pdf-extended' ); ?>
+    </em>
+
+	<?php
+	/* @TODO */
+	do_action( 'gfpdf_post_license_settings_page' );
+	?>
+</div>

--- a/tests/phpunit/unit-tests/test-addon.php
+++ b/tests/phpunit/unit-tests/test-addon.php
@@ -1,0 +1,331 @@
+<?php
+
+namespace GFPDF\Tests;
+
+use GFPDF\Helper\Helper_Abstract_Addon;
+use GFPDF\Helper\Helper_Interface_Extension_Settings;
+use GFPDF\Helper\Helper_Logger;
+use GFPDF\Helper\Helper_Notices;
+use GFPDF\Helper\Helper_Singleton;
+
+use GPDFAPI;
+
+use WP_UnitTestCase;
+
+/**
+ * Test Gravity PDF Abstract Addon functionality
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.2
+ */
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class Test_Addon
+ *
+ * @package GFPDF\Tests
+ *
+ * @since   4.2
+ *
+ * @group   addon
+ */
+class Test_Addon extends WP_UnitTestCase {
+
+	/**
+	 * Our test class
+	 *
+	 * @var Helper_Abstract_Addon
+	 *
+	 * @since 4.2
+	 */
+	public $addon;
+
+	/**
+	 * The WP Unit Test Set up function
+	 *
+	 * @since 4.2
+	 */
+	public function setUp() {
+		global $gfpdf;
+
+		/* run parent method */
+		parent::setUp();
+
+		/* Setup our test classes */
+		$this->addon = new Addon(
+			'my-custom-plugin',
+			'My Custom Plugin',
+			'Gravity PDF',
+			'1.0',
+			'/path/to/plugin/file.php',
+			GPDFAPI::get_data_class(),
+			GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'my-custom-plugin', 'My Custom Plugin' ),
+			new Helper_Notices()
+		);
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_get_slug() {
+		$this->assertEquals( 'my-custom-plugin', $this->addon->get_slug() );
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_get_name() {
+		$this->assertEquals( 'My Custom Plugin', $this->addon->get_name() );
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_get_version() {
+		$this->assertEquals( '1.0', $this->addon->get_version() );
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_get_author() {
+		$this->assertEquals( 'Gravity PDF', $this->addon->get_author() );
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_get_main_plugin_file() {
+		$this->assertEquals( '/path/to/plugin/file.php', $this->addon->get_main_plugin_file() );
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_init() {
+		global $gfpdf;
+
+		$sub_addon = new SubAddon();
+		$this->assertFalse( $sub_addon->run );
+
+		$this->addon->init( [ $sub_addon, ] );
+
+		$this->assertTrue( $sub_addon->run );
+		$this->assertEquals( 10, has_action( 'admin_init', [ $this->addon, 'plugin_updater' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_init', [ $this->addon, 'maybe_schedule_license_check' ] ) );
+		$this->assertEquals( 10, has_action( 'gfpdf_' . $this->addon->get_slug() . '_license_check', [
+			$this->addon,
+			'schedule_license_check',
+		] ) );
+
+		$this->assertEquals( $this->addon, $gfpdf->data->addon[ $this->addon->get_slug() ] );
+
+		$gfpdf->data->addon = [];
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_license_info() {
+		global $gfpdf;
+
+		$license = $this->addon->get_license_info();
+
+		$this->assertArrayHasKey( 'license', $license );
+		$this->assertArrayHasKey( 'status', $license );
+		$this->assertArrayHasKey( 'message', $license );
+
+		$this->addon->update_license_info( [
+			'license' => 'my key',
+			'status'  => 'active',
+			'message' => 'Success!',
+		] );
+
+		$license = $this->addon->get_license_info();
+
+		$this->assertEquals( 'my key', $license['license'] );
+		$this->assertEquals( 'active', $license['status'] );
+		$this->assertEquals( 'Success!', $license['message'] );
+
+		$this->addon->delete_license_info();
+
+		$settings = $gfpdf->options->get_settings();
+
+		$this->assertArrayNotHasKey( 'license_' . $this->addon->get_slug(), $settings );
+		$this->assertArrayNotHasKey( 'license_' . $this->addon->get_slug() . '_status', $settings );
+		$this->assertArrayNotHasKey( 'license_' . $this->addon->get_slug() . '_message', $settings );
+	}
+
+	/*
+	 * @since 4.2
+	 */
+	public function test_get_license_key() {
+		$this->addon->update_license_info( [
+			'license' => 'my key',
+			'status'  => 'active',
+			'message' => 'Success!',
+		] );
+
+		$this->assertEquals( 'my key', $this->addon->get_license_key() );
+
+		$this->addon->delete_license_info();
+	}
+
+	/*
+	 * @since 4.2
+	 */
+	public function test_get_license_status() {
+		$this->addon->update_license_info( [
+			'license' => 'my key',
+			'status'  => 'active',
+			'message' => 'Success!',
+		] );
+
+		$this->assertEquals( 'active', $this->addon->get_license_status() );
+
+		$this->addon->delete_license_info();
+	}
+
+	/*
+	 * @since 4.2
+	 */
+	public function test_get_license_message() {
+		$this->addon->update_license_info( [
+			'license' => 'my key',
+			'status'  => 'active',
+			'message' => 'Success!',
+		] );
+
+		$this->assertEquals( 'Success!', $this->addon->get_license_message() );
+
+		$this->addon->delete_license_info();
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_maybe_schedule_license_check() {
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_' . $this->addon->get_slug() . '_license_check' ) );
+		$this->addon->maybe_schedule_license_check();
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_' . $this->addon->get_slug() . '_license_check' ) );
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_schedule_license_check() {
+		$ApiResponse = function() {
+			return [
+				'response' => [ 'code' => 201 ],
+			];
+		};
+
+		add_filter( 'pre_http_request', $ApiResponse );
+
+		$this->assertFalse( wp_next_scheduled( 'gfpdf_' . $this->addon->get_slug() . '_license_check' ) );
+		$this->assertFalse( $this->addon->schedule_license_check() );
+		$this->assertNotFalse( wp_next_scheduled( 'gfpdf_' . $this->addon->get_slug() . '_license_check' ) );
+
+		remove_filter( 'pre_http_request', $ApiResponse );
+
+		$ApiResponse = function() {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => json_encode( [ 'error' => 'revoked' ] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $ApiResponse );
+
+		$this->assertTrue( $this->addon->schedule_license_check() );
+		$this->assertEquals( 'Your license key has been disabled', $this->addon->get_license_message() );
+
+		remove_filter( 'pre_http_request', $ApiResponse );
+		$this->addon->delete_license_info();
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_auto_register_global_fields() {
+		global $gfpdf;
+
+		/* Setup our test classes */
+		$addon = new Addon_Fields(
+			'my-custom-plugin2',
+			'My Custom Plugin2',
+			'Gravity PDF',
+			'1.0',
+			'/path/to/plugin2/file.php',
+			GPDFAPI::get_data_class(),
+			GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( 'my-custom-plugin2', 'My Custom Plugin2' ),
+			new Helper_Notices()
+		);
+
+		$addon->init();
+
+		$this->assertEquals( 10, has_filter( 'gfpdf_settings_extensions', [ $addon, 'register_addon_fields' ] ) );
+
+		$settings = $gfpdf->options->get_registered_fields();
+		$this->assertArrayHasKey( 'addon_field', $settings['extensions'] );
+
+		$gfpdf->data->addon = [];
+	}
+}
+
+/**
+ * Test class which extends Helper_Abstract_Addon
+ */
+class Addon extends Helper_Abstract_Addon {
+	public function plugin_updater() {
+	}
+}
+
+class Addon_Fields extends Helper_Abstract_Addon implements Helper_Interface_Extension_Settings {
+	public function plugin_updater() {
+
+	}
+
+	public function get_global_addon_fields() {
+		return [
+			'addon_field' => [
+				'id'   => 'addon_field',
+				'name' => 'Addon Field',
+				'type' => 'text',
+			],
+		];
+	}
+}
+
+class SubAddon {
+	public $run = false;
+
+	public function init() {
+		$this->run = true;
+	}
+}

--- a/tests/phpunit/unit-tests/test-ajax.php
+++ b/tests/phpunit/unit-tests/test-ajax.php
@@ -717,4 +717,29 @@ class Test_PDF_Ajax extends WP_Ajax_UnitTestCase {
 
 		$this->assertNotFalse( $this->_last_response, '<optgroup label="Core">' );
 	}
+
+	public function test_ajax_process_license_deactivation() {
+		/* set up our post data and role */
+		$this->_setRole( 'administrator' );
+
+		/* Check for nonce failure */
+		try {
+			$this->_handleAjax( 'gfpdf_deactivate_license' );
+		} catch ( WPAjaxDieStopException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$this->assertEquals( '401', $e->getMessage() );
+
+		/* Setup a bad request */
+		$_POST['nonce'] = wp_create_nonce( 'gfpdf_deactivate_license' );
+
+		try {
+			$this->_handleAjax( 'gfpdf_deactivate_license' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			/* do nothing (error expected) */
+		}
+
+		$this->assertEquals( 'An error occurred during deactivation, please try again', json_decode( $this->_last_response )->error );
+	}
 }

--- a/tests/phpunit/unit-tests/test-bootstrap.php
+++ b/tests/phpunit/unit-tests/test-bootstrap.php
@@ -92,8 +92,6 @@ class Test_Bootstrap extends WP_UnitTestCase {
 			$this->loader,
 			'auto_noconflict_styles',
 		] ) );
-
-		$this->assertEquals( 10, has_filter( 'gform_logging_supported', [ $this->loader, 'add_gf_logger' ] ) );
 	}
 
 	/**
@@ -216,15 +214,6 @@ class Test_Bootstrap extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Check we're registering Gravity PDF with the Gravity Forms logger
-	 *
-	 * @since 4.0
-	 */
-	public function test_add_gf_logger() {
-		$this->assertArrayHasKey( 'gravity-pdf', $this->loader->add_gf_logger( [] ) );
-	}
-
-	/**
 	 * Test backwards compatibility function for our v3 default PDF templates
 	 *
 	 * @since 4.0
@@ -254,6 +243,16 @@ class Test_Bootstrap extends WP_UnitTestCase {
 		$this->assertTrue( $settings['html_field'] );
 		$this->assertFalse( $settings['page_names'] );
 		$this->assertFalse( $settings['section_content'] );
+	}
 
+	/**
+	 * @since 4.2
+	 */
+	public function test_licensing_requirements() {
+		global $gfpdf;
+
+		$this->assertTrue( class_exists( '\GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater' ) );
+		$this->assertTrue( is_array( $gfpdf->data->addon ) );
+		$this->assertNotEmpty( $gfpdf->data->store_url );
 	}
 }

--- a/tests/phpunit/unit-tests/test-logger.php
+++ b/tests/phpunit/unit-tests/test-logger.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace GFPDF\Tests;
+
+use GFPDF\Helper\Helper_logger;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2016, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.2
+ */
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2016, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Test the logger helper works correctly
+ *
+ * @since 4.2
+ * @group logger
+ */
+class Test_Logger extends WP_UnitTestCase {
+
+	/**
+	 * @var Helper_Logger
+	 *
+	 * @since 4.2
+	 */
+	private $logger;
+
+	/**
+	 * @since 4.2
+	 */
+	public function setUp() {
+		/* run parent method */
+		parent::setUp();
+
+		$this->logger = new Helper_Logger( 'slug', 'Name' );
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_logger() {
+		$this->assertInstanceOf( '\Monolog\Logger', $this->logger->get_logger() );
+		$this->assertEquals( 10, has_filter( 'gform_logging_supported', [
+			$this->logger,
+			'register_logger_with_gf',
+		] ) );
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_register_gf_logger() {
+		$results = $this->logger->register_logger_with_gf( [] );
+		$this->assertArrayHasKey( 'slug', $results );
+		$this->assertEquals( 'Name', $results['slug'] );
+	}
+}

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -128,6 +128,21 @@ class Test_Options_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @since 4.2
+	 */
+	public function test_update_settings() {
+		$oldsettings = $settings = $this->options->get_settings();
+
+		$this->assertEquals( 'custom', $settings['default_pdf_size'] );
+		$settings['default_pdf_size'] = 'Letter';
+		$this->options->update_settings( $settings );
+
+		$settings = $this->options->get_settings();
+		$this->assertEquals( 'Letter', $settings['default_pdf_size'] );
+		$this->options->update_settings( $oldsettings );
+	}
+
+	/**
 	 * Check if Gravity Forms PDF settings getter function works correctly
 	 *
 	 * @since 4.0
@@ -1143,5 +1158,19 @@ class Test_Options_API extends WP_UnitTestCase {
 				'',
 			],
 		];
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	public function test_get_form_value_licensing() {
+		$results = $this->options->get_form_value( [
+			'id' => 'test',
+			'type' => 'license'
+		] );
+
+		$this->assertArrayHasKey( 'key', $results );
+		$this->assertArrayHasKey( 'msg', $results );
+		$this->assertArrayHasKey( 'status', $results );
 	}
 }


### PR DESCRIPTION
Automatically handle license checks and include abstract class for common add-on functionality.

Changes include:
- Abstract the logger methods for use in add-ons and include unit tests
- Fix timezone offset issue with Monolog
- Add logging support to add-ons
- Add notice support for add-ons
- Added Global Extensions settings support
- Add automated license management 