### PR TITLE
Fixed WARNING: 'useBuiltIns' without declaring a core-js version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,8 @@
         },
         "modules": false,
         "forceAllTransforms": true,
-        "useBuiltIns": "usage"
+        "useBuiltIns": "usage",
+        "corejs": 2
       }
     ],
     "@babel/preset-react"


### PR DESCRIPTION
## Description

Fixed Terminal WARNING: 'useBuiltIns' without declaring a core-js version

Resolves #904

## Testing instructions
Run: yarn build

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->