### PR TITLE
Add check for 'watermark_font' setting before using it.

### DIFF
--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -2032,7 +2032,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @since 5.0
 	 */
 	public function set_watermark_font( $mpdf, $form, $entry, $settings ) {
-		$mpdf->watermark_font = $settings['watermark_font'];
+		$mpdf->watermark_font = ( isset( $settings['watermark_font'] ) ) ? $settings['watermark_font'] : $settings['font'];
 
 		return $mpdf;
 	}


### PR DESCRIPTION
Fallback to 'font' setting if no watermark font setting found