### PR TITLE
Pre-process any mergetags that go through wp_kses_post()

### DIFF
--- a/src/helper/fields/Field_Checkbox.php
+++ b/src/helper/fields/Field_Checkbox.php
@@ -175,10 +175,10 @@ class Field_Checkbox extends Helper_Abstract_Fields {
 
 		foreach ( $value as $key => $item ) {
 			$label = esc_html( GFCommon::selection_display( $item, $this->field, '', true ) );
-			$label = wp_kses_post( wp_specialchars_decode( $label, ENT_QUOTES ) );
+			$label = wp_kses_post( $this->gform->process_tags( wp_specialchars_decode( $label, ENT_QUOTES ), $this->form, $this->entry ) );
 
 			$value = esc_html( GFCommon::selection_display( $item, $this->field ) );
-			$value = wp_kses_post( wp_specialchars_decode( $value, ENT_QUOTES ) );
+			$value = wp_kses_post( $this->gform->process_tags( wp_specialchars_decode( $value, ENT_QUOTES ), $this->form, $this->entry ) );
 
 			$items[] = [
 				'value' => $value,

--- a/src/helper/fields/Field_Html.php
+++ b/src/helper/fields/Field_Html.php
@@ -120,7 +120,11 @@ class Field_Html extends Helper_Abstract_Fields {
 			return $this->cache();
 		}
 
-		$value = ( isset( $this->field->content ) ) ? wpautop( wp_kses_post( $this->field->content ) ) : '';
+		$value = ( isset( $this->field->content ) ) ? wpautop(
+			wp_kses_post(
+				$this->gform->process_tags( $this->field->content, $this->form, $this->entry )
+			)
+		) : '';
 
 		$this->cache( $value );
 

--- a/src/helper/fields/Field_Post_Content.php
+++ b/src/helper/fields/Field_Post_Content.php
@@ -105,7 +105,9 @@ class Field_Post_Content extends Helper_Abstract_Fields {
 		$value = $this->get_value();
 
 		if ( isset( $this->field->useRichTextEditor ) && true === $this->field->useRichTextEditor ) {
-			$html = wp_kses_post( $value );
+			$html = wp_kses_post(
+				$this->gform->process_tags( $value, $this->form, $this->entry )
+			);
 		} else {
 			$html = nl2br( esc_html( $value ) );
 		}

--- a/src/helper/fields/Field_Radio.php
+++ b/src/helper/fields/Field_Radio.php
@@ -163,10 +163,9 @@ class Field_Radio extends Helper_Abstract_Fields {
 
 		/* Allow HTML if the radio value isn't the "other" option */
 		if ( ! $this->is_user_defined_value( $value ) ) {
-			$value = wp_kses_post( wp_specialchars_decode( $value, ENT_QUOTES ) );
-			$label = wp_kses_post( wp_specialchars_decode( $label, ENT_QUOTES ) );
+			$value = wp_kses_post( $this->gform->process_tags( wp_specialchars_decode( $value, ENT_QUOTES ), $this->form, $this->entry ) );
+			$label = wp_kses_post( $this->gform->process_tags( wp_specialchars_decode( $label, ENT_QUOTES ), $this->form, $this->entry ) );
 		}
-
 
 		/* return value / label as an array */
 		$this->cache( [

--- a/src/helper/fields/Field_Section.php
+++ b/src/helper/fields/Field_Section.php
@@ -184,7 +184,9 @@ class Field_Section extends Helper_Abstract_Fields {
 
 		$this->cache( [
 			'title'       => esc_html( $this->field->label ),
-			'description' => wp_kses_post( $this->field->description ),
+			'description' => wp_kses_post(
+				$this->gform->process_tags( $this->field->description, $this->form, $this->entry )
+			),
 		] );
 
 		return $this->cache();

--- a/src/helper/fields/Field_Textarea.php
+++ b/src/helper/fields/Field_Textarea.php
@@ -95,7 +95,11 @@ class Field_Textarea extends Helper_Abstract_Fields {
 		$value = $this->get_value();
 
 		if ( isset( $this->field->useRichTextEditor ) && true === $this->field->useRichTextEditor ) {
-			$html = wp_kses_post( wpautop( $value ) );
+			$html = wp_kses_post(
+				wpautop(
+					$this->gform->process_tags( $value, $this->form, $this->entry )
+				)
+			);
 		} else {
 			$html = nl2br( esc_html( $value ) );
 		}

--- a/src/helper/fields/Field_Tos.php
+++ b/src/helper/fields/Field_Tos.php
@@ -108,7 +108,11 @@ class Field_Tos extends Helper_Abstract_Fields {
 	 */
 	public function html( $value = '', $label = true ) {
 
-		$terms = wp_kses_post( wpautop( $this->field->gwtermsofservice_terms ) );
+		$terms = wp_kses_post(
+			wpautop(
+				$this->gform->process_tags( $this->field->gwtermsofservice_terms , $this->form, $this->entry )
+			)
+		);
 		$value = $this->value();
 
 		$html = "

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     path: __dirname + '/dist/assets/js/',
     filename: 'app.bundle.min.js'
   },
-  devtool: PROD ? 'source-map' : 'eval-cheap-module-source-map',
+  devtool: PROD ? 'source-map' : 'eval-source-map',
   module: {
     loaders: [
       {
@@ -54,6 +54,6 @@ module.exports = {
       }
     })
   ] : [
-    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.bundle.min.js' }),
+    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.bundle.min.js' })
   ]
 }


### PR DESCRIPTION
This prevents problems with using merge tags in attributes. Plus wp_kses_post() can better validate the markup as it's been transformed already.

Resolves #711