### PR TITLE
Merge tag refractor

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ var gulp = require('gulp'),
 /* Minify our CSS */
 gulp.task('minify', function () {
   return gulp.src('src/assets/css/*.css')
-    .pipe(cleanCSS({target: 'dist/assets/css'}))
+    .pipe(cleanCSS())
     .pipe(rename({
       suffix: '.min'
     }))
@@ -28,7 +28,7 @@ gulp.task('compress', function () {
 
 /* Generate the latest language files */
 gulp.task('language', function () {
-  return gulp.src('**/*.php')
+  return gulp.src(['src/**/*.php', '*.php'])
     .pipe(wpPot({
       domain: 'gravity-forms-pdf-extended',
       package: 'Gravity PDF'
@@ -41,6 +41,4 @@ gulp.task('watch', function () {
   watch('src/assets/css/*.css', function () { gulp.start('minify') })
 })
 
-gulp.task('default', function () {
-  gulp.start('language', 'minify', 'compress')
-})
+gulp.task('default', ['language', 'minify', 'compress'] )

--- a/src/assets/css/gfpdf-admin-styles.css
+++ b/src/assets/css/gfpdf-admin-styles.css
@@ -9,7 +9,7 @@
 	.notice.gfpdf-alert-mascot {
 		padding-left: 145px !important;
 
-		background-image: url( ../images/paws-with-logo-small.png);
+		background-image: url(../../../src/assets/images/paws-with-logo-small.png);
 		background-position: 10px 50%;
 		background-repeat: no-repeat;
 		background-size: 125px;

--- a/src/assets/css/gfpdf-styles.css
+++ b/src/assets/css/gfpdf-styles.css
@@ -13,7 +13,7 @@
 }
 
 .gfpdf-badge {
-	background: url("../images/gravitypdf-globe-black.png") no-repeat 50% 5px;
+	background: url("../../../src/assets/images/gravitypdf-globe-black.png") no-repeat 50% 5px;
 	color: #333;
 	display: inline-block;
 	font-size: 14px;

--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -102,12 +102,14 @@
         }
 
         /*
+         * Backwards compatibility support prior to Gravity Forms 2.3
+         *
          * Override the gfMergeTagsObj.getTargetElement prototype to better handle CSS special characters in selectors
          * This is because Gravity Forms doesn't correctly espace meta-characters such a [ and ] (which we use extensively as IDs)
          * This functionality assists with the merge tag loader
          * @since 4.0
          */
-        if (typeof form != 'undefined') {
+        if (window.gfMergeTags && typeof form != 'undefined') {
           window.gfMergeTags.getTargetElement = this.resetGfMergeTags
         }
       }
@@ -678,9 +680,12 @@
             /* Only process if the response is valid */
             if (response.fields) {
 
-              /* Remove any existing mergetag-marked inputs so they aren't processed twice after we add our new fields to the DOM */
-              $('.merge-tag-support').removeClass('merge-tag-support')
-              $('.all-merge-tags a.open-list').off('click')
+              /* Backwards compatibility support prior to Gravity Forms 2.3 */
+              if (window.gfMergeTags) {
+                /* Remove any existing mergetag-marked inputs so they aren't processed twice after we add our new fields to the DOM */
+                $('.merge-tag-support').removeClass('merge-tag-support')
+                $('.all-merge-tags a.open-list').off('click')
+              }
 
               /* Remove any previously loaded editors to prevent conflicts loading an editor with same name */
               $.each(response.editors, function (index, value) {
@@ -926,9 +931,18 @@
        * @since 4.0
        */
       this.doMergetags = function () {
-        if (typeof form != 'undefined') {
+
+        /* Backwards compatibility support prior to Gravity Forms 2.3 */
+        if (window.gfMergeTags && typeof form != 'undefined') {
           window.gfMergeTags = new gfMergeTagsObj(form)
           window.gfMergeTags.getTargetElement = this.resetGfMergeTags
+        }
+
+        /* Gravity Forms 2.3+ Merge tag support */
+        if (!window.gfMergeTags && typeof form != 'undefined' && $('.merge-tag-support').length >= 0) {
+          $('.merge-tag-support').each(function () {
+            new gfMergeTagsObj(form, $(this))
+          });
         }
       }
 


### PR DESCRIPTION
Gravity Forms 2.3 has updated how their merge tags are initialised. Add supprt for this new technique and ensure backwards compatibility until we bump the Gravity Forms minimum version.