### PR TITLE
5.1.5 Release

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://gravitypdf.com/donate-to-plugin/
 Tags: gravity, forms, pdf, automation, attachment, email
 Requires at least: 4.8
 Tested up to: 5.1
-Stable tag: 5.1.4
+Stable tag: 5.1.5
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl.txt
@@ -89,6 +89,12 @@ Also, if you enjoy using the software [we'd love it if you could give us a revie
 18. Blank Slate provides a print-friendly template focusing solely on the user-submitted data.
 
 == Changelog ==
+
+= 5.1.5 =
+* Housekeeping: Add filter `gfpdf_mpdf_post_init_class` to interact with mPDF right after the initial Gravity PDF object setup [GH#890]
+* Bug: Fix URL rewrite issue with plugins that use `action` GET super global [GH#892]
+* Bug: Fix conflict with the SG Optimizer plugin's Minify HTML option [GH#897]
+* Bug: Strip Page Breaks from Headers and Footers to prevent Fatal PHP Error [GH#898]
 
 = 5.1.4 =
 * Housekeeping: Upgrade Mpdf from 7.1.8 to 7.1.9 https://github.com/mpdf/mpdf/compare/v7.1.8...v7.1.9

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Plugin URI: https://gravitypdf.com/
 Donate link: https://gravitypdf.com/donate-to-plugin/
 Tags: gravity, forms, pdf, automation, attachment, email
 Requires at least: 4.8
-Tested up to: 5.0
+Tested up to: 5.1
 Stable tag: 5.1.4
 Requires PHP: 5.6
 License: GPLv2 or later

--- a/pdf.php
+++ b/pdf.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Gravity PDF
-Version: 5.1.4
+Version: 5.1.5
 Description: Automatically generate highly-customisable PDF documents using Gravity Forms.
 Author: Gravity PDF
 Author URI: https://gravitypdf.com
@@ -37,7 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /*
  * Set base constants we'll use throughout the plugin
  */
-define( 'PDF_EXTENDED_VERSION', '5.1.4' ); /* the current plugin version */
+define( 'PDF_EXTENDED_VERSION', '5.1.5' ); /* the current plugin version */
 define( 'PDF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); /* plugin directory path */
 define( 'PDF_PLUGIN_URL', plugin_dir_url( __FILE__ ) ); /* plugin directory url */
 define( 'PDF_PLUGIN_BASENAME', plugin_basename( __FILE__ ) ); /* the plugin basename */

--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -209,9 +209,6 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Cleanup filters */
 		add_filter( 'gform_before_resend_notifications', [ $this->model, 'resend_notification_pdf_cleanup' ], 10, 2 );
-
-		/* GravityView */
-		add_filter( 'gravityview/internal/ignored_endpoints', [ $this->model, 'fix_gravityview_frontpage_conflict' ] );
 	}
 
 	/**

--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -209,6 +209,10 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* Cleanup filters */
 		add_filter( 'gform_before_resend_notifications', [ $this->model, 'resend_notification_pdf_cleanup' ], 10, 2 );
+
+		/* Third Party Conflict Fixes */
+		add_filter( 'gfpdf_pre_view_or_download_pdf', [ $this, 'sgoptimizer_html_minification_fix' ] );
+		add_filter( 'gfpdf_legacy_pre_view_or_download_pdf', [ $this, 'sgoptimizer_html_minification_fix' ] );
 	}
 
 	/**
@@ -286,6 +290,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		$GLOBALS['wp']->query_vars['lid']  = $config['lid'];
 
 		/* Send to our model to handle validation / authentication */
+		do_action( 'gfpdf_legacy_pre_view_or_download_pdf', $config['lid'], $pid, $config['action'] );
 		$results = $this->model->process_pdf( $pid, $config['lid'], $config['action'] );
 
 		/* if error, display to user */
@@ -308,6 +313,26 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	public function remove_pre_pdf_hooks() {
 		remove_filter( 'wp_kses_allowed_html', [ $this->view, 'allow_pdf_html' ] );
 		remove_filter( 'safe_style_css', [ $this->view, 'allow_pdf_css' ] );
+	}
+
+	/**
+	 * Disables the Siteground HTML Minifier when generating PDFs for the browser
+	 *
+	 * @since 5.1.5
+	 *
+	 * @see   https://github.com/GravityPDF/gravity-pdf/issues/863
+	 */
+	public function sgoptimizer_html_minification_fix() {
+		if ( class_exists( '\SiteGround_Optimizer\Minifier\Minifier' ) ) {
+
+			/* Remove the shutdown buffer and manually close an open buffers */
+			$minifier = \SiteGround_Optimizer\Minifier\Minifier::get_instance();
+			remove_action( 'shutdown', [ $minifier, 'end_html_minifier_buffer' ] );
+
+			while ( ob_get_level() > 0 ) {
+				ob_end_flush();
+			}
+		}
 	}
 
 	/**

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -180,6 +180,8 @@ class Helper_Misc {
 	 *
 	 * 4. Convert any image URLs to local path where applicable
 	 *
+	 * 5. Strips out page breaks
+	 *
 	 * @param string $html The HTML to parse
 	 *
 	 * @return string
@@ -189,6 +191,10 @@ class Helper_Misc {
 		$html = wp_kses_post( $html );
 		$html = trim( wpautop( $html ) );
 		$html = $this->fix_header_footer_images( $html );
+
+		/* Strip page breaks */
+		$html = preg_replace( '/<pagebreak(.+?)?\/?>/', '', $html );
+		$html = preg_replace( '/page-break-(before|after):( +)?(always|left|right|auto|avoid)/', '', $html );
 
 		return $html;
 	}

--- a/src/helper/Helper_PDF.php
+++ b/src/helper/Helper_PDF.php
@@ -239,6 +239,13 @@ class Helper_PDF {
 		$this->set_pdf_format();
 		$this->set_pdf_security();
 		$this->set_display_mode();
+
+		/*
+		 * Allow $mpdf object class to be modified after it is fully initialised
+		 *
+		 * See https://gravitypdf.com/documentation/v5/gfpdf_mpdf_post_init_class/ for more details about this filter
+		 */
+		$this->mpdf = apply_filters( 'gfpdf_mpdf_post_init_class', $this->mpdf, $this->form, $this->entry, $this->settings, $this );
 	}
 
 	/**

--- a/src/model/Model_Install.php
+++ b/src/model/Model_Install.php
@@ -380,10 +380,15 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @return array
 	 */
 	public function register_rewrite_tags( $tags ) {
-		$tags[] = 'gpdf';
-		$tags[] = 'pid';
-		$tags[] = 'lid';
-		$tags[] = 'action';
+		global $wp;
+
+		/* Conditionally register rewrite tags to prevent conflict with other plugins */
+		if ( ! empty( $_GET['gpdf'] ) || ! empty( $_GET['gf_pdf'] ) || strpos( $wp->matched_query, 'gpdf=1' ) === 0 ) {
+			$tags[] = 'gpdf';
+			$tags[] = 'pid';
+			$tags[] = 'lid';
+			$tags[] = 'action';
+		}
 
 		return $tags;
 	}

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -2050,18 +2050,6 @@ class Model_PDF extends Helper_Abstract_Model {
 	}
 
 	/**
-	 * @param array $ignored
-	 *
-	 * @since 4.2
-	 */
-	public function fix_gravityview_frontpage_conflict( $ignored ) {
-		$ignored[] = 'lid';
-		$ignored[] = 'action';
-
-		return $ignored;
-	}
-
-	/**
 	 * Set the watermark font to the current PDF font
 	 *
 	 * @param Mpdf  $mpdf


### PR DESCRIPTION
Changes include:

* Housekeeping: Add filter `gfpdf_mpdf_post_init_class` to interact with mPDF right after the initial Gravity PDF object setup [GH#890]
* Bug: Fix URL rewrite issue with plugins that use `action` GET superglobal [GH#892]
* Bug: Fix conflict with the SG Optimizer plugin's Minify HTML option [GH#897]
* Bug: Strip Page Breaks from Headers and Footers to prevent Fatal PHP Error [GH#898]