### PR TITLE
Disable the background processing code by default

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -875,7 +875,9 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$model_pdf = $this->singleton->get_class( 'Model_PDF' );
 		$class = new Controller\Controller_Pdf_Queue( $queue, $model_pdf, $this->log );
 
-		$class->init();
+		if ( $this->options->get_option( 'background_processing', 'Disable' ) === 'Disable' ) {
+			$class->init();
+		}
 
 		$this->singleton->add_class( $queue );
 		$this->singleton->add_class( $class );

--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -145,6 +145,9 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_action( 'gform_entries_first_column_actions', [ $this->model, 'view_pdf_entry_list' ], 10, 4 );
 		add_action( 'gform_entry_info', [ $this->model, 'view_pdf_entry_detail' ], 10, 2 );
 
+		/* Add save PDF filter */
+		add_action( 'gform_after_submission', [ $this->model, 'maybe_save_pdf' ], 10, 2 );
+
 		/* Clean-up actions */
 		add_action( 'gform_after_submission', [ $this->model, 'cleanup_pdf' ], 9999, 2 );
 		add_action( 'gform_after_update_entry', [ $this->model, 'cleanup_pdf_after_submission' ], 9999, 2 );

--- a/src/controller/Controller_Pdf_Queue.php
+++ b/src/controller/Controller_Pdf_Queue.php
@@ -99,7 +99,6 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller implements Helper_
 	 * Set up our dependancies
 	 *
 	 * @param \GFPDF\Helper\Helper_Pdf_Queue
-	 * @param \GFPDF\Helper\_Queue_Callbacks
 	 * @param \GFPDF\Model\Model_PDF $model_pdf
 	 * @param LoggerInterface        $log Our logger class
 	 *

--- a/src/helper/Helper_Options_Fields.php
+++ b/src/helper/Helper_Options_Fields.php
@@ -172,6 +172,19 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 						'tooltip' => '<h6>' . esc_html__( 'Entry View', 'gravity-forms-pdf-extended' ) . '</h6>' . esc_html__( 'Choose to view the PDF in your web browser or download the document to your computer.', 'gravity-forms-pdf-extended' ),
 					],
 
+					'background_processing' => [
+						'id'      => 'background_processing',
+						'name'    => esc_html__( 'Background Processing', 'gravity-forms-pdf-extended' ),
+						'desc'    => sprintf( esc_html__( 'When enable, during form submission and resending notifications PDFs will be processed and emailed in a background task. %sRequires Background tasks to be enabled%s.', 'gravity-forms-pdf-extended' ), '<a href="' . admin_url( 'admin.php?page=gf_system_status' ) . '">', '</a>' ),
+						'type'    => 'radio',
+						'options' => [
+							'Enable'  => esc_html__( 'Enable', 'gravity-forms-pdf-extended' ),
+							'Disable' => esc_html__( 'Disable', 'gravity-forms-pdf-extended' ),
+						],
+						'std'     => 'Disable',
+						'tooltip' => '<h6>' . esc_html__( 'Background Processing', 'gravity-forms-pdf-extended' ) . '</h6>' . esc_html__( 'When enabled, users will spent less time waiting during form submission as PDF generation is off-loaded to a background process. It is important to ensure Background Tasks are enabled in the Gravity Forms System Status before enabling this feature.', 'gravity-forms-pdf-extended' ),
+					],
+
 					'shortcode_debug_messages' => [
 						'id'      => 'shortcode_debug_messages',
 						'name'    => esc_html__( 'Shortcode Debug Message', 'gravity-forms-pdf-extended' ),

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -138,6 +138,7 @@ class Test_PDF extends WP_UnitTestCase {
 			'view_pdf_entry_list',
 		] ) );
 		$this->assertSame( 10, has_action( 'gform_entry_info', [ $this->model, 'view_pdf_entry_detail' ] ) );
+		$this->assertSame( 10, has_action( 'gform_after_submission', [ $this->model, 'maybe_save_pdf' ] ) );
 		$this->assertSame( 9999, has_action( 'gform_after_submission', [ $this->model, 'cleanup_pdf' ] ) );
 		$this->assertSame( 9999, has_action( 'gform_after_update_entry', [
 			$this->model,

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -210,6 +210,36 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check if the correct PDFs are saved on disk
+	 * Belongs to Model_PDF.php
+	 *
+	 * @since 4.0
+	 */
+	public function test_maybe_save_pdf() {
+		global $gfpdf;
+
+		/* Setup some test data */
+		$results = $this->create_form_and_entries();
+		$entry   = $results['entry'];
+		$form    = $results['form'];
+		$file    = $gfpdf->data->template_tmp_location . "{$form['id']}{$entry['id']}/test-{$form['id']}.pdf";
+
+		$this->model->maybe_save_pdf( $entry, $form );
+
+		/* Check the results are successful */
+		$this->assertFileExists( $file );
+
+		/* Clean up */
+		unlink( $file );
+
+		/* Ensure function doesn't run when background processing enabled */
+		$gfpdf->options->update_option( 'background_processing', 'Enable' );
+
+		$this->model->maybe_save_pdf( $entry, $form );
+		$this->assertFileNotExists( $file );
+	}
+
+	/**
 	 * Test that we can successfully generate a PDF based on an entry and settings
 	 *
 	 * Belongs to View_PDF.php


### PR DESCRIPTION
Give users the option to opt-in via a new PDF setting. This will stop a lot of issues related to Background tasks not firing correctly when there's a CURL problem triggering the background process.