### PR TITLE
Strip Page Breaks from Header / Footers

### DIFF
--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -180,6 +180,8 @@ class Helper_Misc {
 	 *
 	 * 4. Convert any image URLs to local path where applicable
 	 *
+	 * 5. Strips out page breaks
+	 *
 	 * @param string $html The HTML to parse
 	 *
 	 * @return string
@@ -189,6 +191,10 @@ class Helper_Misc {
 		$html = wp_kses_post( $html );
 		$html = trim( wpautop( $html ) );
 		$html = $this->fix_header_footer_images( $html );
+
+		/* Strip page breaks */
+		$html = preg_replace( '/<pagebreak(.+?)?\/?>/', '', $html );
+		$html = preg_replace( '/page-break-(before|after):( +)?(always|left|right|auto|avoid)/', '', $html );
 
 		return $html;
 	}


### PR DESCRIPTION
Resolves #896 

*Steps to Replicate*
1. Start on the `development` branch of Gravity PDF
1. [Add a new PDF to any Gravity Form](https://gravitypdf.com/documentation/v5/user-setup-pdf/)
1. Select the Template tab and then locate the "Header" setting
1. Select the "HTML" tab in the Rich Text Editor and add the following:

```
<pagebreak>
<pagebreak/>
<pagebreak />
<pagebreak stuff="" other="">
<pagebreak stuff="" other=""/>

<div style="page-break-before:always"></div>
<div style="page-break-before: always"></div>
<div style="page-break-before: left"></div>
<div style="page-break-before:  left"></div>
<div style="page-break-before:right"></div>

<div style="page-break-after:always"></div>
<div style="page-break-after: avoid"></div>
<div style="page-break-after: left"></div>
<div style="page-break-after:  auto"></div>
<div style="page-break-after:right"></div>
```

5. Save the settings and [view the PDF](https://gravitypdf.com/documentation/v5/user-viewing-pdfs/). A fatal error will be displayed
6. Checkout this branch and repeat the step above. No fatal error will be generated and the PDF will display correctly.