### PR TITLE
Add fallback mPDF temporary directory when we cannot write PHP file to disk

### DIFF
--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -1116,7 +1116,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				);
 
 				foreach ( $directory_list as $file ) {
-					if ( in_array( $file->getFilename(), [ '.htaccess', 'index.html' ] ) ) {
+					if ( in_array( $file->getFilename(), [ '.htaccess', 'index.html' ] ) || strpos( realpath( $file->getPathname() ), realpath( $this->data->mpdf_tmp_location ) ) !== false ) {
 						continue;
 					}
 

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -1079,8 +1079,10 @@ class Test_PDF extends WP_UnitTestCase {
 		$tmp_save = $gfpdf->data->template_tmp_location;
 		$gfpdf->data->template_tmp_location = $gfpdf->data->template_location . 'tmp/';
 		$tmp = $gfpdf->data->template_tmp_location;
+		$gfpdf->data->mpdf_tmp_location = $tmp . 'mpdf';
 
 		wp_mkdir_p( $tmp );
+		wp_mkdir_p( $gfpdf->data->mpdf_tmp_location );
 
 		/* Create our files to test */
 		$files = [
@@ -1091,6 +1093,7 @@ class Test_PDF extends WP_UnitTestCase {
 			'test5'     => time() - ( 15 * 3600 ),
 			'test6'     => time() - ( 5 * 3600 ),
 			'.htaccess' => time() - ( 48 * 3600 ),
+			'mpdf/test' => time() - ( 25 * 3600 ), /* normally deleted, but excluded */
 		];
 
 		foreach ( $files as $file => $modified ) {
@@ -1107,6 +1110,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertTrue( is_file( $tmp . 'test5' ) );
 		$this->assertTrue( is_file( $tmp . 'test6' ) );
 		$this->assertTrue( is_file( $tmp . '.htaccess' ) );
+		$this->assertTrue( is_file( $tmp . 'mpdf/test' ) );
 
 		/* Cleanup our files */
 		foreach ( $files as $file => $modified ) {


### PR DESCRIPTION
This prevents problems on some web hosting providers who cannot write to the PHP tmp directory

Resolves #836