### PR TITLE
Adjust tests to fix PHP notices

### DIFF
--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -1824,7 +1824,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		$pdfs = array_values( $pdfs );
 
 		/* Use the legacy aid to determine which PDF to load */
-		if ( $config['aid'] !== false ) {
+		if ( isset( $config['aid'] ) && $config['aid'] !== false ) {
 			$selector = $config['aid'] - 1;
 
 			if ( isset( $pdfs[ $selector ] ) && $pdfs[ $selector ]['template'] == $config['template'] ) {

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -242,6 +242,8 @@ class Test_Form_Settings extends WP_UnitTestCase {
 	 */
 	public function test_process_list_view() {
 
+		$GLOBALS['hook_suffix'] = '';
+
 		require_once( GFCommon::get_base_path() . '/form_settings.php' );
 
 		$form_id = $this->form_id;
@@ -381,6 +383,7 @@ class Test_Form_Settings extends WP_UnitTestCase {
 
 		/* Create semi-valid post data */
 		$_POST['gfpdf_settings']['name'] = 'My New Name';
+		$_POST['gfpdf_settings']['pdf_size'] = '';
 
 		/* Fail sanitization */
 		$this->assertFalse( $this->model->process_submission( $form_id, $pid ) );

--- a/tests/phpunit/unit-tests/test-helper-misc.php
+++ b/tests/phpunit/unit-tests/test-helper-misc.php
@@ -357,13 +357,15 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_evaluate_conditional_logic() {
+		$data = $this->create_form_and_entries();
+
 		$logic['actionType'] = 'show';
 
-		$this->assertTrue( $this->misc->evaluate_conditional_logic( $logic, [] ) );
+		$this->assertTrue( $this->misc->evaluate_conditional_logic( $logic, $data['entry'] ) );
 
 		$logic['actionType'] = 'hide';
 
-		$this->assertFalse( $this->misc->evaluate_conditional_logic( $logic, [] ) );
+		$this->assertFalse( $this->misc->evaluate_conditional_logic( $logic, $data['entry'] ) );
 	}
 
 	/**
@@ -473,7 +475,7 @@ class Test_Helper_Misc extends WP_UnitTestCase {
 		$this->assertFalse( $compat['security'] );
 		$this->assertFalse( $compat['pdfa1b'] );
 		$this->assertFalse( $compat['pdfx1a'] );
-		$this->assertEquals( '', $compat['password'] );
+		$this->assertEquals( '', $compat['pdf_password'] );
 		$this->assertEquals( '', $compat['pdf_privileges'] );
 		$this->assertEquals( 96, $compat['dpi'] );
 

--- a/tests/phpunit/unit-tests/test-helper-templates.php
+++ b/tests/phpunit/unit-tests/test-helper-templates.php
@@ -180,9 +180,9 @@ class Test_Templates_Helper extends WP_UnitTestCase {
 	 * @since 4.1
 	 */
 	public function test_is_template_compatible() {
-		$this->assertTrue( $this->templates->is_template_compatible( PDF_EXTENDED_VERSION - 1 ) );
+		$this->assertTrue( $this->templates->is_template_compatible( (float) PDF_EXTENDED_VERSION - 1 ) );
 		$this->assertTrue( $this->templates->is_template_compatible( PDF_EXTENDED_VERSION ) );
-		$this->assertFalse( $this->templates->is_template_compatible( PDF_EXTENDED_VERSION + 1 ) );
+		$this->assertFalse( $this->templates->is_template_compatible( (float) PDF_EXTENDED_VERSION + 1 ) );
 	}
 
 	/**
@@ -193,7 +193,7 @@ class Test_Templates_Helper extends WP_UnitTestCase {
 	public function test_maybe_add_template_compatibility_notice() {
 		$this->assertEquals( 'Template', $this->templates->maybe_add_template_compatibility_notice( 'Template', PDF_EXTENDED_VERSION ) );
 
-		$version = PDF_EXTENDED_VERSION + 1;
+		$version = (float) PDF_EXTENDED_VERSION + 1;
 		$this->assertEquals( 'Template (Requires Gravity PDF v' . $version . ')', $this->templates->maybe_add_template_compatibility_notice( 'Template', $version ) );
 	}
 

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -491,7 +491,7 @@ class Test_Options_API extends WP_UnitTestCase {
 	 */
 	public function test_add_pdf_filter() {
 		add_filter( 'gfpdf_form_add_pdf', function () {
-			return [ 'name' => 'Add Filter Fired' ];
+			return [ 'id' => 'id', 'name' => 'Add Filter Fired' ];
 		} );
 
 		/* run our method */
@@ -505,7 +505,7 @@ class Test_Options_API extends WP_UnitTestCase {
 		remove_all_filters( 'gfpdf_pdf_config' );
 
 		add_filter( 'gfpdf_form_add_pdf_' . $this->form_id, function () {
-			return [ 'name' => 'ID Add Filter Fired' ];
+			return [ 'id' => 'id', 'name' => 'ID Add Filter Fired' ];
 		} );
 
 		/* run our method */

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -1625,8 +1625,14 @@ class Test_PDF extends WP_UnitTestCase {
 			'rtl'             => 'No',
 		];
 
+
 		/* Test everything passes back the same */
-		$this->assertSame( 0, sizeof( array_diff( $settings, $this->model->apply_backwards_compatibility_filters( $settings, $entry ) ) ) );
+		$results = $this->model->apply_backwards_compatibility_filters( $settings, $entry );
+
+		foreach( $results as $key => $value ) {
+			$this->assertArrayHasKey( $key, $settings );
+			$this->assertEquals( $value, $settings[ $key ] );
+		}
 
 		/* Add filters to manipulate the data */
 		add_filter( 'gfpdfe_pdf_name', function ( $item ) {
@@ -1680,6 +1686,8 @@ class Test_PDF extends WP_UnitTestCase {
 	 */
 	public function test_preprocess_template_arguments() {
 
+		$data = $this->create_form_and_entries();
+
 		/* Setup the testing data */
 		$args = [
 			'settings' => [
@@ -1689,6 +1697,8 @@ class Test_PDF extends WP_UnitTestCase {
 				'first_footer' => '<img src="/this/is/my/path/image.gif" class="class1 class2" />',
 				'other_value'  => 'testing',
 			],
+			'form'  => $data['form'],
+			'entry' => $data['entry'],
 		];
 
 		$results = $this->model->preprocess_template_arguments( $args );

--- a/tests/phpunit/unit-tests/test-settings.php
+++ b/tests/phpunit/unit-tests/test-settings.php
@@ -455,6 +455,7 @@ class Test_Settings extends WP_UnitTestCase {
 	 */
 	public function test_is_font_name_unique() {
 		global $gfpdf;
+		$gfpdf->options->update_option( 'custom_fonts', [] );
 
 		/* Check the name is unique */
 		$this->assertTrue( $this->model->is_font_name_unique( 'Calibri' ) );

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -328,8 +328,10 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 			unlink( $filename );
 		}
 
+		$settings['template'] = 'doesntexist';
+
 		/* Trigger an error */
-		$error = $this->model->generate_and_save_pdf( [], [ 'filename' => '' ] );
+		$error = $this->model->generate_and_save_pdf( $entry, $settings );
 
 		$this->assertTrue( is_wp_error( $error ) );
 	}


### PR DESCRIPTION
These notices were hidden because MPDF turned them off. We've since removed the PHP error reporting adjustment code.