### PR TITLE
Resolve JS errors in build and tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -22,6 +22,7 @@
   "env": {
     "test": {
       "plugins": [
+        "./tests/mocha/arrow-function-coverage-fix.js",
         [
           "istanbul",
           {

--- a/tests/mocha/arrow-function-coverage-fix.js
+++ b/tests/mocha/arrow-function-coverage-fix.js
@@ -1,0 +1,17 @@
+// Restore old babylon behavior for istanbul.
+// https://github.com/babel/babel/pull/6836
+// https://github.com/istanbuljs/istanbuljs/issues/119
+module.exports = function hacks () {
+  return {
+    visitor: {
+      Program (programPath) {
+        programPath.traverse({
+          ArrowFunctionExpression (path) {
+            const node = path.node
+            node.expression = node.body.type !== 'BlockStatement'
+          },
+        })
+      },
+    },
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,6 @@ module.exports = {
             'NODE_ENV': JSON.stringify('production')
         }
     }),
-    new webpack.optimize.ModuleConcatenationPlugin(),
     new UglifyJSPlugin({
       parallel: true,
       sourceMap: true,


### PR DESCRIPTION
An issue with Istanbul and Babel7 code. Build issue was due to the `ModuleConcatenationPlugin` which is no longer needed since combining the vendor and app files together.