### PR TITLE
Add PDF/Email background processing on form submission and the resend notification feature.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     		"GFPDF\\Controller\\": "src/controller/",
     		"GFPDF\\Model\\": "src/model/",
     		"GFPDF\\View\\": "src/view/",
+    		"GFPDF\\Statics\\": "src/statics/",
     		"GFPDF\\Helper\\": ["src/helper/", "src/helper/abstract/", "src/helper/interface/", "src/helper/trait/"],
     		"GFPDF\\Helper\\Licensing\\": "src/helper/licensing/",
     		"GFPDF\\Helper\\Fields\\": "src/helper/fields/",

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -231,6 +231,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$this->actions();
 		$this->template_manager();
 		$this->load_core_font_handler();
+		$this->async_pdfs();
 
 		/* Add localisation support */
 		$this->add_localization_support();
@@ -837,6 +838,24 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		$class->init();
 
+		$this->singleton->add_class( $class );
+	}
+
+	/**
+	 * Initialise our background PDF processing handler
+	 *
+	 * @since 4.4
+	 *
+	 * @return void
+	 */
+	public function async_pdfs() {
+		$queue = new Helper\Helper_Pdf_Queue( $this->log );
+		$model_pdf = $this->singleton->get_class( 'Model_PDF' );
+		$class = new Controller\Controller_Pdf_Queue( $queue, $model_pdf, $this->log );
+
+		$class->init();
+
+		$this->singleton->add_class( $queue );
 		$this->singleton->add_class( $class );
 	}
 

--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -145,9 +145,6 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_action( 'gform_entries_first_column_actions', [ $this->model, 'view_pdf_entry_list' ], 10, 4 );
 		add_action( 'gform_entry_info', [ $this->model, 'view_pdf_entry_detail' ], 10, 2 );
 
-		/* Add save PDF filter */
-		add_action( 'gform_after_submission', [ $this->model, 'maybe_save_pdf' ], 10, 2 );
-
 		/* Clean-up actions */
 		add_action( 'gform_after_submission', [ $this->model, 'cleanup_pdf' ], 9999, 2 );
 		add_action( 'gform_after_update_entry', [ $this->model, 'cleanup_pdf_after_submission' ], 9999, 2 );

