### PR TITLE
Update codebase to use strict comparisons

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,6 +10,7 @@
     <exclude-pattern>/tmp/*</exclude-pattern>
     <exclude-pattern>/dist/*</exclude-pattern>
     <exclude-pattern>*.js</exclude-pattern>
+    <exclude-pattern>/src/helper/licensing/EDD_SL_Plugin_Updater.php</exclude-pattern>
     <exclude-pattern>/tests/phpunit/bootstrap.php</exclude-pattern>
     <exclude-pattern>/tests/phpunit/phpunit6-compat.php</exclude-pattern>
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -330,7 +330,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function plugin_row_meta( $links, $file ) {
 
-		if ( $file == PDF_PLUGIN_BASENAME ) {
+		if ( $file === PDF_PLUGIN_BASENAME ) {
 			$row_meta = [
 				'docs'           => '<a href="' . esc_url( 'https://gravitypdf.com/documentation/v5/five-minute-install/' ) . '" title="' . esc_attr__( 'View Gravity PDF Documentation', 'gravity-forms-pdf-extended' ) . '">' . esc_html__( 'Docs', 'gravity-forms-pdf-extended' ) . '</a>',
 				'support'        => '<a href="' . esc_url( $this->data->settings_url . '&tab=help' ) . '" title="' . esc_attr__( 'Get Help and Support', 'gravity-forms-pdf-extended' ) . '">' . esc_html__( 'Support', 'gravity-forms-pdf-extended' ) . '</a>',
@@ -466,7 +466,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 			wp_enqueue_script( 'gfpdf_js_backbone' );
 		}
 
-		if ( rgget( 'page' ) == 'gf_entries' ) {
+		if ( rgget( 'page' ) === 'gf_entries' ) {
 			wp_enqueue_script( 'gfpdf_js_entries' );
 			wp_enqueue_style( 'gfpdf_css_styles' );
 		}
@@ -956,10 +956,10 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		}
 
 		return [
-			'empty_field'     => ( isset( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' ) ? true : false,
-			'html_field'      => ( isset( $settings['show_html'] ) && $settings['show_html'] == 'Yes' ) ? true : false,
-			'page_names'      => ( isset( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' ) ? true : false,
-			'section_content' => ( isset( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' ) ? true : false,
+			'empty_field'     => ( isset( $settings['show_empty'] ) && $settings['show_empty'] === 'Yes' ) ? true : false,
+			'html_field'      => ( isset( $settings['show_html'] ) && $settings['show_html'] === 'Yes' ) ? true : false,
+			'page_names'      => ( isset( $settings['show_page_names'] ) && $settings['show_page_names'] === 'Yes' ) ? true : false,
+			'section_content' => ( isset( $settings['show_section_content'] ) && $settings['show_section_content'] === 'Yes' ) ? true : false,
 		];
 	}
 }

--- a/src/controller/Controller_Actions.php
+++ b/src/controller/Controller_Actions.php
@@ -196,7 +196,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 
 		/* Prevent actions being displayed on our welcome pages */
 		if ( ! is_admin() ||
-			 ( rgget( 'page' ) == 'gfpdf-getting-started' ) || ( rgget( 'page' ) == 'gfpdf-update' ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX )
+			 ( rgget( 'page' ) === 'gfpdf-getting-started' ) || ( rgget( 'page' ) === 'gfpdf-update' ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX )
 		) {
 			return null;
 		}
