### PR TITLE
Prevent multiple AJAX calls when template list changes (add/delete)

### DIFF
--- a/src/assets/js/react/bootstrap/templateBootstrap.js
+++ b/src/assets/js/react/bootstrap/templateBootstrap.js
@@ -142,6 +142,7 @@ export function templateChangeStoreListener (store, $templateField) {
     if (listCount !== list.size) {
       /* update the list size so we don't run it twice */
       listCount = list.size
+      var currentActive = $templateField.val()
 
       /* Do our AJAX call to get the new Select Box DOM */
       request
@@ -151,8 +152,8 @@ export function templateChangeStoreListener (store, $templateField) {
         .then((response) => {
           $templateField
             .html(response.text)
+            .val(currentActive)
             .trigger('chosen:updated')
-            .trigger('change')
         })
     }
   }))


### PR DESCRIPTION
Ensure the correct default template is selected when we get the new select list and remove the change event trigger.

Resolves #651