### PR TITLE
Ensure no errors occur when using the JS History object during testing

### DIFF
--- a/tests/mocha/unit-tests/components/template.activate.button.spec.js
+++ b/tests/mocha/unit-tests/components/template.activate.button.spec.js
@@ -9,7 +9,7 @@ describe('<TemplateActivateButton />', () => {
   let History = createHistory()
 
   beforeEach(function () {
-    History.push('/template')
+    History.replace('/template')
   })
 
 

--- a/tests/mocha/unit-tests/components/template.button.spec.js
+++ b/tests/mocha/unit-tests/components/template.button.spec.js
@@ -9,7 +9,7 @@ describe('<TemplateButton />', () => {
   let History = createHistory()
 
   beforeEach(function () {
-    History.push('/')
+    History.replace('/')
   })
 
   it('a button should be displayed', () => {

--- a/tests/mocha/unit-tests/components/template.close.dialog.spec.js
+++ b/tests/mocha/unit-tests/components/template.close.dialog.spec.js
@@ -9,7 +9,7 @@ describe('<TemplateCloseDialog />', () => {
   let History = createHistory()
 
   beforeEach(function () {
-    History.push('/templates/zadani')
+    History.replace('/templates/zadani')
   })
 
   it('a button should be displayed', () => {


### PR DESCRIPTION
Resolves #649 