--- a/src/controller/Controller_Pdf_Queue.php
+++ b/src/controller/Controller_Pdf_Queue.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use GFPDF\Model\Model_PDF;
+use GFPDF\Helper\Helper_Abstract_Controller;
+use GFPDF\Helper\Helper_Interface_Actions;
+use GFPDF\Helper\Helper_Interface_Filters;
+use GFPDF\Helper\Helper_Pdf_Queue;
+
+use Psr\Log\LoggerInterface;
+use GFCommon;
+
+/**
+ * Save Core Fonts Controller
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2017, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.4
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2017, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class Controller_Save_Core_Fonts
+ *
+ * @package GFPDF\Controller
+ *
+ * @since   4.4
+ */
+class Controller_Pdf_Queue extends Helper_Abstract_Controller implements Helper_Interface_Actions, Helper_Interface_Filters {
+
+	/**
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
+	 *
+	 * @var \GFPDF\Helper\Helper_Form
+	 *
+	 * @since 4.4
+	 */
+	protected $gform;
+
+	/**
+	 * Holds our log class
+	 *
+	 * @var LoggerInterface
+	 *
+	 * @since 4.4
+	 */
+	protected $log;
+
+	/**
+	 * @var Model_PDF|\GFPDF\Model\Model_PDF
+	 *
+	 * @since 4.4
+	 */
+	protected $model_pdf;
+
+	/**
+	 * @var \GFPDF\Helper\Helper_Pdf_Queue
+	 *
+	 * @since 4.4
+	 */
+	protected $queue;
+
+	/**
+	 * Set up our dependancies
+	 *
+	 * @param \GFPDF\Helper\Helper_Pdf_Queue
+	 * @param \GFPDF\Helper\_Queue_Callbacks
+	 * @param \GFPDF\Model\Model_PDF $model_pdf
+	 * @param LoggerInterface        $log Our logger class
+	 *
+	 * @since 4.4
+	 */
+	public function __construct( Helper_Pdf_Queue $queue, Model_PDF $model_pdf, LoggerInterface $log ) {
+		/* Assign our internal variables */
+		$this->log       = $log;
+		$this->model_pdf = $model_pdf;
+		$this->queue     = $queue;
+	}
+
+	/**
+	 * Initialise our class defaults
+	 *
+	 * @since 4.4
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->add_actions();
+		$this->add_filters();
+
+		//$this->queue->clear();
+	}
+
+	/**
+	 * Apply any actions needed for the welcome page
+	 *
+	 * @since 4.4
+	 *
+	 * @return void
+	 */
+	public function add_actions() {
+		add_action( 'gform_after_submission', [ $this, 'queue_async_form_submission_tasks' ], 5, 2 );
+
+		add_action( 'gform_after_resend_notification', [ $this, 'queue_async_resend_notification_tasks' ], 10, 3 );
+		add_action( 'gform_resend_notifications_complete', [ $this, 'queue_dispatch_resend_notification_tasks' ] );
+	}
+
+	/**
+	 * @since 4.4
+	 *
+	 * @return void
+	 */
+	public function add_filters() {
+		add_filter( 'gform_disable_notification', [ $this, 'maybe_disable_submission_notifications' ], 10, 4 );
+
+		add_filter( 'gform_disable_resend_notification', [ $this, 'maybe_disable_resend_notifications' ], 10, 4 );
+	}
+
+	/**
+	 * Only process notifications that occur on form submission
+	 *
+	 * @param bool  $is_disabled
+	 * @param array $notification
+	 * @param array $form
+	 * @param array $entry
+	 *
+	 * @return bool
+	 *
+	 * @since 4.4
+	 */
+	public function maybe_disable_submission_notifications( $is_disabled, $notification, $form, $entry ) {
+		if ( empty( $notification['event'] ) || $notification['event'] !== 'form_submission' ) {
+			return $is_disabled;
+		}
+
+		return $this->do_we_disable_notification( $is_disabled, $notification, $form, $entry );
+	}
+
+	/**
+	 * Only process notifications that occur when resending notifications
+	 *
+	 * @param bool  $is_disabled
+	 * @param array $notification
+	 * @param array $form
+	 * @param array $entry
+	 *
+	 * @return bool
+	 *
+	 * @since 4.4
+	 */
+	public function maybe_disable_resend_notifications( $is_disabled, $notification, $form, $entry ) {
+		return $this->do_we_disable_notification( $is_disabled, $notification, $form, $entry );
+	}
+
+	/**
+	 * Check if there are any PDFs that need to be sent with the notifications and disable so we can process in the background
+	 *
+	 * @param bool  $default
+	 * @param array $notification
+	 * @param array $form
+	 * @param array $entry
+	 *
+	 * @return bool
+	 *
+	 * @since 4.4
+	 */
+	public function do_we_disable_notification( $default, $notification, $form, $entry ) {
+		$pdfs = ( isset( $form['gfpdf_form_settings'] ) ) ? $this->model_pdf->get_active_pdfs( $form['gfpdf_form_settings'], $entry ) : [];
+
+		/* Disable notification if PDF needs to be attached to it */
+		foreach ( $pdfs as $pdf ) {
+			if ( $this->model_pdf->maybe_attach_to_notification( $notification, $pdf, $entry, $form ) ) {
+				$this->log->addNotice( 'Gravity Forms Notification Delayed for Async Processing', [
+					'notification' => $notification,
+					'pdf'          => $pdf,
+				] );
+
+				return true;
+			}
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Queue all PDFs/Notifications during form submission and dispatch
+	 *
+	 * @param $entry
+	 * @param $form
+	 *
+	 * @since 4.4
+	 */
+	public function queue_async_form_submission_tasks( $entry, $form ) {
+		/* Push and trigger async queue */
+		$this->queue
+			->push_to_queue( $this->get_queue_tasks( $entry, $form ) )
+			->save()
+			->dispatch();
+	}
+
+	/**
+	 * Push jobs to our background process queue when resending notifications
+	 *
+	 * @param $notification
+	 * @param $form
+	 * @param $entry
+	 *
+	 * @since 4.4
+	 */
+	public function queue_async_resend_notification_tasks( $notification, $form, $entry ) {
+		add_filter( 'gfpdf_maybe_always_save_pdf', '__return_false' );
+
+		/* Push to async queue */
+		$this->queue->push_to_queue( $this->get_queue_tasks( $entry, $form, [ $notification ] ) );
+
+		remove_filter( 'gfpdf_maybe_always_save_pdf', '__return_false' );
+	}
+
+	/**
+	 * If we have any jobs in our background process queue after resending the notifications, dispatch them
+	 *
+	 * @since 4.4
+	 */
+	public function queue_dispatch_resend_notification_tasks() {
+		if ( count( $this->queue->get_data() ) > 0 ) {
+			$this->queue
+				->save()
+				->dispatch();
+		}
+	}
+
+	/**
+	 * Create and dispatch an async queue that will generate the PDFs and send the submission notification(s)
+	 * Filters are also available for devs to run processes before or after the tasks
+	 *
+	 * We use static callbacks to keep the queue database size small (queues are stored in the options table)
+	 *
+	 * @param $entry
+	 * @param $form
+	 * @param $notifications
+	 *
+	 * @since 4.4
+	 *
+	 * @return array
+	 */
+	protected function get_queue_tasks( $entry, $form, $notifications = [] ) {
+		/* Check if the PDF should be generated  */
+		$pdfs = ( isset( $form['gfpdf_form_settings'] ) ) ? $this->model_pdf->get_active_pdfs( $form['gfpdf_form_settings'], $entry ) : [];
+
+		$queue_data = apply_filters( 'gfpdf_queue_initialise', [], $entry, $form );
+
+		/* Queue up the PDF generation callback */
+		if ( count( $pdfs ) > 0 ) {
+			$notifications = ( count( $notifications ) > 0 ) ? $notifications : $this->get_active_notifications( $form, $entry );
+
+			$pdf_queue_data          = $this->queue_pdfs( $notifications, $pdfs, $form, $entry );
+			$notification_queue_data = $this->queue_notifications( $notifications, $pdfs, $form, $entry );
+
+			$queue_data = array_merge( $queue_data, $pdf_queue_data, $notification_queue_data );
+
+			/* Queue up a cleanup callback */
+			if ( count( $pdf_queue_data ) > 0 ) {
+				$queue_data[] = [
+					'id'   => 'cleanup-pdf-' . $form['id'] . '-' . $entry['id'],
+					'func' => '\GFPDF\Statics\Queue_Callbacks::cleanup_pdfs',
+					'args' => [ $form['id'], $entry['id'] ],
+				];
+			}
+		}
+
+		$queue_data = apply_filters( 'gfpdf_queue_pre_dispatch', $queue_data, $entry, $form );
+
+		$this->log->addNotice( 'PDF Background Processing Queue', [
+			'queue' => $queue_data,
+		] );
+
+		return $queue_data;
+	}
+
+	/**
+	 * Get all active notifications who's conditional logic has been met
+	 *
+	 * @param $form
+	 * @param $entry
+	 *
+	 * @return array
+	 *
+	 * @since 4.4
+	 */
+	protected function get_active_notifications( $form, $entry ) {
+		$notifications = GFCommon::get_notifications_to_send( 'form_submission', $form, $entry );
+		$notifications = array_filter( $notifications, function( $notification ) {
+			return ( ! isset( $notification['isActive'] ) || $notification['isActive'] );
+		} );
+
+		return $notifications;
+	}
+
+	/**
+	 * Queue up the PDFs that should always be saved to disk, or should be attached to one of the notifications
+	 *
+	 * @param array $notifications
+	 * @param array $pdfs
+	 * @param array $form
+	 * @param array $entry
+	 *
+	 * @return array
+	 *
+	 * @since 4.4
+	 */
+	protected function queue_pdfs( $notifications, $pdfs, $form, $entry ) {
+		$queue_data = apply_filters( 'gfpdf_queue_pre_pdf_creation', [], $entry, $form );
+
+		foreach ( $pdfs as $pdf ) {
+			foreach ( $notifications as $notification ) {
+				if ( $this->model_pdf->maybe_always_save_pdf( $pdf ) || $this->model_pdf->maybe_attach_to_notification( $notification, $pdf, $entry, $form ) ) {
+					$queue_data[] = [
+						'id'   => $this->get_queue_id( $form, $entry, $pdf ),
+						'func' => '\GFPDF\Statics\Queue_Callbacks::create_pdf',
+						'args' => [ $entry['id'], $pdf['id'] ],
+					];
+
+					/* Only queue each PDF once (even if attached to multiple notifications) */
+					break;
+				}
+			}
+		}
+
+		$queue_data = apply_filters( 'gfpdf_queue_post_pdf_creation', $queue_data, $entry, $form );
+
+		return $queue_data;
+	}
+
+	/**
+	 * Queue up the notifications that we delayed because PDFs needed to be attached to them
+	 *
+	 * @param array $notifications
+	 * @param array $pdfs
+	 * @param array $form
+	 * @param array $entry
+	 *
+	 * @return array
+	 *
+	 * @since 4.4
+	 */
+	protected function queue_notifications( $notifications, $pdfs, $form, $entry ) {
+
+		$queue_data = apply_filters( 'gfpdf_queue_pre_notifications', [], $entry, $form );
+
+		foreach ( $notifications as $notification ) {
+			foreach ( $pdfs as $pdf ) {
+				if ( $this->model_pdf->maybe_attach_to_notification( $notification, $pdf, $entry, $form ) ) {
+					$queue_data[] = [
+						'id'   => $this->get_queue_id( $form, $entry, $pdf ) . '-' . $notification['id'],
+						'func' => '\GFPDF\Statics\Queue_Callbacks::send_notification',
+						'args' => [ $form['id'], $entry['id'], $notification ],
+					];
+
+					/* Only queue each notification once (even if there are multiple PDFs) */
+					break;
+				}
+			}
+		}
+
+		$queue_data = apply_filters( 'gfpdf_queue_post_notifications', $queue_data, $entry, $form );
+
+		return $queue_data;
+	}
+
+	/**
+	 * Return the PDF queue ID used for logging
+	 *
+	 * @param $form
+	 * @param $entry
+	 * @param $pdf
+	 *
+	 * @return string
+	 *
+	 * @since 4.4
+	 */
+	protected function get_queue_id( $form, $entry, $pdf ) {
+		return $form['id'] . '-' . $entry['id'] . '-' . $pdf['id'];
+	}
+}

--- a/src/helper/Helper_Pdf_Queue.php
+++ b/src/helper/Helper_Pdf_Queue.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace GFPDF\Helper;
+
+use Psr\Log\LoggerInterface;
+
+use GFCommon;
+use GF_Background_Process;
+
+use Exception;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2017, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.4
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2017, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+if ( ! class_exists( 'WP_Async_Request' ) ) {
+	require_once( GFCommon::get_base_path() . '/includes/libraries/wp-async-request.php' );
+}
+
+if ( ! class_exists( 'GF_Background_Process' ) ) {
+	require_once( GFCommon::get_base_path() . '/includes/libraries/gf-background-process.php' );
+}
+
+/**
+ * Class Helper_Pdf_Queue
+ *
+ * @package GFPDF\Helper
+ */
+class Helper_Pdf_Queue extends GF_Background_Process {
+
+	/**
+	 * Holds our log class
+	 *
+	 * @var LoggerInterface
+	 *
+	 * @since 4.4
+	 */
+	protected $log;
+
+	/**
+	 * @var string
+	 *
+	 * @since 4.4
+	 */
+	protected $action = 'gravitypdf';
+
+	/**
+	 * Helper_Pdf_Queue constructor.
+	 *
+	 * @param LoggerInterface $log
+	 *
+	 * @since 4 .4
+	 */
+	public function __construct( LoggerInterface $log ) {
+		parent::__construct();
+
+		$this->log = $log;
+	}
+
+	public function clear() {
+		var_dump($this->is_process_running());
+		var_dump($this->is_queue_empty());
+		$this->cancel_process();
+		$this->unlock_process();
+		exit;
+	}
+
+	/**
+	 * Add a getter for the stored async data
+	 *
+	 * @return array
+	 *
+	 * @since 4.4
+	 */
+	public function get_data() {
+		return $this->data;
+	}
+
+	/**
+	 * Process our PDF queue as a background process
+	 *
+	 * @param array $callbacks [ 'func' => callback, 'args' => array ]
+	 *
+	 * @return array|false Return false if our queue has completed, otherwise return the remaining callbacks
+	 *
+	 * @since 4.4
+	 */
+	public function task( $callbacks ) {
+		$callback = array_shift( $callbacks );
+
+		$this->log->addNotice( sprintf(
+			'Begin async PDF task for %s',
+			$callback['id']
+		) );
+
+		if ( is_callable( $callback['func'] ) ) {
+			try {
+				/* Call our use function and pass in any arguments */
+				$args = ( isset( $callback['args'] ) && is_array( $callback['args'] ) ) ? $callback['args'] : [];
+				call_user_func_array( $callback['func'], $args );
+			} catch ( Exception $e ) {
+
+				/* Log Error */
+				$this->log->addError( sprintf(
+					'Async PDF task error for %s',
+					$callback['id']
+				), [ 'args' => ( isset( $callback['args'] ) ) ? $callback['args'] : [] ] );
+
+				/* Add back to our queue to retry (up to a grand total of three times) */
+				if ( empty( $callback['retry'] ) || $callback['retry'] < 2 ) {
+					$callback['retry'] = isset( $callback['retry'] ) ? $callback['retry'] + 1 : 1;
+					array_unshift( $callbacks, $callback );
+				}
+			}
+		}
+
+		$this->log->addNotice( sprintf(
+			'End async PDF task for %s',
+			$callback['id']
+		) );
+
+		return ( count( $callbacks ) > 0 ) ? $callbacks : false;
+	}
+}

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -1040,33 +1040,6 @@ class Model_PDF extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * Creates a PDF on every submission, except when the PDF is already created during the notification hook
-	 *
-	 * @param  array $entry The GF Entry Details
-	 * @param  array $form  The Gravity Form
-	 *
-	 * @return void
-	 *
-	 * @since 4.0
-	 */
-	public function maybe_save_pdf( $entry, $form ) {
-		$pdfs = ( isset( $form['gfpdf_form_settings'] ) ) ? $this->get_active_pdfs( $form['gfpdf_form_settings'], $entry ) : [];
-
-		if ( sizeof( $pdfs ) > 0 ) {
-
-			/* Loop through each PDF config */
-			foreach ( $pdfs as $pdf ) {
-				$settings = $this->options->get_pdf( $entry['form_id'], $pdf['id'] );
-
-				/* Only generate if the PDF wasn't created during the notification process */
-				if ( ! is_wp_error( $settings ) && $this->maybe_always_save_pdf( $settings ) ) {
-					$this->generate_and_save_pdf( $entry, $settings );
-				}
-			}
-		}
-	}
-
-	/**
 	 * Check if the current PDF to be processed already exists on disk
 	 *
 	 * @param  \GFPDF\Helper\Helper_PDF $pdf The Helper_PDF Object

--- a/src/statics/Queue_Callbacks.php
+++ b/src/statics/Queue_Callbacks.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace GFPDF\Statics;
+
+use GFPDF\Helper\Helper_PDF;
+
+use Psr\Log\LoggerInterface;
+use GFCommon;
+use GPDFAPI;
+use Exception;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2017, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.4
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2017, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class _Queue_Callbacks
+ *
+ * @package GFPDF\Helper
+ *
+ * @since   4.4
+ */
+class Queue_Callbacks {
+
+	/**
+	 * Generate and save a PDF to disk
+	 *
+	 * @param $entry_id
+	 * @param $pdf_id
+	 *
+	 * @throws Exception
+	 *
+	 * @since 4.4
+	 */
+	public static function create_pdf( $entry_id, $pdf_id ) {
+		$log     = GPDFAPI::get_log_class();
+		$results = GPDFAPI::create_pdf( $entry_id, $pdf_id );
+
+		if ( is_wp_error( $results ) ) {
+			$log->addError( 'PDF Generation Error', [
+				'code'    => $results->get_error_code(),
+				'message' => $results->get_error_message(),
+			] );
+
+			throw new Exception();
+		}
+	}
+
+	/**
+	 * Send a Gravity Forms notification
+	 *
+	 * @param int   $form_id
+	 * @param int   $entry_id
+	 * @param array $notification
+	 *
+	 * @since 4.4
+	 */
+	public static function send_notification( $form_id, $entry_id, $notification ) {
+		$gform = GPDFAPI::get_form_class();
+
+		GFCommon::send_notification( $notification, $gform->get_form( $form_id ), $gform->get_entry( $entry_id ) );
+	}
+
+	/**
+	 * Cleanup PDFs saved to disk
+	 *
+	 * @param $form_id
+	 * @param $entry_id
+	 *
+	 * @since 4.4
+	 */
+	public static function cleanup_pdfs( $form_id, $entry_id ) {
+		$gform     = GPDFAPI::get_form_class();
+		$data      = GPDFAPI::get_data_class();
+		$misc      = GPDFAPI::get_misc_class();
+		$templates = GPDFAPI::get_templates_class();
+		$model_pdf = GPDFAPI::get_mvc_class( 'Model_PDF' );
+
+		$form  = $gform->get_form( $form_id );
+		$entry = $gform->get_entry( $entry_id );
+		$pdfs  = ( isset( $form['gfpdf_form_settings'] ) ) ? $model_pdf->get_active_pdfs( $form['gfpdf_form_settings'], $entry ) : [];
+
+		foreach ( $pdfs as $pdf ) {
+			$notification = ( isset( $pdf['notification'] ) && is_array( $pdf['notification'] ) ) ? $pdf['notification'] : [];
+			if ( count( $notification ) > 0 || $pdf['save'] === 'Yes' ) {
+				$pdf_generator = new Helper_PDF( $entry, $pdf, $gform, $data, $misc, $templates );
+				$misc->rmdir( $pdf_generator->get_path() );
+				break;
+			}
+		}
+	}
+}

--- a/tests/phpunit/unit-tests/test-pdf-queue.php
+++ b/tests/phpunit/unit-tests/test-pdf-queue.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace GFPDF\Tests;
+
+use GFPDF\Controller\Controller_Pdf_Queue;
+use GFPDF\Helper\Helper_Pdf_Queue;
+use GFPDF\Statics\Queue_Callbacks;
+
+use WP_UnitTestCase;
+
+/**
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2017, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.4
+ */
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2017, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Test the model / controller for the Templates UI
+ *
+ * @since 4.4
+ * @group queue
+ */
+class Test_Pdf_Queue extends WP_UnitTestCase {
+
+	/**
+	 * @var \GFPDF\Controller\Controller_Pdf_Queue
+	 * @since 4.4
+	 */
+	public $controller;
+
+	/**
+	 * @var \GFPDF\Helper\Helper_Pdf_Queue
+	 * @since 4.4
+	 */
+	public $queue;
+
+	/**
+	 * @since 4.4
+	 */
+	public $queue_mock;
+
+	/**
+	 * The WP Unit Test Set up function
+	 *
+	 * @since 4.4
+	 */
+	public function setUp() {
+		global $gfpdf;
+
+		/* run parent method */
+		parent::setUp();
+
+		/* Setup our test classes */
+		$this->queue = new Helper_Pdf_Queue( $gfpdf->log );
+		$model_pdf   = $gfpdf->singleton->get_class( 'Model_PDF' );
+
+		$this->queue_mock = $this->getMock( '\GFPDF\Helper\Helper_Pdf_Queue', [
+			'save',
+			'dispatch',
+		], [ $gfpdf->log ] );
+
+		$this->queue_mock->expects( $this->any() )
+		                 ->method( 'save' )
+		                 ->will( $this->returnValue( $this->queue_mock ) );
+
+		$this->controller = new Controller_Pdf_Queue( $this->queue_mock, $model_pdf, $gfpdf->log );
+	}
+
+	/**
+	 * Create our testing data
+	 *
+	 * @since 4.0
+	 */
+	private function create_form_and_entries() {
+		global $gfpdf;
+
+		$form  = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+
+		$gfpdf->data->form_settings                = [];
+		$gfpdf->data->form_settings[ $form['id'] ] = $form['gfpdf_form_settings'];
+
+		return [
+			'form'  => $form,
+			'entry' => $entry,
+		];
+	}
+
+	/**
+	 * Test our queue runs once when the function runs without any problems
+	 *
+	 * @since 4.4
+	 */
+	public function test_queue_tasks() {
+		$mock = $this->getMock( 'stdClass', [ 'callback' ] );
+		$mock->expects( $this->exactly( 1 ) )
+		     ->method( 'callback' );
+
+		$callback = [
+			[
+				'id'   => 'test',
+				'func' => [ $mock, 'callback' ],
+			],
+		];
+
+		while ( $callback !== false ) {
+			$callback = $this->queue->task( $callback );
+		}
+	}
+
+	/**
+	 * Test our queue attempts to run up to three times when a function throws an exception
+	 *
+	 * @since 4.4
+	 */
+	public function test_failed_queue_tasks() {
+		$mock = $this->getMock( 'stdClass', [ 'callback' ] );
+		$mock->expects( $this->exactly( 3 ) )
+		     ->method( 'callback' )
+		     ->will( $this->throwException( new \Exception ) );
+
+		$callback = [
+			[
+				'id'   => 'test',
+				'func' => [ $mock, 'callback' ],
+			],
+		];
+
+		while ( $callback !== false ) {
+			$callback = $this->queue->task( $callback );
+		}
+	}
+
+	/**
+	 * Test our callback is passed the correct arguments
+	 *
+	 * @since 4.4
+	 */
+	public function test_arguments_queue_tasks() {
+		$mock = $this->getMock( 'stdClass', [ 'callback' ] );
+		$mock->expects( $this->exactly( 1 ) )
+		     ->method( 'callback' )
+		     ->with( 'item1', true, [ 1, 2, 3 ] );
+
+		$callback = [
+			[
+				'id'   => 'test',
+				'func' => [ $mock, 'callback' ],
+				'args' => [ 'item1', true, [ 1, 2, 3 ] ],
+			],
+		];
+
+		while ( $callback !== false ) {
+			$callback = $this->queue->task( $callback );
+		}
+	}
+
+	/**
+	 * Ensure we disable the standard form submission notifications when a PDF is being attached
+	 *
+	 * @since 4.4
+	 */
+	public function test_maybe_disable_notifications() {
+		$results = $this->create_form_and_entries();
+		$entry   = $results['entry'];
+		$form    = $results['form'];
+
+		$this->assertFalse( $this->controller->maybe_disable_submission_notifications( false, [], $form, $entry ) );
+		$this->assertFalse( $this->controller->maybe_disable_submission_notifications( false, [ 'event' => 'paid' ], $form, $entry ) );
+		$this->assertFalse( $this->controller->maybe_disable_submission_notifications( false, [
+			'id'    => '',
+			'event' => 'form_submission',
+		], $form, $entry ) );
+		$this->assertTrue( $this->controller->maybe_disable_submission_notifications( false, [
+			'id'    => '54bca349732b8',
+			'event' => 'form_submission',
+		], $form, $entry ) );
+	}
+
+	/**
+	 * Test the form submission queue works as expected
+	 *
+	 * @since 4.4
+	 */
+	public function test_queue_async_form_submission_tasks() {
+		$results                                            = $this->create_form_and_entries();
+		$entry                                              = $results['entry'];
+		$form                                               = $results['form'];
+		$form['notifications']['1254123223']                = $form['notifications']['54bca349732b8'];
+		$form['notifications']['54bca349732b8']['isActive'] = true;
+
+		$this->controller->queue_async_form_submission_tasks( $entry, $form );
+
+		$queue = $this->queue_mock->get_data();
+
+		$this->assertSame( 4, count( $queue[0] ) );
+
+		$actions = [ 'create_pdf', 'create_pdf', 'send_notification', 'cleanup_pdfs' ];
+		for ( $i = 0; $i < 4; $i++ ) {
+			$this->assertNotFalse( strpos( $queue[0][ $i ]['func'], $actions[ $i ] ) );
+		}
+	}
+
+	/**
+	 * Test the resend notification queue works as expected
+	 *
+	 * @since 4.4
+	 */
+	public function test_queue_async_resend_notification_tasks() {
+		$results                                            = $this->create_form_and_entries();
+		$entry                                              = $results['entry'];
+		$form                                               = $results['form'];
+		$form['notifications']['54bca349732b8']['isActive'] = true;
+
+		$this->controller->queue_async_resend_notification_tasks( $form['notifications']['54bca349732b8'], $form, $entry );
+
+		$queue = $this->queue_mock->get_data();
+
+		$this->assertSame( 4, count( $queue[0] ) );
+
+		$actions = [ 'create_pdf', 'create_pdf', 'send_notification', 'cleanup_pdfs' ];
+		for ( $i = 0; $i < 4; $i++ ) {
+			$this->assertNotFalse( strpos( $queue[0][ $i ]['func'], $actions[ $i ] ) );
+		}
+	}
+
+	/**
+	 * Test our queue dispatch runs only when the queue has data
+	 *
+	 * @since 4.4
+	 */
+	public function test_queue_dispatch_resend_notification_tasks() {
+		$this->queue_mock->expects( $spy = $this->any() )
+		                 ->method( 'dispatch' )
+		                 ->will( $this->returnValue( $this->queue_mock ) );
+
+		$this->controller->queue_dispatch_resend_notification_tasks();
+
+		$invocations = $spy->getInvocations();
+		$this->assertEquals( 0, count( $invocations ) );
+
+		$this->queue_mock->push_to_queue( 'item' );
+		$this->controller->queue_dispatch_resend_notification_tasks();
+
+		$invocations = $spy->getInvocations();
+		$this->assertEquals( 1, count( $invocations ) );
+	}
+
+	/**
+	 * Test PDFs are cleaned up correctly
+	 *
+	 * @since 4.4
+	 */
+	public function test_cleanup_pdfs() {
+		global $gfpdf;
+
+		$results = $this->create_form_and_entries();
+		$entry   = $results['entry'];
+		$form    = $results['form'];
+
+		$path = $gfpdf->data->template_tmp_location . $entry['form_id'] . $entry['id'] . '/';
+		wp_mkdir_p( $path );
+		$test_file = $path . 'file';
+		touch( $test_file );
+		$this->assertFileExists( $test_file );
+
+		Queue_Callbacks::cleanup_pdfs( $form['id'], $entry['id'] );
+
+		$this->assertFileNotExists( $test_file );
+		$this->assertFileNotExists( $path );
+	}
+}

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -138,7 +138,6 @@ class Test_PDF extends WP_UnitTestCase {
 			'view_pdf_entry_list',
 		] ) );
 		$this->assertSame( 10, has_action( 'gform_entry_info', [ $this->model, 'view_pdf_entry_detail' ] ) );
