### PR TITLE
Move legacy JavaScript from Gulp to Webpack

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
-var gulp = require('gulp'),
-  uglify = require('gulp-uglify'),
+let gulp = require('gulp'),
   cleanCSS = require('gulp-clean-css'),
   rename = require('gulp-rename'),
   wpPot = require('gulp-wp-pot'),
@@ -15,16 +14,6 @@ gulp.task('minify', function () {
     .pipe(gulp.dest('dist/assets/css/'))
 })
 
-/* Minify our non-react JS (handled by webpack) */
-gulp.task('compress', function () {
-  return gulp.src('src/assets/js/*.js')
-    .pipe(uglify())
-    .pipe(rename({
-      suffix: '.min'
-    }))
-    .pipe(gulp.dest('dist/assets/js/'))
-})
-
 /* Generate the latest language files */
 gulp.task('language', function () {
   return gulp.src(['src/**/*.php', '*.php'])
@@ -36,8 +25,7 @@ gulp.task('language', function () {
 })
 
 gulp.task('watch', function () {
-  watch('src/assets/js/*.js', gulp.series('compress'))
   watch('src/assets/css/*.css', gulp.series('compress'))
 })
 
-gulp.task('default', gulp.series(['language', 'minify', 'compress']))
+gulp.task('default', gulp.series(['language', 'minify']))

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "gulp-clean-css": "^4.0.0",
     "gulp-rename": "^1.4.0",
     "gulp-sort": "^2.0.0",
-    "gulp-uglify": "^3.0.2",
     "gulp-watch": "^5.0.1",
     "gulp-wp-pot": "^2.3.4",
     "jquery": "^3.3.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,16 +1,19 @@
-var webpack = require('webpack')
-var path = require('path')
+const webpack = require('webpack')
+const path = require('path')
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin')
-
-var PROD = (process.env.NODE_ENV === 'production')
+const PROD = (process.env.NODE_ENV === 'production')
 
 module.exports = {
   entry: {
-    app: './src/assets/js/react/gfpdf-main.js',
+    'app.bundle': './src/assets/js/react/gfpdf-main.js',
+    'gfpdf-backbone': './src/assets/js/gfpdf-backbone.js',
+    'gfpdf-entries': './src/assets/js/gfpdf-entries.js',
+    'gfpdf-migration': './src/assets/js/gfpdf-migration.js',
+    'gfpdf-settings': './src/assets/js/gfpdf-settings.js'
   },
   output: {
     path: __dirname + '/dist/assets/js/',
-    filename: 'app.bundle.min.js'
+    filename: '[name].min.js'
   },
   mode: PROD ? 'production' : 'development',
   devtool: PROD ? 'source-map' : 'eval-source-map',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3703,22 +3703,6 @@ gulp-sort@^2.0.0:
   dependencies:
     through2 "^2.0.1"
 
-gulp-uglify@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/gulp-uglify/-/gulp-uglify-3.0.2.tgz#5f5b2e8337f879ca9dec971feb1b82a5a87850b0"
-  integrity sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==
-  dependencies:
-    array-each "^1.0.1"
-    extend-shallow "^3.0.2"
-    gulplog "^1.0.0"
-    has-gulplog "^0.1.0"
-    isobject "^3.0.1"
-    make-error-cause "^1.1.1"
-    safe-buffer "^5.1.2"
-    through2 "^2.0.0"
-    uglify-js "^3.0.5"
-    vinyl-sourcemaps-apply "^0.2.0"
-
 gulp-watch@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/gulp-watch/-/gulp-watch-5.0.1.tgz#83d378752f5bfb46da023e73c17ed1da7066215d"
@@ -3816,13 +3800,6 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
-
-has-gulplog@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
-  integrity sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=
-  dependencies:
-    sparkles "^1.0.0"
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -5013,18 +4990,6 @@ make-dir@^2.0.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
-
-make-error-cause@^1.1.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/make-error-cause/-/make-error-cause-1.2.2.tgz#df0388fcd0b37816dff0a5fb8108939777dcbc9d"
-  integrity sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=
-  dependencies:
-    make-error "^1.2.0"
-
-make-error@^1.2.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
-  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
 
 make-iterator@^1.0.0:
   version "1.0.1"
@@ -7822,7 +7787,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-uglify-js@^3.0.0, uglify-js@^3.0.5, uglify-js@^3.1.4:
+uglify-js@^3.0.0, uglify-js@^3.1.4:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.2.tgz#dc0c7ac2da0a4b7d15e84266818ff30e82529474"
   integrity sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==
@@ -8119,7 +8084,7 @@ vinyl-sourcemap@^1.1.0:
     remove-bom-buffer "^3.0.0"
     vinyl "^2.0.0"
 
-vinyl-sourcemaps-apply@0.2.1, vinyl-sourcemaps-apply@^0.2.0:
+vinyl-sourcemaps-apply@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
   integrity sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=


### PR DESCRIPTION
## Description

Moving legacy Javascript from Gulp to Webpack bundler.

## Testing instructions
Run the following command:
 - gulp
 - yarn run build

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
