### PR TITLE
Define the mPDF tmp location and use that instead of the `template_fontdata_location`

### DIFF
--- a/api.php
+++ b/api.php
@@ -639,8 +639,8 @@ final class GPDFAPI {
 			return new WP_Error( 'font_delete_failure', 'There was a problem deleting the font files.' );
 		}
 
-		/* Cleanup our fontdata directory to prevent caching issues with mPDF */
-		$misc->cleanup_dir( $data->template_fontdata_location );
+		/* Cleanup our mPDF directory to prevent caching issues with mPDF */
+		$misc->cleanup_dir( $data->mpdf_tmp_location );
 
 		/* Update the database */
 		unset( $fonts[ $font_id ] );

--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -184,11 +184,6 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			'notifications',
 		], 9999, 3 ); /* ensure Gravity PDF is one of the last filters to be applied */
 
-		/* Modify mPDF's path locations */
-		add_filter( 'mpdf_tmp_path', [ $this->model, 'mpdf_tmp_path' ] );
-		add_filter( 'mpdf_font_path', [ $this->model, 'mpdf_font_path' ] );
-		add_filter( 'mpdf_fontdata_path', [ $this->model, 'mpdf_tmp_font_path' ] );
-
 		/* Change mPDF settings */
 		add_filter( 'mpdf_font_data', [ $this->model, 'register_custom_font_data_with_mPDF' ] );
 		add_filter( 'mpdf_font_data', [ $this->model, 'add_unregistered_fonts_to_mPDF' ], 20 );