@@ -234,7 +234,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 		foreach ( $this->get_routes() as $route ) {
 
 			/* Check we have a valid action and the display condition is true */
-			if ( rgpost( 'gfpdf_action' ) == 'gfpdf_' . $route['action'] && call_user_func( $route['condition'] ) ) {
+			if ( rgpost( 'gfpdf_action' ) === 'gfpdf_' . $route['action'] && call_user_func( $route['condition'] ) ) {
 
 				/* Check user capability */
 				if ( ! $this->gform->has_capability( $route['capability'] ) ) {

--- a/src/controller/Controller_PDF.php
+++ b/src/controller/Controller_PDF.php
@@ -237,7 +237,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		$pid    = $GLOBALS['wp']->query_vars['pid'];
 		$lid    = (int) $GLOBALS['wp']->query_vars['lid'];
-		$action = ( ( isset( $GLOBALS['wp']->query_vars['action'] ) ) && $GLOBALS['wp']->query_vars['action'] == 'download' ) ? 'download' : 'view';
+		$action = ( ( isset( $GLOBALS['wp']->query_vars['action'] ) ) && $GLOBALS['wp']->query_vars['action'] === 'download' ) ? 'download' : 'view';
 
 		$this->log->addNotice(
 			'Processing PDF endpoint.',
@@ -367,7 +367,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		/* only display detailed error to admins */
 		$whitelist_errors = [ 'timeout_expired', 'access_denied' ];
-		if ( $this->gform->has_capability( 'gravityforms_view_settings' ) || in_array( $error->get_error_code(), $whitelist_errors ) ) {
+		if ( $this->gform->has_capability( 'gravityforms_view_settings' ) || in_array( $error->get_error_code(), $whitelist_errors, true ) ) {
 			wp_die( $error->get_error_message() );
 		} else {
 			wp_die( esc_html__( 'There was a problem generating your PDF', 'gravity-forms-pdf-extended' ) );

--- a/src/controller/Controller_Save_Core_Fonts.php
+++ b/src/controller/Controller_Save_Core_Fonts.php
@@ -165,7 +165,7 @@ class Controller_Save_Core_Fonts extends Helper_Abstract_Controller implements H
 			return false;
 		}
 
-		if ( $res_code != '200' ) {
+		if ( $res_code !== 200 ) {
 			$this->log->addError(
 				'Core Font API Response Failed',
 				[

--- a/src/deprecated.php
+++ b/src/deprecated.php
@@ -457,7 +457,7 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 			$excluded = [ 'captcha', 'password', 'page' ];
 
 			/* Skip over any fields we don't want to include */
-			if ( in_array( $input, $excluded ) ) {
+			if ( in_array( $input, $excluded, true ) ) {
 				continue;
 			}
 
@@ -467,7 +467,7 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 			self::load_legacy_css( $field );
 
 			/* Check if HTML field should be included */
-			if ( $input == 'html' ) {
+			if ( $input === 'html' ) {
 
 				if ( $config['html_field'] === true ) {
 					$html = $class->html();

--- a/src/helper/Helper_Field_Container.php
+++ b/src/helper/Helper_Field_Container.php
@@ -302,7 +302,7 @@ class Helper_Field_Container {
 	 */
 	private function process_skipped_fields( GF_Field $field ) {
 		/* if we have a skipped field and the container is open we will close it */
-		if ( in_array( $field->type, $this->skip_fields ) ) {
+		if ( in_array( $field->type, $this->skip_fields, true ) ) {
 			$this->strip_field_of_any_classmaps( $field );
 			$this->close();
 

--- a/src/helper/Helper_Logger.php
+++ b/src/helper/Helper_Logger.php
@@ -134,9 +134,9 @@ class Helper_Logger {
 
 		/* Set the logger timezone once (if needed) */
 		if ( ! $timezone ) {
-			$offset = get_option( 'gmt_offset' );
+			$offset = (float) get_option( 'gmt_offset' );
 
-			if ( $offset != 0 ) {
+			if ( $offset !== 0.0 ) {
 				try {
 					$timezone = new DateTimeZone( ( $offset > 0 ) ? '+' . $offset : $offset );
 					Logger::setTimezone( $timezone );

--- a/src/helper/Helper_Migration.php
+++ b/src/helper/Helper_Migration.php
@@ -276,7 +276,7 @@ class Helper_Migration {
 
 		/* Fix the public access key */
 		if ( isset( $node['access'] ) ) {
-			$node['access'] = ( $node['access'] == 'all' ) ? 'Yes' : 'No';
+			$node['access'] = ( $node['access'] === 'all' ) ? 'Yes' : 'No';
 		}
 
 		/* Remove .php from the template file */
@@ -293,7 +293,7 @@ class Helper_Migration {
 		if ( isset( $node['pdf_size'] ) && is_array( $node['pdf_size'] ) ) {
 
 			/* Ensure it's in the correct format */
-			if ( sizeof( $node['pdf_size'] ) == 2 ) {
+			if ( sizeof( $node['pdf_size'] ) === 2 ) {
 				$node['pdf_size'][0] = (int) $node['pdf_size'][0];
 				$node['pdf_size'][1] = (int) $node['pdf_size'][1];
 				$node['pdf_size'][2] = 'millimeters';
@@ -312,7 +312,7 @@ class Helper_Migration {
 
 			/* Convert our boolean values into 'Yes' or 'No' responses, with the exception of notification */
 			$skip_nodes = [ 'notifications', 'notification' ];
-			if ( ! in_array( $id, $skip_nodes ) ) {
+			if ( ! in_array( $id, $skip_nodes, true ) ) {
 				$val = $this->misc->update_deprecated_config( $val );
 			}
 
@@ -337,7 +337,7 @@ class Helper_Migration {
 	 */
 	private function process_v3_configuration( $raw_config ) {
 
-		if ( ! is_array( $raw_config['config'] ) || sizeof( $raw_config['config'] ) == 0 ) {
+		if ( ! is_array( $raw_config['config'] ) || sizeof( $raw_config['config'] ) === 0 ) {
 			return [];
 		}
 
@@ -467,7 +467,7 @@ class Helper_Migration {
 				foreach ( $form['notifications'] as $notification ) {
 					$event = ( isset( $notification['event'] ) ) ? $notification['event'] : '';
 
-					if ( ! in_array( $event, $omit ) ) {
+					if ( ! in_array( $event, $omit, true ) ) {
 						$notifications[ $notification['id'] ] = $notification['name'];
 					}
 				}
@@ -518,7 +518,7 @@ class Helper_Migration {
 
 							$new_notification = [];
 							foreach ( $node['notification'] as $email ) {
-								$match = array_search( $email, $notifications );
+								$match = array_search( $email, $notifications, true );
 
 								if ( $match !== false ) {
 									$new_notification[] = $match;

--- a/src/helper/Helper_Misc.php
+++ b/src/helper/Helper_Misc.php
@@ -536,7 +536,7 @@ class Helper_Misc {
 		$upload_path = trim( get_option( 'upload_path' ) );
 		$dir         = $upload_path;
 
-		if ( empty( $upload_path ) || 'wp-content/uploads' == $upload_path ) {
+		if ( empty( $upload_path ) || 'wp-content/uploads' === $upload_path ) {
 			$dir = WP_CONTENT_DIR . '/uploads';
 		} elseif ( 0 !== strpos( $upload_path, ABSPATH ) ) {
 			/* $dir is absolute, $upload_path is (maybe) relative to ABSPATH */
@@ -545,7 +545,7 @@ class Helper_Misc {
 
 		$url = get_option( 'upload_url_path' );
 		if ( ! $url ) {
-			if ( empty( $upload_path ) || ( 'wp-content/uploads' == $upload_path ) || ( $upload_path == $dir ) ) {
+			if ( empty( $upload_path ) || ( 'wp-content/uploads' === $upload_path ) || ( $upload_path === $dir ) ) {
 				$url = WP_CONTENT_URL . '/uploads';
 			} else {
 				$url = trailingslashit( $siteurl ) . $upload_path;
@@ -575,7 +575,7 @@ class Helper_Misc {
 	public function convert_url_to_path( $url ) {
 
 		/* If $url is empty we'll return early */
-		if ( trim( $url ) == false ) {
+		if ( empty( trim( $url ) ) ) {
 			return $url;
 		}
 
@@ -633,7 +633,7 @@ class Helper_Misc {
 	public function convert_path_to_url( $path ) {
 
 		/* If $url is empty we'll return early */
-		if ( trim( $path ) == false ) {
+		if ( empty( trim( $path ) ) ) {
 			return $path;
 		}
 
@@ -709,7 +709,7 @@ class Helper_Misc {
 	public function get_legacy_ids( $entry_id, $settings ) {
 
 		$leads    = rgget( 'lid' );
-		$override = ( isset( $settings['public_access'] ) && $settings['public_access'] == 'Yes' ) ? true : false;
+		$override = ( isset( $settings['public_access'] ) && $settings['public_access'] === 'Yes' ) ? true : false;
 
 		if ( $leads && ( $override === true || $this->gform->has_capability( 'gravityforms_view_entries' ) ) ) {
 			$ids = explode( ',', $leads );
@@ -853,14 +853,14 @@ class Helper_Misc {
 	public function backwards_compat_conversion( $settings, $form, $entry ) {
 
 		$compat                   = [];
-		$compat['premium']        = ( isset( $settings['advanced_template'] ) && $settings['advanced_template'] == 'Yes' ) ? true : false;
-		$compat['rtl']            = ( isset( $settings['rtl'] ) && $settings['rtl'] == 'Yes' ) ? true : false;
+		$compat['premium']        = ( isset( $settings['advanced_template'] ) && $settings['advanced_template'] === 'Yes' ) ? true : false;
+		$compat['rtl']            = ( isset( $settings['rtl'] ) && $settings['rtl'] === 'Yes' ) ? true : false;
 		$compat['dpi']            = ( isset( $settings['image_dpi'] ) ) ? (int) $settings['image_dpi'] : 96;
-		$compat['security']       = ( isset( $settings['security'] ) && $settings['security'] == 'Yes' ) ? true : false;
+		$compat['security']       = ( isset( $settings['security'] ) && $settings['security'] === 'Yes' ) ? true : false;
 		$compat['pdf_password']   = ( isset( $settings['password'] ) ) ? $this->gform->process_tags( $settings['password'], $form, $entry ) : '';
 		$compat['pdf_privileges'] = ( isset( $settings['privileges'] ) ) ? $settings['privileges'] : '';
-		$compat['pdfa1b']         = ( isset( $settings['format'] ) && $settings['format'] == 'PDFA1B' ) ? true : false;
-		$compat['pdfx1a']         = ( isset( $settings['format'] ) && $settings['format'] == 'PDFX1A' ) ? true : false;
+		$compat['pdfa1b']         = ( isset( $settings['format'] ) && $settings['format'] === 'PDFA1B' ) ? true : false;
+		$compat['pdfx1a']         = ( isset( $settings['format'] ) && $settings['format'] === 'PDFX1A' ) ? true : false;
 
 		return $compat;
 	}
@@ -917,11 +917,13 @@ class Helper_Misc {
 	 */
 	public function in_array( $needle, $haystack, $strict = true ) {
 		foreach ( $haystack as $item ) {
+			/* phpcs:disable */
 			if ( ( $strict ? $item === $needle : $item == $needle ) ||
 				 ( is_array( $item ) && $this->in_array( $needle, $item, $strict ) )
 			) {
 				return true;
 			}
+			/* phpcs:enable */
 		}
 
 		return false;

--- a/src/helper/Helper_PDF.php
+++ b/src/helper/Helper_PDF.php
@@ -434,7 +434,7 @@ class Helper_PDF {
 	public function set_output_type( $type ) {
 		$valid = [ 'DISPLAY', 'DOWNLOAD', 'SAVE' ];
 
-		if ( ! in_array( strtoupper( $type ), $valid ) ) {
+		if ( ! in_array( strtoupper( $type ), $valid, true ) ) {
 			throw new Exception( sprintf( 'Display type not valid. Use %s', implode( ', ', $valid ) ) );
 		}
 
@@ -494,7 +494,7 @@ class Helper_PDF {
 		$valid_layout = [ 'single', 'continuous', 'two', 'twoleft', 'tworight', 'default' ];
 
 		/* check the mode */
-		if ( ! in_array( strtolower( $mode ), $valid_mode ) ) {
+		if ( ! in_array( strtolower( $mode ), $valid_mode, true ) ) {
 			/* determine if the mode is an integer */
 			if ( ! is_int( $mode ) || $mode <= 10 ) {
 				throw new Exception( sprintf( 'Mode must be an number value more than 10 or one of these types: %s', implode( ', ', $valid_mode ) ) );
@@ -502,7 +502,7 @@ class Helper_PDF {
 		}
 
 		/* check the layout */
-		if ( ! in_array( strtolower( $layout ), $valid_layout ) ) {
+		if ( ! in_array( strtolower( $layout ), $valid_layout, true ) ) {
 			throw new Exception( sprintf( 'Layout must be one of these types: %s', implode( ', ', $valid_layout ) ) );
 		}
 
@@ -763,12 +763,12 @@ class Helper_PDF {
 			'CUSTOM',
 		];
 
-		if ( ! in_array( $paper_size, $valid_paper_size ) ) {
+		if ( ! in_array( $paper_size, $valid_paper_size, true ) ) {
 			throw new Exception( sprintf( 'Paper size not valid. Use %s', implode( ', ', $valid_paper_size ) ) );
 		}
 
 		/* set our paper size and orientation based on user selection */
-		if ( $paper_size == 'CUSTOM' ) {
+		if ( $paper_size === 'CUSTOM' ) {
 			$this->set_custom_paper_size();
 			$this->set_orientation( true );
 		} else {
@@ -817,8 +817,8 @@ class Helper_PDF {
 	 * @since  4.0
 	 */
 	protected function get_paper_size( $size ) {
-		$size[0] = ( $size[2] == 'inches' ) ? (int) $size[0] * 25.4 : (int) $size[0];
-		$size[1] = ( $size[2] == 'inches' ) ? (int) $size[1] * 25.4 : (int) $size[1];
+		$size[0] = ( $size[2] === 'inches' ) ? (int) $size[0] * 25.4 : (int) $size[0];
+		$size[1] = ( $size[2] === 'inches' ) ? (int) $size[1] * 25.4 : (int) $size[1];
 
 		/* tidy up custom paper size array */
 		unset( $size[2] );
@@ -845,9 +845,9 @@ class Helper_PDF {
 		 * @todo Update mPDF to be more consistent when setting portrait and landscape documentation
 		 */
 		if ( $custom ) {
-			$this->orientation = ( $orientation == 'landscape' ) ? 'L' : 'P';
+			$this->orientation = ( $orientation === 'landscape' ) ? 'L' : 'P';
 		} else {
-			$this->orientation = ( $orientation == 'landscape' ) ? '-L' : '';
+			$this->orientation = ( $orientation === 'landscape' ) ? '-L' : '';
 			$this->paper_size .= $this->orientation;
 		}
 	}
@@ -929,7 +929,7 @@ class Helper_PDF {
 	protected function set_text_direction() {
 		$rtl = ( isset( $this->settings['rtl'] ) ) ? $this->settings['rtl'] : 'No';
 
-		if ( strtolower( $rtl ) == 'yes' ) {
+		if ( strtolower( $rtl ) === 'yes' ) {
 			$this->mpdf->SetDirectionality( 'rtl' );
 		}
 	}
@@ -965,7 +965,7 @@ class Helper_PDF {
 	 */
 	protected function set_pdf_security() {
 		/* Security settings cannot be applied to pdfa1b or pdfx1a formats */
-		if ( strtolower( $this->settings['format'] ) == 'standard' && strtolower( $this->settings['security'] == 'Yes' ) ) {
+		if ( strtolower( $this->settings['format'] ) === 'standard' && strtolower( $this->settings['security'] ) === 'yes' ) {
 
 			$password        = ( isset( $this->settings['password'] ) ) ? $this->gform->process_tags( $this->settings['password'], $this->form, $this->entry ) : '';
 			$privileges      = ( isset( $this->settings['privileges'] ) ) ? $this->settings['privileges'] : [];

--- a/src/helper/Helper_PDF_List_Table.php
+++ b/src/helper/Helper_PDF_List_Table.php
@@ -197,7 +197,7 @@ class Helper_PDF_List_Table extends WP_List_Table {
 	public function single_row( $item ) {
 		static $row_class = '';
 
-		$row_class = ( $row_class == '' ? 'class="alternate"' : $row_class );
+		$row_class = ( $row_class === '' ? 'class="alternate"' : $row_class );
 
 		echo '<tr id="gfpdf-' . $item['id'] . '" ' . $row_class . '>';
 		$this->single_row_columns( $item );
@@ -263,7 +263,7 @@ class Helper_PDF_List_Table extends WP_List_Table {
 	 * @since 4.0
 	 */
 	public function column_notifications( $item ) {
-		if ( ! isset( $item['notification'] ) || sizeof( $item['notification'] ) == 0 ) {
+		if ( ! isset( $item['notification'] ) || sizeof( $item['notification'] ) === 0 ) {
 			esc_html_e( 'None', 'gravity-forms-pdf-extended' );
 
 			return;
@@ -272,7 +272,7 @@ class Helper_PDF_List_Table extends WP_List_Table {
 		/* Convert our IDs to names */
 		$notification_names = [];
 		foreach ( $this->form['notifications'] as $notification ) {
-			if ( in_array( $notification['id'], $item['notification'] ) ) {
+			if ( in_array( $notification['id'], $item['notification'], true ) ) {
 				$notification_names[] = $notification['name'];
 			}
 		}
@@ -355,7 +355,7 @@ class Helper_PDF_List_Table extends WP_List_Table {
 				$keys     = array_keys( $actions );
 				$last_key = array_pop( $keys );
 				foreach ( $actions as $key => $html ) {
-					$divider = $key == $last_key ? '' : ' | ';
+					$divider = $key === $last_key ? '' : ' | ';
 					?>
 					<span class="<?php echo $key; ?>">
 						<?php echo $html . $divider; ?>

--- a/src/helper/Helper_Templates.php
+++ b/src/helper/Helper_Templates.php
@@ -259,7 +259,7 @@ class Helper_Templates {
 			 * we'll include it in our template list
 			 */
 			if ( $file_name !== 'configuration' && $file_name !== 'configuration.archive'
-				 && ! in_array( $file_name, $current_template_list )
+				 && ! in_array( $file_name, $current_template_list, true )
 			) {
 				$template_list[] = $template;
 			}
@@ -562,7 +562,7 @@ class Helper_Templates {
 			]
 		);
 
-		if ( in_array( $template_id, $legacy_templates ) ) {
+		if ( in_array( $template_id, $legacy_templates, true ) ) {
 			try {
 				$class = $this->load_template_config_file( PDF_PLUGIN_DIR . 'src/templates/config/legacy.php' );
 			} catch ( Exception $e ) {

--- a/src/helper/abstract/Helper_Abstract_Fields.php
+++ b/src/helper/abstract/Helper_Abstract_Fields.php
@@ -309,7 +309,7 @@ abstract class Helper_Abstract_Fields {
 		 */
 		$skip_fields = apply_filters( 'gfpdf_skip_encode_mergetags_on_fields', [ 'html', 'section' ], $this->field, $this->entry, $this->form );
 		if ( ( empty( $this->field->visibility ) || $this->field->visibility !== 'administrative' ) &&
-			 ! in_array( $this->field->type, $skip_fields ) ) {
+			 ! in_array( $this->field->type, $skip_fields, true ) ) {
 			$value = $this->encode_tags( $value );
 		}
 

--- a/src/helper/abstract/Helper_Abstract_Options.php
+++ b/src/helper/abstract/Helper_Abstract_Options.php
@@ -567,7 +567,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			]
 		);
 
-		if ( empty( $pdf ) || ! is_array( $pdf ) || sizeof( $pdf ) == 0 ) {
+		if ( empty( $pdf ) || ! is_array( $pdf ) || sizeof( $pdf ) === 0 ) {
 			/* No value was passed in so we will delete the PDF */
 			$remove_option = $this->delete_pdf( $form_id, $pdf_id );
 
@@ -837,7 +837,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		foreach ( $roles as $role ) {
 			if ( isset( $role['capabilities'] ) && is_array( $role['capabilities'] ) ) {
 				foreach ( $role['capabilities'] as $cap => $val ) {
-					if ( ! isset( $capabilities[ $cap ] ) && ! in_array( $cap, $gf_caps ) ) {
+					if ( ! isset( $capabilities[ $cap ] ) && ! in_array( $cap, $gf_caps, true ) ) {
 						$capabilities[ esc_html__( 'Active WordPress Capabilities', 'gravity-forms-pdf-extended' ) ][ $cap ] = $cap;
 					}
 				}
@@ -1146,7 +1146,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 
 		$gfpdf_options = $this->settings;
 
-		if ( empty( $_POST['_wp_http_referer'] ) || empty( $_POST['option_page'] ) || $_POST['option_page'] != 'gfpdf_settings' ) {
+		if ( empty( $_POST['_wp_http_referer'] ) || empty( $_POST['option_page'] ) || $_POST['option_page'] !== 'gfpdf_settings' ) {
 			return $input;
 		}
 
@@ -1165,7 +1165,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			 * Check if extra item(s) belongs on page but isn't the existing page
 			 * Note that this requires the section ID share a similar ID to what is referenced in $tab
 			 */
-			if ( $tab != $id && $tab == substr( $id, 0, $tab_len ) ) {
+			if ( $tab !== $id && $tab === substr( $id, 0, $tab_len ) ) {
 				$settings = array_merge( $settings, $s );
 			}
 		}
@@ -1278,7 +1278,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	 * @since 4.0
 	 */
 	public function sanitize_paper_size( $input ) {
-		if ( is_array( $input ) && sizeof( $input ) == 3 ) {
+		if ( is_array( $input ) && sizeof( $input ) === 3 ) {
 			$input[0] = abs( $input[0] );
 			$input[1] = abs( $input[1] );
 		}
@@ -1319,7 +1319,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			$settings
 		);
 
-		if ( in_array( $key, $ignored_fields ) ) {
+		if ( in_array( $key, $ignored_fields, true ) ) {
 			return $value;
 		}
 
@@ -1432,7 +1432,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		}
 
 		/* Fix up our conditional logic array so it returns a string value */
-		if ( $args['id'] == 'conditionalLogic' && isset( $pdf_form_settings['conditionalLogic'] ) ) {
+		if ( $args['id'] === 'conditionalLogic' && isset( $pdf_form_settings['conditionalLogic'] ) ) {
 			$pdf_form_settings['conditionalLogic'] = json_encode( $pdf_form_settings['conditionalLogic'] );
 		}
 
@@ -1620,7 +1620,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		foreach ( $args['options'] as $key => $option ) {
 
 			$checked = false;
-			if ( $selected == $key ) {
+			if ( $selected === $key ) {
 				$checked = true;
 			}
 
@@ -1902,7 +1902,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 				if ( is_array( $value ) ) {
 					foreach ( $value as $v ) {
 						$selected = selected( $option, $v, false );
-						if ( $selected != '' ) {
+						if ( $selected !== '' ) {
 							break;
 						}
 					}
@@ -1918,7 +1918,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 					if ( is_array( $value ) ) {
 						foreach ( $value as $v ) {
 							$selected = selected( $op_value, $v, false );
-							if ( $selected != '' ) {
+							if ( $selected !== '' ) {
 								break;
 							}
 						}

--- a/src/helper/fields/Field_Address.php
+++ b/src/helper/fields/Field_Address.php
@@ -101,7 +101,7 @@ class Field_Address extends Helper_Abstract_Fields {
 		}
 
 		/* display in the standard "city, state zip" format */
-		if ( $address_display_format != 'zip_before_city' ) {
+		if ( $address_display_format !== 'zip_before_city' ) {
 			$zip_string  = $data['city'];
 			$zip_string .= ( ! empty( $zip_string ) && ! empty( $data['state'] ) ) ? ", {$data['state']}" : trim( $data['state'] );
 			$zip_string .= " {$data['zip']}";

--- a/src/helper/fields/Field_Likert.php
+++ b/src/helper/fields/Field_Likert.php
@@ -149,7 +149,7 @@ class Field_Likert extends Helper_Abstract_Fields {
 					/* check if user selected this likert value */
 					$data = rgar( $this->entry, $row['id'] );
 
-					$likert['rows'][ $row['label'] ][ $text ] = ( ( $row['name'] . ':' . $id ) == $data ) ? 'selected' : '';
+					$likert['rows'][ $row['label'] ][ $text ] = ( ( $row['name'] . ':' . $id ) === $data ) ? 'selected' : '';
 				}
 			}
 		} else { /* Handle our single-row likert */
@@ -158,7 +158,7 @@ class Field_Likert extends Helper_Abstract_Fields {
 			$data = rgar( $this->entry, $this->field->id );
 			foreach ( $likert['col'] as $id => $text ) {
 				/* check if user selected this likert value */
-				$likert['row'][ $text ] = ( $id == $data ) ? 'selected' : '';
+				$likert['row'][ $text ] = ( $id === $data ) ? 'selected' : '';
 			}
 		}
 

--- a/src/helper/fields/Field_Multiselect.php
+++ b/src/helper/fields/Field_Multiselect.php
@@ -167,7 +167,7 @@ class Field_Multiselect extends Helper_Abstract_Fields {
 		/* Add support for JSON stored multiselect fields (added to GF2.2) */
 		if ( $this->field->storageType === 'json' ) {
 			$value = json_decode( $value, true );
-			$value = ( $value == null ) ? [] : $value;
+			$value = ( $value === null ) ? [] : $value;
 		}
 
 		/* split value into an array */

--- a/src/helper/fields/Field_Post_Image.php
+++ b/src/helper/fields/Field_Post_Image.php
@@ -162,7 +162,7 @@ class Field_Post_Image extends Helper_Abstract_Fields {
 			$img['description'] = ( isset( $value[3] ) ) ? esc_html( $value[3] ) : '';
 
 			$path = ( isset( $value[0] ) ) ? $this->misc->convert_url_to_path( $value[0] ) : '';
-			if ( $path != $img['url'] ) {
+			if ( $path !== $img['url'] ) {
 				$img['path'] = $path;
 			}
 		}

--- a/src/helper/fields/Field_Product.php
+++ b/src/helper/fields/Field_Product.php
@@ -81,7 +81,7 @@ class Field_Product extends Helper_Abstract_Field_Products {
 		$html  = '';
 
 		if ( isset( $value['price'] ) ) {
-			if ( in_array( $this->field->get_input_type(), [ 'radio', 'select' ] ) ) {
+			if ( in_array( $this->field->get_input_type(), [ 'radio', 'select' ], true ) ) {
 				$html .= $value['name'] . ' - ' . $value['price'];
 			} else {
 				$html .= $value['price'];

--- a/src/helper/fields/Field_Products.php
+++ b/src/helper/fields/Field_Products.php
@@ -170,7 +170,7 @@ class Field_Products extends Helper_Abstract_Fields {
 						foreach ( $products['products'] as $field_id => $product ) :
 
 							/* Skip over Gravity Perks Ecommerce Fields */
-							if ( class_exists( 'GP_Ecommerce_Fields' ) && in_array( $fields[ $field_id ]->type, [ 'tax', 'discount' ] ) ) {
+							if ( class_exists( 'GP_Ecommerce_Fields' ) && in_array( $fields[ $field_id ]->type, [ 'tax', 'discount' ], true ) ) {
 								continue;
 							}
 							?>

--- a/src/helper/fields/Field_Quiz.php
+++ b/src/helper/fields/Field_Quiz.php
@@ -87,7 +87,7 @@ class Field_Quiz extends Helper_Abstract_Fields {
 		$value = apply_filters( 'gform_entry_field_value', $this->get_value(), $this->field, $this->entry, $this->form );
 
 		/* Return early to prevent any problems with when field is empty or the quiz plugin isn't enabled */
-		if ( ! class_exists( 'GFQuiz' ) || ! is_string( $value ) || trim( $value ) == false ) {
+		if ( ! class_exists( 'GFQuiz' ) || ! is_string( $value ) || trim( $value ) === false ) {
 			return parent::html( '' );
 		}
 
@@ -123,7 +123,7 @@ class Field_Quiz extends Helper_Abstract_Fields {
 		/* Loop through our results */
 		foreach ( $value as $item ) {
 			foreach ( $this->field->choices as $choice ) {
-				if ( $choice['value'] == $item ) {
+				if ( $choice['value'] === $item ) {
 					$formatted[] = [
 						'text'      => esc_html( $choice['text'] ),
 						'isCorrect' => $choice['gquizIsCorrect'],

--- a/src/helper/fields/Field_Rank.php
+++ b/src/helper/fields/Field_Rank.php
@@ -104,7 +104,7 @@ class Field_Rank extends Helper_Abstract_Fields {
 
 			/* Loop through the total choices */
 			foreach ( $this->field->choices as $choice ) {
-				if ( trim( $choice['value'] ) == trim( $rating ) ) {
+				if ( trim( $choice['value'] ) === trim( $rating ) ) {
 					$value[] = esc_html( $choice['text'] );
 					break; /* exit inner loop as soon as found */
 				}

--- a/src/helper/fields/Field_Rating.php
+++ b/src/helper/fields/Field_Rating.php
@@ -104,7 +104,7 @@ class Field_Rating extends Helper_Abstract_Fields {
 
 			/* Loop through the total choices */
 			foreach ( $this->field->choices as $choice ) {
-				if ( trim( $choice['value'] ) == trim( $rating ) ) {
+				if ( trim( $choice['value'] ) === trim( $rating ) ) {
 					$value[] = esc_html( $choice['text'] );
 					break; /* exit inner loop as soon as found */
 				}

--- a/src/helper/fields/Field_Slim_Post.php
+++ b/src/helper/fields/Field_Slim_Post.php
@@ -91,7 +91,7 @@ class Field_Slim_Post extends Helper_Abstract_Fields {
 			$img['description'] = ( isset( $value[3] ) ) ? esc_html( $value[3] ) : '';
 
 			$path = ( isset( $value[0] ) ) ? $this->misc->convert_url_to_path( $value[0] ) : '';
-			if ( $path != $img['url'] ) {
+			if ( $path !== $img['url'] ) {
 				$img['path'] = $path;
 			}
 		}

--- a/src/helper/fields/Field_Survey.php
+++ b/src/helper/fields/Field_Survey.php
@@ -155,7 +155,7 @@ class Field_Survey extends Helper_Abstract_Fields {
 				/* Convert survey ID to real value */
 				foreach ( $this->field->choices as $choice ) {
 
-					$key = array_search( $choice['value'], $value );
+					$key = array_search( $choice['value'], $value, true );
 					if ( $key !== false ) {
 						$value[ $key ] = esc_html( $choice['text'] );
 					}

--- a/src/model/Model_Form_Settings.php
+++ b/src/model/Model_Form_Settings.php
@@ -342,7 +342,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* Do validation */
 		if ( empty( $sanitized['name'] ) || empty( $sanitized['filename'] ) ||
-			 ( $sanitized['pdf_size'] == 'CUSTOM' && ( (int) $sanitized['custom_pdf_size'][0] === 0 || (int) $sanitized['custom_pdf_size'][1] === 0 ) )
+			 ( $sanitized['pdf_size'] === 'CUSTOM' && ( (int) $sanitized['custom_pdf_size'][0] === 0 || (int) $sanitized['custom_pdf_size'][1] === 0 ) )
 		) {
 			$this->notices->add_error( esc_html__( 'PDF could not be saved. Please enter all required information below.', 'gravity-forms-pdf-extended' ) );
 
@@ -465,7 +465,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	 */
 	public function check_custom_size_error_highlighting( $skip, $field, $input ) {
 
-		if ( $field['id'] == 'custom_pdf_size' ) {
+		if ( $field['id'] === 'custom_pdf_size' ) {
 
 			/* Skip if not currently being shown */
 			if ( $input['pdf_size'] !== 'CUSTOM' ) {
@@ -700,7 +700,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	 */
 	public function parse_filename_extension( $value, $key ) {
 
-		if ( $key == 'filename' ) {
+		if ( $key === 'filename' ) {
 			$value = $this->misc->remove_extension_from_string( $value );
 		}
 
@@ -717,7 +717,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 	 */
 	public function decode_json( $value, $key ) {
 
-		if ( $key == 'conditionalLogic' ) {
+		if ( $key === 'conditionalLogic' ) {
 			return json_decode( $value, true );
 		}
 
@@ -746,7 +746,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			foreach ( $notifications as $notification ) {
 				$event = ( isset( $notification['event'] ) ) ? $notification['event'] : '';
 
-				if ( ! in_array( $event, $omit ) ) {
+				if ( ! in_array( $event, $omit, true ) ) {
 					$options[ $notification['id'] ] = $notification['name'];
 				}
 			}
@@ -950,7 +950,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		$settings = $this->setup_custom_appearance_settings( $class );
 
 		/* Only handle fields when in the PDF Forms Settings, and not in the general settings */
-		if ( $type != 'gfpdf_settings[default_template]' ) {
+		if ( $type !== 'gfpdf_settings[default_template]' ) {
 
 			/* Get the template type so we can return out to the browser */
 			$template_data = $this->templates->get_template_info_by_id( $template );
@@ -986,7 +986,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			$editors = [];
 
 			foreach ( $settings as $field ) {
-				if ( isset( $field['type'] ) && $field['type'] == 'rich_editor' ) {
+				if ( isset( $field['type'] ) && $field['type'] === 'rich_editor' ) {
 					$editors[] = 'gfpdf_settings_' . $field['id'];
 				}
 			}

--- a/src/model/Model_PDF.php
+++ b/src/model/Model_PDF.php
@@ -599,7 +599,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		if ( ! is_wp_error( $action ) ) {
 			/* check if the user is logged in but is not the current owner */
 			if ( is_user_logged_in() &&
-				 ( ( $this->options->get_option( 'limit_to_admin', 'No' ) == 'Yes' ) || ( $this->is_current_pdf_owner( $entry, 'logged_in' ) === false ) )
+				 ( ( $this->options->get_option( 'limit_to_admin', 'No' ) === 'Yes' ) || ( $this->is_current_pdf_owner( $entry, 'logged_in' ) === false ) )
 			) {
 
 				/* Handle permissions checks */
@@ -906,7 +906,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				$this->options->increment_pdf_count();
 
 				/* Add Backwards compatibility support for our v3 Tier 2 Add-on */
-				if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) == 'yes' ) {
+				if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) === 'yes' ) {
 
 					/* Check if we should process this document using our legacy system */
 					if ( $this->handle_legacy_tier_2_processing( $pdf, $entry, $settings, $args ) ) {
@@ -1090,7 +1090,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		$attach = false;
 		if ( isset( $settings['notification'] ) && is_array( $settings['notification'] ) ) {
-			if ( in_array( $notification['id'], $settings['notification'] ) ) {
+			if ( in_array( $notification['id'], $settings['notification'], true ) ) {
 				$attach = true;
 			}
 		}
@@ -1114,7 +1114,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	public function maybe_always_save_pdf( $settings ) {
 
 		$save = false;
-		if ( isset( $settings['save'] ) && strtolower( $settings['save'] ) == 'yes' ) {
+		if ( isset( $settings['save'] ) && strtolower( $settings['save'] ) === 'yes' ) {
 			$save = true;
 		}
 
@@ -1195,7 +1195,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				);
 
 				foreach ( $directory_list as $file ) {
-					if ( in_array( $file->getFilename(), [ '.htaccess', 'index.html' ] ) || strpos( realpath( $file->getPathname() ), realpath( $this->data->mpdf_tmp_location ) ) !== false ) {
+					if ( in_array( $file->getFilename(), [ '.htaccess', 'index.html' ], true ) || strpos( realpath( $file->getPathname() ), realpath( $this->data->mpdf_tmp_location ) ) !== false ) {
 						continue;
 					}
 
@@ -1418,7 +1418,7 @@ class Model_PDF extends Helper_Abstract_Model {
 					]
 				);
 
-				if ( in_array( $field->type, $fields_to_skip ) ) {
+				if ( in_array( $field->type, $fields_to_skip, true ) ) {
 					continue;
 				}
 
@@ -1568,7 +1568,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				foreach ( $fields as $field ) {
 
 					/* Check if we have a multifield likert and replace the row key */
-					if ( isset( $field['gsurveyLikertEnableMultipleRows'] ) && $field['gsurveyLikertEnableMultipleRows'] == 1 ) {
+					if ( isset( $field['gsurveyLikertEnableMultipleRows'] ) && $field['gsurveyLikertEnableMultipleRows'] === true ) {
 
 						foreach ( $field['gsurveyLikertRows'] as $row ) {
 
@@ -1719,7 +1719,7 @@ class Model_PDF extends Helper_Abstract_Model {
 						$results['field_data'][ $field->id ] = $this->replace_key( $results['field_data'][ $field->id ], $choice['value'], $choice['text'] );
 
 						/* Check if this is the correct field */
-						if ( isset( $choice['gquizIsCorrect'] ) && $choice['gquizIsCorrect'] == 1 ) {
+						if ( isset( $choice['gquizIsCorrect'] ) && $choice['gquizIsCorrect'] === true ) {
 							$results['field_data'][ $field->id ]['misc']['correct_option_name'][] = esc_html( $choice['text'] );
 						}
 					}
@@ -1798,7 +1798,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		if ( isset( $form['fields'] ) ) {
 			foreach ( $form['fields'] as $field ) {
-				if ( $field['type'] == $type ) {
+				if ( $field['type'] === $type ) {
 					return true;
 				}
 			}
@@ -1923,14 +1923,14 @@ class Model_PDF extends Helper_Abstract_Model {
 		if ( isset( $config['aid'] ) && $config['aid'] !== false ) {
 			$selector = $config['aid'] - 1;
 
-			if ( isset( $pdfs[ $selector ] ) && $pdfs[ $selector ]['template'] == $config['template'] ) {
+			if ( isset( $pdfs[ $selector ] ) && $pdfs[ $selector ]['template'] === $config['template'] ) {
 				return $pdfs[ $selector ]['id'];
 			}
 		}
 
 		/* The aid method failed so lets load the first matching configuration */
 		foreach ( $pdfs as $pdf ) {
-			if ( $pdf['active'] === true && $pdf['template'] == $config['template'] ) {
+			if ( $pdf['active'] === true && $pdf['template'] === $config['template'] ) {
 				return $pdf['id'];
 			}
 		}
@@ -2064,7 +2064,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	public function field_middle_html_fields( $action, $field, $entry, $form, $config ) {
 		if ( $action === false ) {
 			$show_html_fields = ( isset( $config['meta']['html_field'] ) ) ? $config['meta']['html_field'] : false;
-			if ( $show_html_fields === false && $field->type == 'html' ) {
+			if ( $show_html_fields === false && $field->type === 'html' ) {
 				return true;
 			}
 		}
@@ -2089,7 +2089,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 */
 	public function field_middle_blacklist( $action, $field, $entry, $form, $config, $products, $blacklisted ) {
 		if ( $action === false ) {
-			if ( in_array( $field->get_input_type(), $blacklisted ) ) {
+			if ( in_array( $field->get_input_type(), $blacklisted, true ) ) {
 				return true;
 			}
 		}

--- a/src/model/Model_Settings.php
+++ b/src/model/Model_Settings.php
@@ -310,11 +310,11 @@ class Model_Settings extends Helper_Abstract_Model {
 			foreach ( $custom_fonts as $font ) {
 
 				/* Skip over itself */
-				if ( ! empty( $id ) && $font['id'] == $id ) {
+				if ( ! empty( $id ) && $font['id'] === $id ) {
 					continue;
 				}
 
-				if ( $name == $this->options->get_font_short_name( $font['font_name'] ) ) {
+				if ( $name === $this->options->get_font_short_name( $font['font_name'] ) ) {
 					return false;
 				}
 			}
@@ -681,7 +681,7 @@ class Model_Settings extends Helper_Abstract_Model {
 
 		if ( $form_id ) {
 			$pid = ( rgget( 'pid' ) ) ? rgget( 'pid' ) : false;
-			if ( $pid == false ) {
+			if ( $pid === false ) {
 				$pid = ( rgpost( 'gform_pdf_id' ) ) ? rgpost( 'gform_pdf_id' ) : false;
 			}
 

--- a/src/model/Model_Shortcodes.php
+++ b/src/model/Model_Shortcodes.php
@@ -201,7 +201,7 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 
 		/* Everything looks valid so let's get the URL */
 		$pdf               = new Model_PDF( $this->gform, $this->log, $this->options, GPDFAPI::get_data_class(), GPDFAPI::get_misc_class(), GPDFAPI::get_notice_class(), GPDFAPI::get_templates_class() );
-		$download          = ( $attributes['type'] == 'download' ) ? true : false;
+		$download          = ( $attributes['type'] === 'download' ) ? true : false;
 		$print             = ( ! empty( $attributes['print'] ) ) ? true : false;
 		$raw               = ( ! empty( $attributes['raw'] ) ) ? true : false;
 		$attributes['url'] = $pdf->get_pdf_url( $attributes['id'], $attributes['entry'], $download, $print, ! $raw );

--- a/src/model/Model_Templates.php
+++ b/src/model/Model_Templates.php
@@ -227,7 +227,7 @@ class Model_Templates extends Helper_Abstract_Model {
 			$config = $this->templates->get_config_class( $template['id'] );
 
 			/* Check if the PDF config impliments our Setup/TearDown interface and run the tear down */
-			if ( in_array( 'GFPDF\Helper\Helper_Interface_Setup_TearDown', class_implements( $config ) ) ) {
+			if ( in_array( 'GFPDF\Helper\Helper_Interface_Setup_TearDown', class_implements( $config ), true ) ) {
 				$config->setUp();
 			}
 		}
@@ -279,7 +279,7 @@ class Model_Templates extends Helper_Abstract_Model {
 			$config = $this->templates->get_config_class( $template_id );
 
 			/* Check if the PDF config impliments our Setup/TearDown interface and run the tear down */
-			if ( in_array( 'GFPDF\Helper\Helper_Interface_Setup_TearDown', class_implements( $config ) ) ) {
+			if ( in_array( 'GFPDF\Helper\Helper_Interface_Setup_TearDown', class_implements( $config ), true ) ) {
 				$config->tearDown();
 			}
 

--- a/src/templates/blank-slate.php
+++ b/src/templates/blank-slate.php
@@ -2,7 +2,7 @@
 
 /*
  * Template Name: Blank Slate
- * Version: 1.2.1
+ * Version: 1.2.2
  * Description: A print-friendly template focusing solely on the user-submitted data. Through the Template tab you can control the PDF header and footer, change the background color or image, and show or hide the form title, page names, HTML fields and the Section Break descriptions.
  * Author: Gravity PDF
  * Author URI: https://gravitypdf.com
@@ -223,12 +223,12 @@ if ( ! class_exists( 'GFForms' ) ) {
 /*
  * Load our core-specific styles from our PDF settings which will be passed to the PDF template $config array
  */
-$show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] == 'Yes' ) ? true : false;
-$show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' ) ? true : false;
-$show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] == 'Yes' ) ? true : false;
-$show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' ) ? true : false;
-$enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] == 'Yes' ) ? true : false;
-$show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' ) ? true : false;
+$show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] === 'Yes' ) ? true : false;
+$show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] === 'Yes' ) ? true : false;
+$show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] === 'Yes' ) ? true : false;
+$show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] === 'Yes' ) ? true : false;
+$enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] === 'Yes' ) ? true : false;
+$show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] === 'Yes' ) ? true : false;
 
 /**
  * Set up our configuration array to control what is and is not shown in the generated PDF

--- a/src/templates/focus-gravity.php
+++ b/src/templates/focus-gravity.php
@@ -2,7 +2,7 @@
 
 /*
  * Template Name: Focus Gravity
- * Version: 1.2.1
+ * Version: 1.2.2
  * Description: Focus Gravity providing a classic layout which epitomises Gravity Forms Print Preview. It's the familiar layout you've come to love. Through the Template tab you can control the PDF header and footer, change the background color or image, and show or hide the form title, page names, HTML fields and the Section Break descriptions.
  * Author: Gravity PDF
  * Author URI: https://gravitypdf.com
@@ -246,7 +246,7 @@ $label_format = ( ! empty( $settings['focusgravity_label_format'] ) ) ? $setting
 		background: none;
 	}
 
-	<?php if ( $label_format == 'combined_label' ): ?>
+	<?php if ( $label_format === 'combined_label' ): ?>
 		.gfpdf-field .label {
 			background: none;
 			border: none;
@@ -274,12 +274,12 @@ $label_format = ( ! empty( $settings['focusgravity_label_format'] ) ) ? $setting
 /*
  * Load our core-specific styles from our PDF settings which will be passed to the PDF template $config array
  */
-$show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] == 'Yes' ) ? true : false;
-$show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' ) ? true : false;
-$show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] == 'Yes' ) ? true : false;
-$show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' ) ? true : false;
-$enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] == 'Yes' ) ? true : false;
-$show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' ) ? true : false;
+$show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] === 'Yes' ) ? true : false;
+$show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] === 'Yes' ) ? true : false;
+$show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] === 'Yes' ) ? true : false;
+$show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] === 'Yes' ) ? true : false;
+$enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] === 'Yes' ) ? true : false;
+$show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] === 'Yes' ) ? true : false;
 
 /**
  * Set up our configuration array to control what is and is not shown in the generated PDF

--- a/src/templates/rubix.php
+++ b/src/templates/rubix.php
@@ -2,7 +2,7 @@
 
 /*
  * Template Name: Rubix
- * Version: 1.2.1
+ * Version: 1.2.2
  * Description: Rubix uses stylish containers to create an aesthetically pleasing design. Through the Template tab you can control the PDF header and footer, change the background color or image, and show or hide the form title, page names, HTML fields and the Section Break descriptions.
  * Author: Gravity PDF
  * Author URI: https://gravitypdf.com
@@ -264,12 +264,12 @@ $contrast = $misc->get_background_and_border_contrast( $container_background_col
 /*
  * Load our core-specific styles from our PDF settings which will be passed to the PDF template $config array
  */
-$show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] == 'Yes' ) ? true : false;
-$show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' ) ? true : false;
-$show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] == 'Yes' ) ? true : false;
-$show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' ) ? true : false;
-$enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] == 'Yes' ) ? true : false;
-$show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' ) ? true : false;
+$show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] === 'Yes' ) ? true : false;
+$show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] === 'Yes' ) ? true : false;
+$show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] === 'Yes' ) ? true : false;
+$show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] === 'Yes' ) ? true : false;
+$enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] === 'Yes' ) ? true : false;
+$show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] === 'Yes' ) ? true : false;
 
 /**
  * Set up our configuration array to control what is and is not shown in the generated PDF

--- a/src/templates/zadani.php
+++ b/src/templates/zadani.php
@@ -2,7 +2,7 @@
 
 /*
  * Template Name: Zadani
- * Version: 1.2.1
+ * Version: 1.2.2
  * Description: A minimalist business-style template that will generate a well-spaced document great for printing. Through the Template tab you can control the PDF header and footer, change the background color or image, and show or hide the form title, page names, HTML fields and the Section Break descriptions.
  * Author: Gravity PDF
  * Author URI: https://gravitypdf.com
@@ -221,12 +221,12 @@ $value_border_colour = ( ! empty( $settings['zadani_border_colour'] ) ) ? $setti
 /*
  * Load our core-specific styles from our PDF settings which will be passed to the PDF template $config array
  */
-$show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] == 'Yes' ) ? true : false;
-$show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] == 'Yes' ) ? true : false;
-$show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] == 'Yes' ) ? true : false;
-$show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] == 'Yes' ) ? true : false;
-$enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] == 'Yes' ) ? true : false;
-$show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] == 'Yes' ) ? true : false;
+$show_form_title      = ( ! empty( $settings['show_form_title'] ) && $settings['show_form_title'] === 'Yes' ) ? true : false;
+$show_page_names      = ( ! empty( $settings['show_page_names'] ) && $settings['show_page_names'] === 'Yes' ) ? true : false;
+$show_html            = ( ! empty( $settings['show_html'] ) && $settings['show_html'] === 'Yes' ) ? true : false;
+$show_section_content = ( ! empty( $settings['show_section_content'] ) && $settings['show_section_content'] === 'Yes' ) ? true : false;
+$enable_conditional   = ( ! empty( $settings['enable_conditional'] ) && $settings['enable_conditional'] === 'Yes' ) ? true : false;
+$show_empty           = ( ! empty( $settings['show_empty'] ) && $settings['show_empty'] === 'Yes' ) ? true : false;
 
 /**
  * Set up our configuration array to control what is and is not shown in the generated PDF

--- a/src/view/View_PDF.php
+++ b/src/view/View_PDF.php
@@ -226,12 +226,12 @@ class View_PDF extends Helper_Abstract_View {
 
 			/* Set display type and allow user to override the behaviour */
 			$settings['pdf_action'] = apply_filters( 'gfpdfe_pdf_output_type', $settings['pdf_action'] ); /* Backwards compat */
-			if ( $settings['pdf_action'] == 'download' ) {
+			if ( $settings['pdf_action'] === 'download' ) {
 				$pdf->set_output_type( 'download' );
 			}
 
 			/* Add Backwards compatibility support for our v3 Tier 2 Add-on */
-			if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) == 'yes' ) {
+			if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) === 'yes' ) {
 
 				/* Check if we should process this document using our legacy system */
 				if ( $model->handle_legacy_tier_2_processing( $pdf, $entry, $settings, $args ) ) {

--- a/src/view/html/Actions/action_buttons.php
+++ b/src/view/html/Actions/action_buttons.php
@@ -43,7 +43,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p>
 		<button class="button button-primary"><?php echo $args['button_text']; ?></button>
 
-		<?php if ( $args['dismissal'] == 'enabled' ): ?>
+		<?php if ( $args['dismissal'] === 'enabled' ): ?>
 			<input class="button" type="submit" value="<?php esc_attr_e( 'Dismiss Notice', 'gravity-forms-pdf-extended' ); ?>" name="gfpdf-dismiss-notice"/>
 		<?php endif; ?>
 	</p>

--- a/src/view/html/PDF/entry_list_pdf_multiple.php
+++ b/src/view/html/PDF/entry_list_pdf_multiple.php
@@ -37,13 +37,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <span class="gf_form_toolbar_settings gf_form_action_has_submenu gfpdf_form_action_has_submenu">
-   | <a href="#" title="View PDFs" onclick="return false" class=""><?php echo ( $args['view'] == 'download' ) ? esc_html__( 'Download PDFs', 'gravity-forms-pdf-extended' ) : esc_html__( 'View PDFs', 'gravity-forms-pdf-extended' ); ?></a>
+   | <a href="#" title="View PDFs" onclick="return false" class=""><?php echo ( $args['view'] === 'download' ) ? esc_html__( 'Download PDFs', 'gravity-forms-pdf-extended' ) : esc_html__( 'View PDFs', 'gravity-forms-pdf-extended' ); ?></a>
 
 	<div class="gf_submenu gfpdf_submenu">
 		<ul>
 			<?php foreach ( $args['pdfs'] as $pdf ): ?>
 				<li>
-					<a href="<?php echo ( $args['view'] == 'download' ) ? esc_url( $pdf['download'] ) : esc_url( $pdf['view'] ); ?>" <?php echo ( $args['view'] != 'download' ) ? 'target="_blank"' : ''; ?>><?php echo esc_html( $pdf['name'] ); ?></a>
+					<a href="<?php echo ( $args['view'] === 'download' ) ? esc_url( $pdf['download'] ) : esc_url( $pdf['view'] ); ?>" <?php echo ( $args['view'] !== 'download' ) ? 'target="_blank"' : ''; ?>><?php echo esc_html( $pdf['name'] ); ?></a>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/src/view/html/PDF/entry_list_pdf_single.php
+++ b/src/view/html/PDF/entry_list_pdf_single.php
@@ -36,6 +36,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 
-| <a href="<?php echo ( $args['view'] == 'download' ) ? esc_url( $args['pdf']['download'] ) : esc_url( $args['pdf']['view'] ); ?>" <?php echo ( $args['view'] != 'download' ) ? 'target="_blank"' : ''; ?>>
-	<?php echo ( $args['view'] == 'download' ) ? esc_html__( 'Download PDF', 'gravity-forms-pdf-extended' ) : esc_html__( 'View PDF', 'gravity-forms-pdf-extended' ); ?>
+| <a href="<?php echo ( $args['view'] === 'download' ) ? esc_url( $args['pdf']['download'] ) : esc_url( $args['pdf']['view'] ); ?>" <?php echo ( $args['view'] !== 'download' ) ? 'target="_blank"' : ''; ?>>
+	<?php echo ( $args['view'] === 'download' ) ? esc_html__( 'Download PDF', 'gravity-forms-pdf-extended' ) : esc_html__( 'View PDF', 'gravity-forms-pdf-extended' ); ?>
 </a>

--- a/src/view/html/Settings/tabs.php
+++ b/src/view/html/Settings/tabs.php
@@ -38,6 +38,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <h2 class="nav-tab-wrapper">
 	<?php foreach ( $args['tabs'] as $tab ): ?>
-		<a data-id="<?php echo esc_attr( $tab['id'] ); ?>" class="nav-tab <?php echo ( $args['selected'] == $tab['id'] ) ? 'nav-tab-active' : ''; ?>" href="<?php echo $args['data']->settings_url . '&amp;tab=' . $tab['id']; ?>"><?php echo $tab['name']; ?></a>
+		<a data-id="<?php echo esc_attr( $tab['id'] ); ?>" class="nav-tab <?php echo ( $args['selected'] === $tab['id'] ) ? 'nav-tab-active' : ''; ?>" href="<?php echo $args['data']->settings_url . '&amp;tab=' . $tab['id']; ?>"><?php echo $tab['name']; ?></a>
 	<?php endforeach; ?>
 </h2>

--- a/tests/phpunit/unit-tests/test-actions.php
+++ b/tests/phpunit/unit-tests/test-actions.php
@@ -116,7 +116,7 @@ class Test_Actions extends WP_UnitTestCase {
 		$expected = [ 'review_plugin', 'migrate_v3_to_v4', 'install_core_fonts' ];
 
 		foreach ( $routes as $route ) {
-			if ( in_array( $route['action'], $expected ) ) {
+			if ( in_array( $route['action'], $expected, true ) ) {
 				$counter++;
 			}
 		}

--- a/tests/phpunit/unit-tests/test-field-container.php
+++ b/tests/phpunit/unit-tests/test-field-container.php
@@ -369,7 +369,7 @@ class Test_Field_Container extends WP_UnitTestCase {
 		$overridden_methods = 0;
 
 		foreach ( $methods as $method ) {
-			if ( '__construct' != $method->name && $method->class == $reflection->getName() ) {
+			if ( '__construct' !== $method->name && $method->class === $reflection->getName() ) {
 				$overridden_methods++;
 			}
 		}

--- a/tests/phpunit/unit-tests/test-form-data.php
+++ b/tests/phpunit/unit-tests/test-form-data.php
@@ -256,14 +256,14 @@ class Test_Form_Data extends WP_UnitTestCase {
 		 * Run our tests...
 		 */
 		$response = 'Second Choice';
-		$this->assertTrue( in_array( $response, $field[4] ) );
-		$this->assertTrue( in_array( $response, $field['4.Multi Select Box'] ) );
-		$this->assertTrue( in_array( $response, $field['Multi Select Box'] ) );
+		$this->assertTrue( in_array( $response, $field[4], true ) );
+		$this->assertTrue( in_array( $response, $field['4.Multi Select Box'], true ) );
+		$this->assertTrue( in_array( $response, $field['Multi Select Box'], true ) );
 
 		$response = 'Multi Select Second Choice';
-		$this->assertTrue( in_array( $response, $field['4_name'] ) );
-		$this->assertTrue( in_array( $response, $field['4.Multi Select Box_name'] ) );
-		$this->assertTrue( in_array( $response, $field['Multi Select Box_name'] ) );
+		$this->assertTrue( in_array( $response, $field['4_name'], true ) );
+		$this->assertTrue( in_array( $response, $field['4.Multi Select Box_name'], true ) );
+		$this->assertTrue( in_array( $response, $field['Multi Select Box_name'], true ) );
 
 		$this->assertEquals( 2, sizeof( $field[4] ) );
 		$this->assertEquals( 2, sizeof( $field['4_name'] ) );
@@ -299,24 +299,24 @@ class Test_Form_Data extends WP_UnitTestCase {
 		 */
 
 		$response = 'Checkbox Choice 2';
-		$this->assertTrue( in_array( $response, $field[6] ) );
-		$this->assertTrue( in_array( $response, $field['6.Checkbox'] ) );
-		$this->assertTrue( in_array( $response, $field['Checkbox'] ) );
+		$this->assertTrue( in_array( $response, $field[6], true ) );
+		$this->assertTrue( in_array( $response, $field['6.Checkbox'], true ) );
+		$this->assertTrue( in_array( $response, $field['Checkbox'], true ) );
 
 		$response = 'Checkbox Choice 2 Text';
-		$this->assertTrue( in_array( $response, $field['6_name'] ) );
-		$this->assertTrue( in_array( $response, $field['6.Checkbox_name'] ) );
-		$this->assertTrue( in_array( $response, $field['Checkbox_name'] ) );
+		$this->assertTrue( in_array( $response, $field['6_name'], true ) );
+		$this->assertTrue( in_array( $response, $field['6.Checkbox_name'], true ) );
+		$this->assertTrue( in_array( $response, $field['Checkbox_name'], true ) );
 
 		$response = 'Checkbox Choice 3';
-		$this->assertTrue( in_array( $response, $field[6] ) );
-		$this->assertTrue( in_array( $response, $field['6.Checkbox'] ) );
-		$this->assertTrue( in_array( $response, $field['Checkbox'] ) );
+		$this->assertTrue( in_array( $response, $field[6], true ) );
+		$this->assertTrue( in_array( $response, $field['6.Checkbox'], true ) );
+		$this->assertTrue( in_array( $response, $field['Checkbox'], true ) );
 
 		$response = 'Checkbox Choice 3 Text';
-		$this->assertTrue( in_array( $response, $field['6_name'] ) );
-		$this->assertTrue( in_array( $response, $field['6.Checkbox_name'] ) );
-		$this->assertTrue( in_array( $response, $field['Checkbox_name'] ) );
+		$this->assertTrue( in_array( $response, $field['6_name'], true ) );
+		$this->assertTrue( in_array( $response, $field['6.Checkbox_name'], true ) );
+		$this->assertTrue( in_array( $response, $field['Checkbox_name'], true ) );
 
 		$this->assertEquals( 2, sizeof( $field[6] ) );
 	}
@@ -580,19 +580,19 @@ class Test_Form_Data extends WP_UnitTestCase {
 		$this->assertEquals( $response, $field['23.Poll Field - Radio Buttons_name'] );
 
 		$this->assertTrue( is_array( $field[41][0] ) );
-		$this->assertTrue( in_array( 'Poll Check First Choice', $field[41][0] ) );
-		$this->assertTrue( in_array( 'Poll Check Second Choice', $field[41][0] ) );
-		$this->assertTrue( in_array( 'Poll Check Third Choice', $field[41][0] ) );
+		$this->assertTrue( in_array( 'Poll Check First Choice', $field[41][0], true ) );
+		$this->assertTrue( in_array( 'Poll Check Second Choice', $field[41][0], true ) );
+		$this->assertTrue( in_array( 'Poll Check Third Choice', $field[41][0], true ) );
 
 		$this->assertTrue( is_array( $field['41.Poll Field - Checkboxes'][0] ) );
-		$this->assertTrue( in_array( 'Poll Check First Choice', $field['41.Poll Field - Checkboxes'][0] ) );
-		$this->assertTrue( in_array( 'Poll Check Second Choice', $field['41.Poll Field - Checkboxes'][0] ) );
-		$this->assertTrue( in_array( 'Poll Check Third Choice', $field['41.Poll Field - Checkboxes'][0] ) );
+		$this->assertTrue( in_array( 'Poll Check First Choice', $field['41.Poll Field - Checkboxes'][0], true ) );
+		$this->assertTrue( in_array( 'Poll Check Second Choice', $field['41.Poll Field - Checkboxes'][0], true ) );
+		$this->assertTrue( in_array( 'Poll Check Third Choice', $field['41.Poll Field - Checkboxes'][0], true ) );
 
 		$this->assertTrue( is_array( $field['Poll Field - Checkboxes'][0] ) );
-		$this->assertTrue( in_array( 'Poll Check First Choice', $field['Poll Field - Checkboxes'][0] ) );
-		$this->assertTrue( in_array( 'Poll Check Second Choice', $field['Poll Field - Checkboxes'][0] ) );
-		$this->assertTrue( in_array( 'Poll Check Third Choice', $field['Poll Field - Checkboxes'][0] ) );
+		$this->assertTrue( in_array( 'Poll Check First Choice', $field['Poll Field - Checkboxes'][0], true ) );
+		$this->assertTrue( in_array( 'Poll Check Second Choice', $field['Poll Field - Checkboxes'][0], true ) );
+		$this->assertTrue( in_array( 'Poll Check Third Choice', $field['Poll Field - Checkboxes'][0], true ) );
 	}
 
 	/**
@@ -1330,7 +1330,7 @@ class Test_Form_Data extends WP_UnitTestCase {
 		$columns = [ 'Strongly disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly agree' ];
 
 		foreach ( $likert['col'] as $col ) {
-			$this->assertTrue( in_array( $col, $columns ) );
+			$this->assertTrue( in_array( $col, $columns, true ) );
 		}
 
 		/* test row */
@@ -1344,7 +1344,7 @@ class Test_Form_Data extends WP_UnitTestCase {
 		$likert = $data[27];
 
 		foreach ( $likert['col'] as $col ) {
-			$this->assertTrue( in_array( $col, $columns ) );
+			$this->assertTrue( in_array( $col, $columns, true ) );
 		}
 
 		/* test row */
@@ -1380,7 +1380,7 @@ class Test_Form_Data extends WP_UnitTestCase {
 	public function test_survey_rating_data() {
 		$data = $this->form_data['survey']['rating'];
 
-		$this->assertTrue( in_array( 'Pretty good', $data[45] ) );
+		$this->assertTrue( in_array( 'Pretty good', $data[45], true ) );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -572,7 +572,7 @@ class Test_Form_Settings extends WP_UnitTestCase {
 		/* loop through array and check results */
 		foreach ( $input as $id => $field ) {
 			if ( isset( $values[ $id ] ) ) {
-				$this->assertTrue( in_array( $values[ $id ], $types ) );
+				$this->assertTrue( in_array( $values[ $id ], $types, true ) );
 			}
 		}
 

--- a/tests/phpunit/unit-tests/test-options-api.php
+++ b/tests/phpunit/unit-tests/test-options-api.php
@@ -179,7 +179,7 @@ class Test_Options_API extends WP_UnitTestCase {
 		/* check for specific values */
 		$this->assertEquals( 'My First PDF Template', $results['name'] );
 		$this->assertEquals( 'Gravity Forms Style', $results['template'] );
-		$this->assertTrue( in_array( 'Admin Notification', $results['notification'] ) );
+		$this->assertTrue( in_array( 'Admin Notification', $results['notification'], true ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Resolve strict linting errors when using the WP Coding Standards 2.1. 

## Testing instructions

Travis CI will pass. 

## Checklist:
- [ ] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
