### PR TITLE
Allow signed URLs when using the Gravity PDF Shortcode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "mpdf/mpdf": "^7.1.0",
         "querypath/QueryPath": ">=3.0.0",
         "monolog/monolog": "^1.23.0",
-        "codeguy/upload": "^1.3"
+        "codeguy/upload": "^1.3",
+        "spatie/url-signer": "^1.0"
     },
 
     "require-dev": {

--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -164,6 +164,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	public function add_filters() {
 		/* PDF authentication middleware */
 		add_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_public_access' ], 10, 3 );
+		add_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_signed_url_access' ], 15, 3 );
 		add_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_active' ], 20, 3 );
 		add_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_conditional' ], 30, 3 );
 		add_filter( 'gfpdf_pdf_middleware', [ $this->model, 'middle_owner_restriction' ], 40, 3 );

--- a/src/controller/Controller_Shortcodes.php
+++ b/src/controller/Controller_Shortcodes.php
@@ -105,6 +105,7 @@ class Controller_Shortcodes extends Helper_Abstract_Controller implements Helper
 		add_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_confirmation' ], 100, 3 );
 		add_filter( 'gform_notification', [ $this->model, 'gravitypdf_notification' ], 100, 3 );
 		add_filter( 'gform_admin_pre_render', [ $this->model, 'gravitypdf_redirect_confirmation' ] );
+		add_filter( 'gform_confirmation', [ $this->model, 'gravitypdf_redirect_confirmation_shortcode_processing'], 10, 3 );
 
 		/* Basic GravityView Support */
 		add_filter( 'gravityview/fields/custom/content_before', [ $this->model, 'gravitypdf_gravityview_custom' ], 10 );

--- a/src/helper/Helper_Sha256_Url_Signer.php
+++ b/src/helper/Helper_Sha256_Url_Signer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace GFPDF\Helper;
+
+use Spatie\UrlSigner\BaseUrlSigner;
+
+/**
+ * Custom URL Signer used for auto-expiring PDF URLs
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2018, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.1
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+    This file is part of Gravity PDF.
+
+    Gravity PDF – Copyright (C) 2018, Blue Liquid Designs
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class Helper_Sha256_Url_Signer
+ *
+ * @package GFPDF\Helper
+ */
+class Helper_Sha256_Url_Signer extends BaseUrlSigner {
+
+	/**
+	 * Generate a token to identify the secure action.
+	 *
+	 * @param \League\Url\UrlImmutable|string $url
+	 * @param string                          $expiration
+	 *
+	 * @return string
+	 */
+	protected function createSignature( $url, $expiration ) {
+		$token_data = [
+			'expires' => $expiration,
+			'url'     => (string) $url,
+		];
+
+		$token = rawurlencode( base64_encode( json_encode( $token_data ) ) );
+
+		return hash_hmac( 'sha256', $token, $this->signatureKey );
+	}
+}


### PR DESCRIPTION
Allow the shortcode to return the URL

Process shortcode in Redirect Confirmations differently to handle signed URLs