-		$this->assertSame( 10, has_action( 'gform_after_submission', [ $this->model, 'maybe_save_pdf' ] ) );
 		$this->assertSame( 9999, has_action( 'gform_after_submission', [ $this->model, 'cleanup_pdf' ] ) );
 		$this->assertSame( 9999, has_action( 'gform_after_update_entry', [
 			$this->model,

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -210,30 +210,6 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Check if the correct PDFs are saved on disk
-	 * Belongs to Model_PDF.php
-	 *
-	 * @since 4.0
-	 */
-	public function test_maybe_save_pdf() {
-		global $gfpdf;
-
-		/* Setup some test data */
-		$results = $this->create_form_and_entries();
-		$entry   = $results['entry'];
-		$form    = $results['form'];
-		$file    = $gfpdf->data->template_tmp_location . "{$form['id']}{$entry['id']}/test-{$form['id']}.pdf";
-
-		$this->model->maybe_save_pdf( $entry, $form );
-
-		/* Check the results are successful */
-		$this->assertFileExists( $file );
-
-		/* Clean up */
-		unlink( $file );
-	}
-
-	/**
 	 * Test that we can successfully generate a PDF based on an entry and settings
 	 *
 	 * Belongs to View_PDF.php


### PR DESCRIPTION
This will stop the standard submission/resend notification functionality
and queue it up with the appropriate PDF generation.

Hooks are included to allow devs to add their own queue tasks.

Resolves #710