### PR TITLE
Pass all the required fields to the preprocess_template_arguments() method

### DIFF
--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -581,7 +581,7 @@ class View_PDF extends Helper_Abstract_View {
 	public function get_core_template_styles( $settings, $entry ) {
 		$form = $this->gform->get_form( $entry['form_id'] );
 
-		$html = $this->load_core_template_styles( $settings );
+		$html = $this->load_core_template_styles( $settings, $entry, $form );
 
 		$html = apply_filters( 'gfpdf_pdf_core_template_html_output', $html, $form, $entry, $settings );
 		$html = apply_filters( 'gfpdf_pdf_core_template_html_output_' . $form['id'], $html, $form, $entry, $settings );
@@ -593,17 +593,23 @@ class View_PDF extends Helper_Abstract_View {
 	 * Load our core PDF template settings
 	 *
 	 * @param $settings
+	 * @param $entry
+	 * @param $form
 	 *
 	 * @return string|\WP_Error
 	 *
 	 * @since 4.0
 	 */
-	public function load_core_template_styles( $settings ) {
+	public function load_core_template_styles( $settings, $entry, $form ) {
 		$controller = $this->getController();
 		$model      = $controller->model;
 
 		/* Run our settings through the preprocessor which requires an array with a 'settings' key */
-		$args     = $model->preprocess_template_arguments( [ 'settings' => $settings ] );
+		$args     = $model->preprocess_template_arguments( [
+			'settings' => $settings,
+			'entry'    => $entry,
+			'form'     => $form,
+		] );
 		$settings = $args['settings'];
 
 		return $this->load( 'core_template_styles', [ 'settings' => $settings ], false );


### PR DESCRIPTION
This resolves a PHP notice and will allow the merge tag processing to work correctly.