### PR TITLE
Restrict PHPunit to be less than v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": ">4.0"
+        "phpunit/phpunit": ">4.0 <7"
     },
 
     "autoload": {


### PR DESCRIPTION
PHPUnit 7 made the phpunit6-compat.php file throw an error due to making PHPUnit\Util\Test a final class.