### PR TITLE
Resolve PHP Fatal Error in PHP 7.2+

### DIFF
--- a/src/helper/fields/Field_Post_Category.php
+++ b/src/helper/fields/Field_Post_Category.php
@@ -129,6 +129,9 @@ class Field_Post_Category extends Helper_Abstract_Fields {
 
 		} else { /* If Checkboxes or Multiselects */
 
+			$value['value'] = [];
+			$value['label'] = [];
+
 			/* Loop through the results and store in array */
 			foreach ( $field_value as $item ) {
 				$value['value'][] = $item['value'];


### PR DESCRIPTION
## Description

Prevent string to array conversion by setting variables explicitly as arrays.

## Testing instructions

On a Local by Flywheel site with PHP7.2.

Create Gravity Form with a Category field type (under Posts) with the field type set to Checkboxes and save. Ensure you add a couple of post categories under Posts -> Categories. 

Submit a test entry and select one or two options from your category field. 

Add a new PDF to the form and select Zadani as the template type. Save.

View the PDF on the newly submitted entry. Prior to the patch a fatal error would occur. After the patch, it'll be correctly displayed.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/2918419/55377727-032dcd00-5562-11e9-9722-022476ea73e8.png)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
