### PR TITLE
Fix gfpdf-settings.js legacy code 'not strict code' for causing error

### DIFF
--- a/src/assets/js/gfpdf-settings.js
+++ b/src/assets/js/gfpdf-settings.js
@@ -511,7 +511,7 @@
           click: function () {
             /* handle ajax call */
             $deleteDialog.wpdialog('close')
-            $elm = $($deleteDialog.data('elm'))
+            let $elm = $($deleteDialog.data('elm'))
 
             /* Add spinner */
             var $spinner = $('<img alt="' + GFPDF.spinnerAlt + '" src="' + GFPDF.spinnerUrl + '" class="gfpdf-spinner gfpdf-spinner-small" />')
@@ -1398,7 +1398,7 @@
         var temp = ''
         if (additionalURL) {
           tempArray = additionalURL.split('&')
-          for (i = 0; i < tempArray.length; i++) {
+          for (let i = 0; i < tempArray.length; i++) {
             if (tempArray[i].split('=')[0] != param) {
               newAdditionalURL += temp + tempArray[i]
               temp = '&'


### PR DESCRIPTION
## Description
Issue: #920
Fixed gfpdf-settings.js legacy code 'not strict code' for causing error.

## Testing instructions

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
