### PR TITLE
Merge Tag Initialisation Refractor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
   - php: 5.4
     env: WP_VERSION=latest WP_MULTISITE=1
   - php: 7.0
+    env: WP_VERSION=4.7 WP_MULTISITE=0
+  - php: 7.0
     env: WP_VERSION=4.6 WP_MULTISITE=0
   - php: 7.0
     env: WP_VERSION=4.5 WP_MULTISITE=0

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Plugin URI: https://gravitypdf.com/
 Donate link: https://gravitypdf.com/donate-to-plugin/
 Tags: gravity, forms, pdf, automation, attachment, email
 Requires at least: 4.4
-Tested up to: 4.7
+Tested up to: 4.8
 Stable tag: 4.2.0-beta1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl.txt

--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -102,12 +102,14 @@
         }
 
         /*
+         * Backwards compatibility support prior to Gravity Forms 2.3
+         *
          * Override the gfMergeTagsObj.getTargetElement prototype to better handle CSS special characters in selectors
          * This is because Gravity Forms doesn't correctly espace meta-characters such a [ and ] (which we use extensively as IDs)
          * This functionality assists with the merge tag loader
          * @since 4.0
          */
-        if (typeof form != 'undefined') {
+        if (window.gfMergeTags && typeof form != 'undefined') {
           window.gfMergeTags.getTargetElement = this.resetGfMergeTags
         }
       }
@@ -678,9 +680,12 @@
             /* Only process if the response is valid */
             if (response.fields) {
 
-              /* Remove any existing mergetag-marked inputs so they aren't processed twice after we add our new fields to the DOM */
-              $('.merge-tag-support').removeClass('merge-tag-support')
-              $('.all-merge-tags a.open-list').off('click')
+              /* Backwards compatibility support prior to Gravity Forms 2.3 */
+              if (window.gfMergeTags) {
+                /* Remove any existing mergetag-marked inputs so they aren't processed twice after we add our new fields to the DOM */
+                $('.merge-tag-support').removeClass('merge-tag-support')
+                $('.all-merge-tags a.open-list').off('click')
+              }
 
               /* Remove any previously loaded editors to prevent conflicts loading an editor with same name */
               $.each(response.editors, function (index, value) {
@@ -926,9 +931,18 @@
        * @since 4.0
        */
       this.doMergetags = function () {
-        if (typeof form != 'undefined') {
+
+        /* Backwards compatibility support prior to Gravity Forms 2.3 */
+        if (window.gfMergeTags && typeof form != 'undefined') {
           window.gfMergeTags = new gfMergeTagsObj(form)
           window.gfMergeTags.getTargetElement = this.resetGfMergeTags
+        }
+
+        /* Gravity Forms 2.3+ Merge tag support */
+        if (!window.gfMergeTags && typeof form != 'undefined' && $('.merge-tag-support').length >= 0) {
+          $('.merge-tag-support').each(function () {
+            new gfMergeTagsObj(form, $(this))
+          });
         }
       }
 


### PR DESCRIPTION
Add support for refractored mergetag JS code coming in Gravity Forms 2.3.

We've also ensured backwards compatibility with older versions of Gravity Forms too. When the minimum version requirement is bumped to 2.3+ we can remove that extra code.

See https://github.com/gravityforms/gravityforms/pull/58 for more details.