### PR TITLE
If master password is empty, set to `null`

### DIFF
--- a/src/helper/Helper_PDF.php
+++ b/src/helper/Helper_PDF.php
@@ -896,7 +896,12 @@ class Helper_PDF {
 
 			$password        = ( isset( $this->settings['password'] ) ) ? $this->gform->process_tags( $this->settings['password'], $this->form, $this->entry ) : '';
 			$privileges      = ( isset( $this->settings['privileges'] ) ) ? $this->settings['privileges'] : [];
-			$master_password = ( isset( $this->settings['master_password'] ) ) ? $this->gform->process_tags( $this->settings['master_password'], $this->form, $this->entry ) : null;
+			$master_password = ( isset( $this->settings['master_password'] ) ) ? $this->gform->process_tags( $this->settings['master_password'], $this->form, $this->entry ) : '';
+
+			/* GitHub Issue #624 - Fix issue with possibility of blank master password being set */
+			if ( strlen( $master_password ) === 0 ) {
+				$master_password = null;
+			}
 
 			$this->mpdf->SetProtection( $privileges, $password, $master_password, 128 );
 		}


### PR DESCRIPTION
The recent change in how the master password is handled in Gravity PDF 4.2 causes the master password to be set to blank which causes issues in some PDF clients.

If the master password is blank, set to null so it's auto-generated by Mpdf.

Fixes #662