### PR TITLE
Exclude `phpcs.xml` file from Git Archive command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /.gitignore 		export-ignore
 /phpunit.xml 		export-ignore
 /phpunit.xml.dist 	export-ignore
+/phpcs.xml  		export-ignore
 /README.md      	export-ignore
 /CONTRIBUTING.md   	export-ignore
 /node_modules  	 	export-ignore


### PR DESCRIPTION
This ensures `phpcs.xml` is excluded from the production build when running `./bin/build.sh` 