--- a/src/deprecated.php
+++ b/src/deprecated.php
@@ -753,7 +753,7 @@ if ( ! class_exists( 'mPDF' ) ) {
 
 				'fontdata' => apply_filters( 'mpdf_font_data', $defaultFontConfig['fontdata'] ),
 
-				'tempDir' => $data->template_tmp_location . 'mpdf',
+				'tempDir' => $this->data->mpdf_tmp_location,
 
 				'allow_output_buffering' => true,
 				'autoLangToFont'         => true,

--- a/src/helper/Helper_Data.php
+++ b/src/helper/Helper_Data.php
@@ -56,8 +56,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @property string  $template_location               The current path to the PDF working directory
  * @property string  $template_location_url           The current URL to the PDF working directory
  * @property string  $template_font_location          The current path to the PDF font directory
- * @property string  $template_fontdata_location      The current path to the PDF tmp font directory
  * @property string  $template_tmp_location           The current path to the PDF tmp location
+ * @property string  $mpdf_tmp_location               The current path to the mPDF tmp directory (including fonts)
  * @property string  $multisite_template_location     The current path to the multisite PDF working directory
  * @property string  $multisite_template_location_url The current URL to the multisite PDF working directory
  *

--- a/src/helper/Helper_PDF.php
+++ b/src/helper/Helper_PDF.php
@@ -642,7 +642,7 @@ class Helper_PDF {
 
 			'fontdata' => apply_filters( 'mpdf_font_data', $defaultFontConfig['fontdata'] ),
 
-			'tempDir' => $this->data->template_tmp_location . 'mpdf',
+			'tempDir' => $this->data->mpdf_tmp_location,
 
 			'allow_output_buffering' => true,
 			'autoLangToFont'         => true,

--- a/src/model/Model_Install.php
+++ b/src/model/Model_Install.php
@@ -223,11 +223,10 @@ class Model_Install extends Helper_Abstract_Model {
 		/* See https://gravitypdf.com/documentation/v5/gfpdf_font_location/ for more details about this filter */
 		$this->data->template_font_location = apply_filters( 'gfpdf_font_location', $this->data->template_location . 'fonts/', $working_folder, $upload_dir ); /* can be in a directory not accessible via the web */
 
-		/* @todo normally font and fontdata should be kept together but it may be worth adding a filter here */
-		$this->data->template_fontdata_location = $this->data->template_font_location . 'fontdata/';
-
 		/* See https://gravitypdf.com/documentation/v5/gfpdf_tmp_location/ for more details about this filter */
 		$this->data->template_tmp_location = apply_filters( 'gfpdf_tmp_location', $this->data->template_location . 'tmp/', $working_folder, $upload_dir_url ); /* encouraged to move this to a directory not accessible via the web */
+
+		$this->data->mpdf_tmp_location = $this->data->template_tmp_location . 'mpdf';
 	}
 
 	/**
@@ -291,8 +290,8 @@ class Model_Install extends Helper_Abstract_Model {
 		$folders = [
 			$this->data->template_location,
 			$this->data->template_font_location,
-			$this->data->template_fontdata_location,
 			$this->data->template_tmp_location,
+			$this->data->mpdf_tmp_location,
 		];
 
 		if ( is_multisite() ) {

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -1210,41 +1210,6 @@ class Model_PDF extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * Changes mPDF's tmp folder
-	 *
-	 * @param  string $path The current path
-	 *
-	 * @return string       The new path
-	 */
-	public function mpdf_tmp_path( $path ) {
-		return $this->data->template_tmp_location;
-	}
-
-	/**
-	 * Changes mPDF's fontdata folders
-	 *
-	 * @param  string $path The current path
-	 *
-	 * @return string       The new path
-	 */
-	public function mpdf_tmp_font_path( $path ) {
-		return $this->data->template_fontdata_location;
-	}
-
-	/**
-	 * Change mPDF's font folder
-	 *
-	 * @param $path
-	 *
-	 * @return string
-	 *
-	 * @since 5.0
-	 */
-	public function mpdf_font_path( $path ) {
-		return $this->data->template_font_location;
-	}
-
-	/**
 	 * An mPDF filter which will register our custom font data with mPDF
 	 *
 	 * @param array $fonts The registered fonts

--- a/src/model/Model_Settings.php
+++ b/src/model/Model_Settings.php
@@ -414,8 +414,8 @@ class Model_Settings extends Helper_Abstract_Model {
 			/* Update our font database */
 			$this->options->update_option( 'custom_fonts', $custom_fonts );
 
-			/* Cleanup our fontdata directory to prevent caching issues with mPDF */
-			$this->misc->cleanup_dir( $this->data->template_fontdata_location );
+			/* Cleanup the mPDF tmp directory to prevent font caching issues  */
+			$this->misc->cleanup_dir( $this->data->mpdf_tmp_location );
 
 		}
 
@@ -488,8 +488,8 @@ class Model_Settings extends Helper_Abstract_Model {
 			if ( $this->remove_font_file( $fonts[ $id ] ) ) {
 				unset( $fonts[ $id ] );
 
-				/* Cleanup our fontdata directory to prevent caching issues with mPDF */
-				$this->misc->cleanup_dir( $this->data->template_fontdata_location );
+				/* Cleanup the mPDF tmp directory to prevent font caching issues  */
+				$this->misc->cleanup_dir( $this->data->mpdf_tmp_location );
 
 				if ( $this->options->update_option( 'custom_fonts', $fonts ) ) {
 					/* Success */

--- a/tests/phpunit/unit-tests/test-installer.php
+++ b/tests/phpunit/unit-tests/test-installer.php
@@ -216,8 +216,8 @@ class Test_Installer extends WP_UnitTestCase {
 		/* Test the results */
 		$this->assertTrue( is_dir( $gfpdf->data->template_location ) );
 		$this->assertTrue( is_dir( $gfpdf->data->template_font_location ) );
-		$this->assertTrue( is_dir( $gfpdf->data->template_fontdata_location ) );
 		$this->assertTrue( is_dir( $gfpdf->data->template_tmp_location ) );
+		$this->assertTrue( is_dir( $gfpdf->data->mpdf_tmp_location ) );
 
 		$this->assertTrue( is_file( $gfpdf->data->template_tmp_location . '.htaccess' ) );
 		$this->assertTrue( is_file( $gfpdf->data->template_tmp_location . 'index.html' ) );

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -165,8 +165,6 @@ class Test_PDF extends WP_UnitTestCase {
 
 		$this->assertSame( 9999, has_filter( 'gform_notification', [ $this->model, 'notifications' ], 9999 ) );
 
-		$this->assertSame( 10, has_filter( 'mpdf_tmp_path', [ $this->model, 'mpdf_tmp_path' ] ) );
-		$this->assertSame( 10, has_filter( 'mpdf_fontdata_path', [ $this->model, 'mpdf_tmp_font_path' ] ) );
 		$this->assertSame( 10, has_filter( 'mpdf_font_data', [
 			$this->model,
 			'register_custom_font_data_with_mPDF',


### PR DESCRIPTION
Also ensure the tmp location is cleaned up when fonts are deleted, removed unnecessary filters and update unit tests.

Resolves #819
Resolves #820