### PR TITLE
Conditionally register our rewrite tags on PDF endpoints

### DIFF
--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -214,9 +214,6 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Cleanup filters */
 		add_filter( 'gform_before_resend_notifications', [ $this->model, 'resend_notification_pdf_cleanup' ], 10, 2 );
-
-		/* GravityView */
-		add_filter( 'gravityview/internal/ignored_endpoints', [ $this->model, 'fix_gravityview_frontpage_conflict' ] );
 	}
 
 	/**

--- a/src/model/Model_Install.php
+++ b/src/model/Model_Install.php
@@ -386,10 +386,15 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @return array
 	 */
 	public function register_rewrite_tags( $tags ) {
-		$tags[] = 'gpdf';
-		$tags[] = 'pid';
-		$tags[] = 'lid';
-		$tags[] = 'action';
+		global $wp;
+
+		/* Conditionally register rewrite tags to prevent conflict with other plugins */
+		if ( ! empty( $_GET['gpdf'] ) || ! empty( $_GET['gf_pdf'] ) || strpos( $wp->matched_query, 'gpdf=1' ) === 0 ) {
+			$tags[] = 'gpdf';
+			$tags[] = 'pid';
+			$tags[] = 'lid';
+			$tags[] = 'action';
+		}
 
 		return $tags;
 	}

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -2095,18 +2095,6 @@ class Model_PDF extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * @param array $ignored
-	 *
-	 * @since 4.2
-	 */
-	public function fix_gravityview_frontpage_conflict( $ignored ) {
-		$ignored[] = 'lid';
-		$ignored[] = 'action';
-
-		return $ignored;
-	}
-
-	/**
 	 * Set the watermark font to the current PDF font
 	 *
 	 * @param Mpdf  $mpdf


### PR DESCRIPTION
This resolves a growing conflict with third party plugins. Because WordPress will check for superglobals with matching names to the registered tags, it had unintended side effects (GravityView, MembersPress ect).

By only registering the tags on Gravity PDF endpoints, there will be no third party side effects.

As this change affects the core functionality of Gravity PDF (displaying PDFs in browser), verifying no unintended consequences occured is a must.

To test:
- [ ] Spin up a new Local by Flywheel site
- [ ] Install Gravity Forms (copy files from your existing site is fine)
- [ ] Install Gravity PDF (copy files from your existing site is fine) then checkout this PR
- [ ] Create a new Gravity Form with a handful of fields and an Email field
- [ ] Create a User Notification and configure with user field
- [ ] Create four PDFs on the form (one for each Core template - Zadani, Focus Gravity, Rubix, Blank Slate). Attach each to the two Notifications shown
- [ ] Submit a test entry
- [ ] Verify you can view all four PDFs from the admin area
- [ ] Verify all the emails arrived using Mailcatcher (located under Utilities in Local By Flywheel)
- [ ] Turn off permalinks in WordPress
- [ ] Repeat the test entry submission / PDF verification process
