### PR TITLE
Refractoring the [gravitypdf] shortcode class 

### DIFF
--- a/src/Controller/Controller_Shortcodes.php
+++ b/src/Controller/Controller_Shortcodes.php
@@ -120,6 +120,6 @@ class Controller_Shortcodes extends Helper_Abstract_Controller implements Helper
 	 * @return void
 	 */
 	public function add_shortcodes() {
-		add_shortcode( 'gravitypdf', [ $this->model, 'gravitypdf' ] );
+		add_shortcode( 'gravitypdf', [ $this->model, 'process' ] );
 	}
 }

--- a/src/Exceptions/GravityPdfShortcodeEntryIdException.php
+++ b/src/Exceptions/GravityPdfShortcodeEntryIdException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GFPDF\Exceptions;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF.
+
+	Gravity PDF – Copyright (c) 2019, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+class GravityPdfShortcodeEntryIdException extends \Exception {
+}

--- a/src/Exceptions/GravityPdfShortcodePdfConditionalLogicFailedException.php
+++ b/src/Exceptions/GravityPdfShortcodePdfConditionalLogicFailedException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GFPDF\Exceptions;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF.
+
+	Gravity PDF – Copyright (c) 2019, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+class GravityPdfShortcodePdfConditionalLogicFailedException extends \Exception {
+}

--- a/src/Exceptions/GravityPdfShortcodePdfConfigNotFoundException.php
+++ b/src/Exceptions/GravityPdfShortcodePdfConfigNotFoundException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GFPDF\Exceptions;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF.
+
+	Gravity PDF – Copyright (c) 2019, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+class GravityPdfShortcodePdfConfigNotFoundException extends \Exception {
+}

--- a/src/Exceptions/GravityPdfShortcodePdfInactiveException.php
+++ b/src/Exceptions/GravityPdfShortcodePdfInactiveException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GFPDF\Exceptions;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF.
+
+	Gravity PDF – Copyright (c) 2019, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+class GravityPdfShortcodePdfInactiveException extends \Exception {
+}

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -1,0 +1,420 @@
+<?php
+
+namespace GFPDF\Helper;
+
+use GFPDF\Exceptions\GravityPdfShortcodeEntryIdException;
+use GFPDF\Exceptions\GravityPdfShortcodePdfConditionalLogicFailedException;
+use GFPDF\Exceptions\GravityPdfShortcodePdfConfigNotFoundException;
+use GFPDF\Exceptions\GravityPdfShortcodePdfInactiveException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Common methods to process shortcodes
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF.
+
+	Gravity PDF – Copyright (c) 2019, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class Helper_Abstract_Pdf_Shortcode
+ *
+ * @package GFPDF\Helper
+ *
+ * @since   5.2
+ */
+abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
+
+	/**
+	 * Set this constant to the Shortcode ID you're using
+	 * @since 5.2
+	 */
+	const SHORTCODE = '';
+
+	/**
+	 * @var Helper_Abstract_Form
+	 * @since 5.2
+	 */
+	protected $gform;
+
+	/**
+	 * @var LoggerInterface
+	 * @since 5.2
+	 */
+	protected $log;
+
+	/**
+	 * @var Helper_Abstract_Options
+	 * @since 5.2
+	 */
+	protected $options;
+
+	/**
+	 * @var Helper_Misc
+	 * @since 5.2
+	 */
+	protected $misc;
+
+	/**
+	 * @var Helper_Interface_Url_Signer
+	 * @since 5.2
+	 */
+	protected $url_signer;
+
+	/**
+	 * Helper_Abstract_Pdf_Shortcode constructor.
+	 *
+	 * @param Helper_Abstract_Form        $gform
+	 * @param LoggerInterface             $log
+	 * @param Helper_Abstract_Options     $options
+	 * @param Helper_Misc                 $misc
+	 * @param Helper_Interface_Url_Signer $url_signer
+	 *
+	 * @since 5.2
+	 */
+	public function __construct( Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Abstract_Options $options, Helper_Misc $misc, Helper_Interface_Url_Signer $url_signer ) {
+		$this->gform      = $gform;
+		$this->log        = $log;
+		$this->options    = $options;
+		$this->misc       = $misc;
+		$this->url_signer = $url_signer;
+	}
+
+	/**
+	 * Generate the mark-up for the shortcode
+	 *
+	 * @param array $attributes The shortcode attributes specified
+	 *
+	 * @return string
+	 *
+	 * @since 4.0
+	 */
+	public abstract function process( $attributes );
+
+	/**
+	 * Try get the Entry ID from specific $_GET keys
+	 *
+	 * @param int $entry_id
+	 *
+	 * @return int
+	 *
+	 * @throws GravityPdfShortcodeEntryIdException
+	 *
+	 * @since 5.2
+	 */
+	protected function get_entry_id_if_empty( $entry_id ) {
+		if ( ! empty( $entry_id ) ) {
+			return $entry_id;
+		}
+
+		if ( isset( $_GET['lid'] ) || isset( $_GET['entry'] ) ) {
+			return isset( $_GET['lid'] ) ? (int) $_GET['lid'] : (int) $_GET['entry'];
+		}
+
+		throw new GravityPdfShortcodeEntryIdException();
+	}
+
+	/**
+	 * Get a valid PDF configuration
+	 *
+	 * @param int    $entry_id The Gravity Forms Entry ID
+	 * @param string $pdf_id   The Gravity PDF ID
+	 *
+	 * @return array
+	 *
+	 * @throws GravityPdfShortcodePdfConditionalLogicFailedException
+	 * @throws GravityPdfShortcodePdfConfigNotFoundException
+	 * @throws GravityPdfShortcodePdfInactiveException
+	 *
+	 * @since 5.2
+	 */
+	protected function get_pdf_config( $entry_id, $pdf_id ) {
+		$entry    = $this->gform->get_entry( $entry_id );
+		$settings = ! is_wp_error( $entry ) ? \GPDFAPI::get_pdf( $entry['form_id'], $pdf_id ) : $entry;
+
+		if ( is_wp_error( $settings ) ) {
+			throw new GravityPdfShortcodePdfConfigNotFoundException();
+		}
+
+		if ( $settings['active'] !== true ) {
+			throw new GravityPdfShortcodePdfInactiveException();
+		}
+
+		if ( isset( $settings['conditionalLogic'] ) && ! $this->misc->evaluate_conditional_logic( $settings['conditionalLogic'], $entry ) ) {
+			throw new GravityPdfShortcodePdfConditionalLogicFailedException();
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Update our Gravity Forms "Text" Confirmation Shortcode to include the current entry ID
+	 *
+	 * @param string|array $confirmation The confirmation text
+	 * @param array        $form         The Gravity Form array
+	 * @param array        $entry        The Gravity Form entry information
+	 *
+	 * @return string|array               The confirmation text
+	 *
+	 * @since 4.0
+	 */
+	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
+
+		/* check if confirmation is text-based */
+		if ( ! is_array( $confirmation ) ) {
+			$confirmation = $this->add_entry_id_to_shortcode( $confirmation, $entry['id'] );
+		}
+
+		return $confirmation;
+	}
+
+	/**
+	 * Update our Gravity Forms Notification Shortcode to include the current entry ID
+	 *
+	 * @param array $notification The notification
+	 * @param array $form         The Gravity Form array
+	 * @param array $entry        The Gravity Form entry information
+	 *
+	 * @return array               The notification
+	 *
+	 * @since 4.0
+	 */
+	public function gravitypdf_notification( $notification, $form, $entry ) {
+		if ( isset( $notification['message'] ) ) {
+			$notification['message'] = $this->add_entry_id_to_shortcode( $notification['message'], $entry['id'] );
+		}
+
+		return $notification;
+	}
+
+	/**
+	 * Add basic GravityView support and parse the Custom Content field for the [gravitypdf] shortcode
+	 * This means users can copy and paste our sample shortcode without having to worry about an entry ID being passed.
+	 *
+	 * @param string $html
+	 *
+	 * @return string
+	 *
+	 * @since 4.0
+	 */
+	public function gravitypdf_gravityview_custom( $html ) {
+
+		if ( ! class_exists( '\GravityView_View' ) ) {
+			return $html;
+		}
+
+		$gravityview_view = \GravityView_View::getInstance();
+		$entry            = $gravityview_view->getCurrentEntry();
+
+		return $this->add_entry_id_to_shortcode( $html, $entry['id'] );
+	}
+
+	/**
+	 * Check for the shortcode and add the entry ID to it
+	 *
+	 * @param string $string   The text to search
+	 * @param int    $entry_id The entry ID to add to our shortcode
+	 *
+	 * @return string
+	 *
+	 * @since 4.0
+	 */
+	protected function add_entry_id_to_shortcode( $string, $entry_id ) {
+		/* Check if our shortcode exists and add the entry ID if needed */
+		$shortcode_information = $this->get_shortcode_information( static::SHORTCODE, $string );
+
+		if ( count( $shortcode_information ) > 0 ) {
+			foreach ( $shortcode_information as $shortcode ) {
+				/* if the user hasn't explicitely defined an entry to display... */
+				if ( ! isset( $shortcode['attr']['entry'] ) ) {
+					/* get the new shortcode information and update confirmation message */
+					$new_shortcode = $this->add_shortcode_attr( $shortcode, 'entry', $entry_id );
+					$string        = str_replace( $shortcode['shortcode'], $new_shortcode['shortcode'], $string );
+				}
+			}
+		}
+
+		return $string;
+	}
+
+	/**
+	 * Update a shortcode attributes
+	 *
+	 * @param array  $code  In individual shortcode array pulled in from the $this->get_shortcode_information() function
+	 * @param string $attr  The attribute to add / replace
+	 * @param string $value The new attribute value
+	 *
+	 * @return array
+	 *
+	 * @since 4.0
+	 */
+	public function add_shortcode_attr( $code, $attr, $value ) {
+
+		/* if the attribute doesn't already exist... */
+		if ( ! isset( $code['attr'][ $attr ] ) ) {
+
+			$raw_attr = "{$code['attr_raw']} {$attr}=\"{$value}\"";
+
+			/* if there are no attributes at all we'll need to fix our str replace */
+			if ( strlen( $code['attr_raw'] ) === 0 ) {
+				$pattern           = '^\[([a-zA-Z]+)';
+				$code['shortcode'] = preg_replace( "/$pattern/s", "[$1 {$attr}=\"{$value}\"", $code['shortcode'] );
+			} else {
+				$code['shortcode'] = str_ireplace( $code['attr_raw'], $raw_attr, $code['shortcode'] );
+			}
+
+			$code['attr_raw'] = $raw_attr;
+
+		} else { /* replace the current attribute */
+			$pattern           = $attr . '="(.+?)"';
+			$code['shortcode'] = preg_replace( "/$pattern/si", $attr . '="' . $value . '"', $code['shortcode'] );
+			$code['attr_raw']  = preg_replace( "/$pattern/si", $attr . '="' . $value . '"', $code['attr_raw'] );
+		}
+
+		/* Update the actual attribute */
+		$code['attr'][ $attr ] = $value;
+
+		return $code;
+	}
+
+	/**
+	 * Check if user is currently submitting a new confirmation redirect URL in the admin area,
+	 * if so replace any shortcodes with a version that will be correctly saved and generated
+	 *
+	 * @param array $form Gravity Form Array
+	 *
+	 * @return array
+	 *
+	 * @since 4.0
+	 */
+	public function gravitypdf_redirect_confirmation( $form ) {
+
+		/* check if the confirmation is currently being saved */
+		if ( isset( $_POST['form_confirmation_url'] ) ) {
+
+			$this->log->addNotice(
+				'Begin Converting Shortcode to URL for Redirect Confirmation',
+				[
+					'form_id' => $form['id'],
+					'post'    => $_POST,
+				]
+			);
+
+			$url = stripslashes_deep( $_POST['form_confirmation_url'] );
+
+			/* check if our shortcode exists and convert it to a URL */
+			$shortcode_information = $this->get_shortcode_information( static::SHORTCODE, $url );
+
+			if ( count( $shortcode_information ) > 0 ) {
+				foreach ( $shortcode_information as $shortcode ) {
+					$new_shortcode = $this->add_shortcode_attr( $shortcode, 'entry', '{entry_id}' );
+					$new_shortcode = $this->add_shortcode_attr( $new_shortcode, 'raw', '1' );
+
+					/* update our confirmation message */
+					$_POST['form_confirmation_url'] = str_replace( $shortcode['shortcode'], $new_shortcode['shortcode'], $url );
+				}
+			}
+		}
+
+		return $form;
+	}
+
+	/**
+	 * If a Redirect Confirmation, convert the Gravity PDF shortcode to it's URL form, if one exists
+	 *
+	 * @param string|array $confirmation
+	 * @param array        $form
+	 * @param array        $entry
+	 *
+	 * @return string|array
+	 *
+	 * @since 5.1
+	 */
+	public function gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry ) {
+
+		if ( isset( $confirmation['redirect'] ) ) {
+			$shortcode_information = $this->get_shortcode_information( static::SHORTCODE, $form['confirmation']['url'] );
+
+			if ( count( $shortcode_information ) > 0 ) {
+				foreach ( $shortcode_information as $shortcode ) {
+					$url = do_shortcode( str_replace( '{entry_id}', $entry['id'], $shortcode['shortcode'] ) );
+
+					/* Add Query string parameters if they exist (but not with signed URLs) */
+					$query_string = substr( $confirmation['redirect'], strrpos( $confirmation['redirect'], '?' ) + 1 );
+					if ( empty( $shortcode['attr']['signed'] ) && strlen( $query_string ) > 0 ) {
+						$url .= ( strpos( $url, '?' ) !== false ) ? '&' . $query_string : '?' . $query_string;
+					}
+
+					$form['confirmation']['url'] = str_replace( $shortcode['shortcode'], $url, $form['confirmation']['url'] );
+				}
+
+				$confirmation['redirect'] = $form['confirmation']['url'];
+			}
+		}
+
+		return $confirmation;
+	}
+
+	/**
+	 * Search for any shortcodes in the text and return any matches
+	 *
+	 * @param string $shortcode The shortcode to search for
+	 * @param string $text      The text to search in
+	 *
+	 * @return array             The shortcode information
+	 *
+	 * @since 4.0
+	 */
+	public function get_shortcode_information( $shortcode, $text ) {
+		$shortcodes = [];
+
+		if ( has_shortcode( $text, $shortcode ) ) {
+			/* our shortcode exists so parse the shortcode data and return an easy-to-use array */
+			preg_match_all( '/' . get_shortcode_regex( [ $shortcode ] ) . '/', $text, $matches, PREG_SET_ORDER );
+
+			if ( empty( $matches ) ) {
+				return $shortcodes;
+			}
+
+			foreach ( $matches as $item ) {
+				if ( $shortcode === $item[2] ) {
+					$attr = shortcode_parse_atts( $item[3] );
+
+					$shortcodes[] = [
+						'shortcode' => $item[0],
+						'attr_raw'  => $item[3],
+						'attr'      => is_array( $attr ) ? $attr : [],
+					];
+				}
+			}
+		}
+
+		return $shortcodes;
+	}
+}

--- a/src/Helper/Helper_Interface_Url_Signer.php
+++ b/src/Helper/Helper_Interface_Url_Signer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace GFPDF\Helper;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF.
+
+	Gravity PDF – Copyright (c) 2019, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Interface Helper_Interface_Url_Signer
+ *
+ * @package GFPDF\Helper
+ */
+interface Helper_Interface_Url_Signer {
+
+	/**
+	 * Sign a URL with a secret token
+	 *
+	 * @param string $url
+	 * @param string $expiration
+	 *
+	 * @return string
+	 *
+	 * @since 5.2
+	 */
+	public function sign( $url, $expiration );
+
+	/**
+	 * Verify if the signed URL is valid
+	 *
+	 * @param string $url
+	 *
+	 * @return bool
+	 *
+	 * @since 5.2
+	 */
+	public function verify( $url );
+}

--- a/src/Model/Model_Shortcodes.php
+++ b/src/Model/Model_Shortcodes.php
@@ -2,18 +2,13 @@
 
 namespace GFPDF\Model;
 
-use GFPDF\Helper\Helper_Abstract_Model;
-use GFPDF\Helper\Helper_Abstract_Form;
-use GFPDF\Helper\Helper_Abstract_Options;
-use GFPDF\Helper\Helper_Misc;
-
-use GFPDF\Helper\Helper_Sha256_Url_Signer;
-use Psr\Log\LoggerInterface;
+use GFPDF\Helper\Helper_Abstract_Pdf_Shortcode;
+use GFPDF\Exceptions\GravityPdfShortcodeEntryIdException;
+use GFPDF\Exceptions\GravityPdfShortcodePdfConditionalLogicFailedException;
+use GFPDF\Exceptions\GravityPdfShortcodePdfConfigNotFoundException;
+use GFPDF\Exceptions\GravityPdfShortcodePdfInactiveException;
 
 use GPDFAPI;
-use GFCommon;
-use GravityView_View;
-use Spatie\UrlSigner\MD5UrlSigner;
 
 /**
  * PDF Shortcode Model
@@ -50,67 +45,34 @@ if ( ! defined( 'ABSPATH' ) ) {
 */
 
 /**
- *
  * Handles all the PDF Shortcode logic
  *
  * @since 4.0
  */
-class Model_Shortcodes extends Helper_Abstract_Model {
+class Model_Shortcodes extends Helper_Abstract_Pdf_Shortcode {
 
 	/**
-	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
-	 *
-	 * @var \GFPDF\Helper\Helper_Form
-	 *
-	 * @since 4.0
+	 * @since 5.2
 	 */
-	protected $gform;
+	const SHORTCODE = 'gravitypdf';
 
 	/**
-	 * Holds our log class
+	 * Generates a direct link to the PDF that should be generated
+	 * If placed in a confirmation the appropriate entry will be displayed.
+	 * A user also has the option to pass in an "entry" parameter to define the entry ID
 	 *
-	 * @var \Monolog\Logger|LoggerInterface
+	 * @param array $attributes The shortcode attributes specified
 	 *
-	 * @since 4.0
+	 * @return string
+	 *
+	 * @since    4.0
+	 *
+	 * @internal Deprecated in 5.2. Use self::process()
 	 */
-	protected $log;
+	public function gravitypdf( $attributes ) {
+		_doing_it_wrong( __METHOD__, __( 'This method has been superceeded by self::process()', 'gravity-forms-pdf-extended' ), '5.2' );
 
-	/**
-	 * Holds our Helper_Abstract_Options / Helper_Options_Fields object
-	 * Makes it easy to access global PDF settings and individual form PDF settings
-	 *
-	 * @var \GFPDF\Helper\Helper_Options_Fields
-	 *
-	 * @since 4.0
-	 */
-	protected $options;
-
-	/**
-	 * Holds our Helper_Misc object
-	 * Makes it easy to access common methods throughout the plugin
-	 *
-	 * @var \GFPDF\Helper\Helper_Misc
-	 *
-	 * @since 4.0
-	 */
-	protected $misc;
-
-	/**
-	 * Setup our class by injecting all our dependancies
-	 *
-	 * @param \GFPDF\Helper\Helper_Abstract_Form|\GFPDF\Helper\Helper_Form              $gform   Our abstracted Gravity Forms helper functions
-	 * @param \Monolog\Logger|LoggerInterface                                           $log     Our logger class
-	 * @param \GFPDF\Helper\Helper_Abstract_Options|\GFPDF\Helper\Helper_Options_Fields $options Our options class which allows us to access any settings
-	 *
-	 * @since 4.0
-	 */
-	public function __construct( Helper_Abstract_Form $gform, LoggerInterface $log, Helper_Abstract_Options $options, Helper_Misc $misc ) {
-
-		/* Assign our internal variables */
-		$this->gform   = $gform;
-		$this->log     = $log;
-		$this->options = $options;
-		$this->misc    = $misc;
+		return $this->process( $attributes );
 	}
 
 	/**
@@ -124,11 +86,11 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 	 *
 	 * @since 4.0
 	 */
-	public function gravitypdf( $attributes ) {
+	public function process( $attributes ) {
 		$controller = $this->getController();
 
-		$shortcode_error_messages_enabled = ( $this->options->get_option( 'debug_mode', 'No' ) === 'Yes' ) ? true : false;
-		$has_view_permissions             = ( $shortcode_error_messages_enabled && $this->gform->has_capability( 'gravityforms_view_entries' ) );
+		$shortcode_error_messages_enabled = $this->options->get_option( 'debug_mode', 'No' ) === 'Yes' ? true : false;
+		$has_view_permissions             = $shortcode_error_messages_enabled && $this->gform->has_capability( 'gravityforms_view_entries' );
 
 		/* merge in any missing defaults */
 		$attributes = shortcode_atts(
@@ -145,347 +107,47 @@ class Model_Shortcodes extends Helper_Abstract_Model {
 				'raw'     => '',
 			],
 			$attributes,
-			'gravitypdf'
+			static::SHORTCODE
 		);
 
 		/* See https://gravitypdf.com/documentation/v5/gfpdf_gravityforms_shortcode_attributes/ for more information about this filter */
 		$attributes = apply_filters( 'gfpdf_gravityforms_shortcode_attributes', $attributes );
 
-		/* Check if we have an entry ID, otherwise check the GET and POST data */
-		if ( empty( $attributes['entry'] ) ) {
-			if ( isset( $_GET['lid'] ) || isset( $_GET['entry'] ) ) {
-				$attributes['entry'] = ( isset( $_GET['lid'] ) ) ? (int) $_GET['lid'] : (int) $_GET['entry'];
-			} else {
+		try {
+			$entry_id = $this->get_entry_id_if_empty( $attributes['entry'] );
 
-				/* Only display error to users with appropriate permissions */
-				if ( $has_view_permissions ) {
-					return $controller->view->no_entry_id();
-				}
+			/* Do PDF validation */
+			$this->get_pdf_config( $entry_id, $attributes['id'] );
 
-				return '';
-			}
-		}
+			$pdf               = GPDFAPI::get_mvc_class( 'Model_PDF' );
+			$download          = $attributes['type'] === 'download';
+			$print             = ! empty( $attributes['print'] );
+			$raw               = ! empty( $attributes['raw'] );
+			$attributes['url'] = $pdf->get_pdf_url( $attributes['id'], $attributes['entry'], $download, $print, ! $raw );
 
-		/* Check if we have a valid PDF configuration */
-		$entry  = $this->gform->get_entry( $attributes['entry'] );
-		$config = ( ! is_wp_error( $entry ) ) ? $this->options->get_pdf( $entry['form_id'], $attributes['id'] ) : $entry; /* if invalid entry a WP_Error will be thrown */
-
-		if ( is_wp_error( $config ) ) {
-
-			/* Only display error to users with appropriate permissions */
-			if ( $has_view_permissions ) {
-				return $controller->view->invalid_pdf_config();
+			/* Sign the URL to allow direct access to the PDF until it expires */
+			if ( ! empty( $attributes['signed'] ) ) {
+				$attributes['url'] = $this->url_signer->sign( $attributes['url'], $attributes['expires'] );
 			}
 
-			return '';
-		}
+			$this->log->addNotice( 'Generating Shortcode Markup', [ 'attr' => $attributes ] );
 
-		/* Check if the PDF is enabled AND the conditional logic (if any) has been met */
-		if ( $config['active'] !== true ) {
-			/* Only display error to users with appropriate permissions */
-			if ( $has_view_permissions ) {
-				return $controller->view->pdf_not_active();
+			if ( $raw ) {
+				return $attributes['url'];
 			}
 
-			return '';
+			return $controller->view->display_gravitypdf_shortcode( $attributes );
+
+		} catch ( GravityPdfShortcodeEntryIdException $e ) {
+			return $has_view_permissions ? $controller->view->no_entry_id() : '';
+		} catch ( GravityPdfShortcodePdfConfigNotFoundException $e ) {
+			return $has_view_permissions ? $controller->view->invalid_pdf_config() : '';
+		} catch ( GravityPdfShortcodePdfInactiveException $e ) {
+			return $has_view_permissions ? $controller->view->pdf_not_active() : '';
+		} catch ( GravityPdfShortcodePdfConditionalLogicFailedException $e ) {
+			return $has_view_permissions ? $controller->view->conditional_logic_not_met() : '';
+		} catch ( \Exception $e ) {
+			return $has_view_permissions ? $e->getMessage() : '';
 		}
-
-		if ( isset( $config['conditionalLogic'] ) && ! $this->misc->evaluate_conditional_logic( $config['conditionalLogic'], $entry ) ) {
-			/* Only display error to users with appropriate permissions */
-			if ( $has_view_permissions ) {
-				return $controller->view->conditional_logic_not_met();
-			}
-
-			return '';
-		}
-
-		/* Everything looks valid so let's get the URL */
-		$pdf               = new Model_PDF( $this->gform, $this->log, $this->options, GPDFAPI::get_data_class(), GPDFAPI::get_misc_class(), GPDFAPI::get_notice_class(), GPDFAPI::get_templates_class() );
-		$download          = ( $attributes['type'] === 'download' ) ? true : false;
-		$print             = ( ! empty( $attributes['print'] ) ) ? true : false;
-		$raw               = ( ! empty( $attributes['raw'] ) ) ? true : false;
-		$attributes['url'] = $pdf->get_pdf_url( $attributes['id'], $attributes['entry'], $download, $print, ! $raw );
-
-		/* Sign the URL to allow direct access to the PDF until it expires */
-		if ( ! empty( $attributes['signed'] ) ) {
-			$secret_key = $this->options->get_option( 'signed_secret_token', '' );
-
-			/* If no secret key exists, generate it */
-			if ( empty( $secret_key ) ) {
-				$secret_key = wp_generate_password( 64 );
-				$this->options->update_option( 'signed_secret_token', $secret_key );
-			}
-
-			$url_signer = new Helper_Sha256_Url_Signer( $secret_key );
-
-			$expires = (int) $this->options->get_option( 'logged_out_timeout', '20' ) . ' minutes';
-			if ( ! empty( $attributes['expires'] ) ) {
-				$expires = $attributes['expires'];
-			}
-
-			$date    = new \DateTime();
-			$timeout = $date->modify( $expires );
-
-			$attributes['url'] = $url_signer->sign( $attributes['url'], $timeout );
-		}
-
-		/* generate the markup and return */
-		$this->log->addNotice(
-			'Generating Shortcode Markup',
-			[
-				'attr' => $attributes,
-			]
-		);
-
-		if ( $raw ) {
-			return $attributes['url'];
-		}
-
-		return $controller->view->display_gravitypdf_shortcode( $attributes );
-	}
-
-	/**
-	 * Update our Gravity Forms "Text" Confirmation Shortcode to include the current entry ID
-	 *
-	 * @param  string $confirmation The confirmation text
-	 * @param  array  $form         The Gravity Form array
-	 * @param  array  $entry        The Gravity Form entry information
-	 *
-	 * @return array               The confirmation text
-	 *
-	 * @since 4.0
-	 */
-	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
-
-		/* check if confirmation is text-based */
-		if ( ! is_array( $confirmation ) ) {
-			$confirmation = $this->add_entry_id_to_shortcode( $confirmation, $entry['id'] );
-		}
-
-		return $confirmation;
-	}
-
-	/**
-	 * Update our Gravity Forms Notification Shortcode to include the current entry ID
-	 *
-	 * @param  string $notification The confirmation text
-	 * @param  array  $form         The Gravity Form array
-	 * @param  array  $entry        The Gravity Form entry information
-	 *
-	 * @return array               The confirmation text
-	 *
-	 * @since 4.0
-	 */
-	public function gravitypdf_notification( $notification, $form, $entry ) {
-
-		/* check if notification has a 'message' */
-		if ( isset( $notification['message'] ) ) {
-			$notification['message'] = $this->add_entry_id_to_shortcode( $notification['message'], $entry['id'] );
-		}
-
-		return $notification;
-	}
-
-	/**
-	 * Add basic GravityView support and parse the Custom Content field for the [gravitypdf] shortcode
-	 * This means users can copy and paste our sample shortcode without having to worry about an entry ID being passed.
-	 *
-	 * @param string $html
-	 *
-	 * @return string
-	 *
-	 * @since 4.0
-	 */
-	public function gravitypdf_gravityview_custom( $html ) {
-		$gravityview_view = GravityView_View::getInstance();
-		$entry            = $gravityview_view->getCurrentEntry();
-
-		return $this->add_entry_id_to_shortcode( $html, $entry['id'] );
-	}
-
-	/**
-	 * Check for the [gravitypdf] shortcode and add the entry ID to it
-	 *
-	 * @param $string   The text to search
-	 * @param $entry_id The entry ID to add to our shortcode
-	 *
-	 * @return string
-	 *
-	 * @since 4.0
-	 */
-	private function add_entry_id_to_shortcode( $string, $entry_id ) {
-		/* Check if our shortcode exists and add the entry ID if needed */
-		$gravitypdf = $this->get_shortcode_information( 'gravitypdf', $string );
-
-		if ( sizeof( $gravitypdf ) > 0 ) {
-			foreach ( $gravitypdf as $shortcode ) {
-				/* if the user hasn't explicitely defined an entry to display... */
-				if ( ! isset( $shortcode['attr']['entry'] ) ) {
-					/* get the new shortcode information */
-					$new_shortcode = $this->add_shortcode_attr( $shortcode, 'entry', $entry_id );
-
-					/* update our confirmation message */
-					$string = str_replace( $shortcode['shortcode'], $new_shortcode['shortcode'], $string );
-				}
-			}
-		}
-
-		return $string;
-	}
-
-	/**
-	 * Update a shortcode attributes
-	 *
-	 * @param array  $code  In individual shortcode array pulled in from the $this->get_shortcode_information() function
-	 * @param string $attr  The attribute to add / replace
-	 * @param string $value The new attribute value
-	 *
-	 * @return array
-	 *
-	 * @since 4.0
-	 */
-	public function add_shortcode_attr( $code, $attr, $value ) {
-
-		/* if the attribute doesn't already exist... */
-		if ( ! isset( $code['attr'][ $attr ] ) ) {
-
-			$raw_attr = "{$code['attr_raw']} {$attr}=\"{$value}\"";
-
-			/* if there are no attributes at all we'll need to fix our str replace */
-			if ( 0 === strlen( $code['attr_raw'] ) ) {
-				$pattern           = '^\[([a-zA-Z]+)';
-				$code['shortcode'] = preg_replace( "/$pattern/s", "[$1 {$attr}=\"{$value}\"", $code['shortcode'] );
-			} else {
-				$code['shortcode'] = str_ireplace( $code['attr_raw'], $raw_attr, $code['shortcode'] );
-			}
-
-			$code['attr_raw'] = $raw_attr;
-
-		} else { /* replace the current attribute */
-			$pattern           = $attr . '="(.+?)"';
-			$code['shortcode'] = preg_replace( "/$pattern/si", $attr . '="' . $value . '"', $code['shortcode'] );
-			$code['attr_raw']  = preg_replace( "/$pattern/si", $attr . '="' . $value . '"', $code['attr_raw'] );
-		}
-
-		/* Update the actual attribute */
-		$code['attr'][ $attr ] = $value;
-
-		return $code;
-	}
-
-	/**
-	 * Check if user is currently submitting a new confirmation redirect URL in the admin area,
-	 * if so replace any shortcodes with a version that will be correctly saved and generated
-	 *
-	 * @param  array $form Gravity Form Array
-	 *
-	 * @return array
-	 *
-	 * @since 4.0
-	 */
-	public function gravitypdf_redirect_confirmation( $form ) {
-
-		/* check if the confirmation is currently being saved */
-		if ( isset( $_POST['form_confirmation_url'] ) ) {
-
-			$this->log->addNotice(
-				'Begin Converting Shortcode to URL for Redirect Confirmation',
-				[
-					'form_id' => $form['id'],
-					'post'    => $_POST,
-				]
-			);
-
-			$url = stripslashes_deep( $_POST['form_confirmation_url'] );
-
-			/* check if our shortcode exists and convert it to a URL */
-			$gravitypdf = $this->get_shortcode_information( 'gravitypdf', $url );
-
-			if ( count( $gravitypdf ) > 0 ) {
-				foreach ( $gravitypdf as $shortcode ) {
-					$new_shortcode = $this->add_shortcode_attr( $shortcode, 'entry', '{entry_id}' );
-					$new_shortcode = $this->add_shortcode_attr( $new_shortcode, 'raw', '1' );
-
-					/* update our confirmation message */
-					$_POST['form_confirmation_url'] = str_replace( $shortcode['shortcode'], $new_shortcode['shortcode'], $url );
-				}
-			}
-		}
-
-		/* it's a filter so return the $form array */
-		return $form;
-	}
-
-	/**
-	 * If a Redirect Confirmation, convert the Gravity PDF shortcode to it's URL form, if one exists
-	 *
-	 * @param string|array $confirmation
-	 * @param array $form
-	 * @param array $entry
-	 *
-	 * @return string|array
-	 *
-	 * @since 5.1
-	 */
-	public function gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry ) {
-
-		if ( isset( $confirmation['redirect'] ) ) {
-			$gravitypdf = $this->get_shortcode_information( 'gravitypdf', $form['confirmation']['url'] );
-
-			if ( count( $gravitypdf ) > 0 ) {
-				foreach ( $gravitypdf as $shortcode ) {
-					$url = do_shortcode( str_replace( '{entry_id}', $entry['id'], $shortcode['shortcode'] ) );
-
-					/* Add Query string parameters if they exist (but not with signed URLs) */
-					$query_string = substr( $confirmation['redirect'], strrpos( $confirmation['redirect'], '?' ) + 1 );
-					if ( empty( $shortcode['attr']['signed'] ) && strlen( $query_string ) > 0 ) {
-						$url .= ( strpos( $url, '?' ) !== false ) ? '&' . $query_string : '?' . $query_string;
-					}
-
-					$form['confirmation']['url'] = str_replace( $shortcode['shortcode'], $url, $form['confirmation']['url'] );
-				}
-
-				$confirmation['redirect'] = $form['confirmation']['url'];
-			}
-		}
-
-		return $confirmation;
-	}
-
-	/**
-	 * Search for any shortcodes in the text and return any matches
-	 *
-	 * @param  string $shortcode The shortcode to search for
-	 * @param  string $text      The text to search in
-	 *
-	 * @return array             The shortcode information
-	 *
-	 * @since 4.0
-	 */
-	public function get_shortcode_information( $shortcode, $text ) {
-		$shortcodes = [];
-
-		if ( has_shortcode( $text, $shortcode ) ) {
-			/* our shortcode exists so parse the shortcode data and return an easy-to-use array */
-			preg_match_all( '/' . get_shortcode_regex( [ $shortcode ] ) . '/', $text, $matches, PREG_SET_ORDER );
-
-			if ( empty( $matches ) ) {
-				return $shortcodes;
-			}
-
-			foreach ( $matches as $item ) {
-				if ( $shortcode === $item[2] ) {
-					$attr = shortcode_parse_atts( $item[3] );
-
-					$shortcodes[] = [
-						'shortcode' => $item[0],
-						'attr_raw'  => $item[3],
-						'attr'      => ( is_array( $attr ) ) ? $attr : [],
-					];
-				}
-			}
-		}
-
-		return $shortcodes;
 	}
 }

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -757,7 +757,8 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 			$this->data,
 			$this->misc,
 			$this->notices,
-			$this->templates
+			$this->templates,
+			new Helper\Helper_Url_Signer()
 		);
 
 		$view = new View\View_PDF(
@@ -788,7 +789,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function shortcodes() {
 
-		$model = new Model\Model_Shortcodes( $this->gform, $this->log, $this->options, $this->misc );
+		$model = new Model\Model_Shortcodes( $this->gform, $this->log, $this->options, $this->misc, new Helper\Helper_Url_Signer() );
 		$view  = new View\View_Shortcodes( [] );
 
 		$class = new Controller\Controller_Shortcodes( $model, $view, $this->log );

--- a/src/helper/Helper_Url_Signer.php
+++ b/src/helper/Helper_Url_Signer.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace GFPDF\Helper;
+
+use Spatie\UrlSigner\Exceptions\InvalidSignatureKey;
+
+/**
+ * Custom URL Signer used for auto-expiring PDF URLs
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.2
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+	This file is part of Gravity PDF.
+
+	Gravity PDF – Copyright (c) 2019, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * Class Helper_Url_Signer
+ *
+ * @package GFPDF\Helper
+ */
+class Helper_Url_Signer implements Helper_Interface_Url_Signer {
+
+	/**
+	 * Sign a URL with a secret token
+	 *
+	 * @param string $url
+	 * @param string $expiration
+	 *
+	 * @return string
+	 * @throws \Spatie\UrlSigner\Exceptions\InvalidSignatureKey
+	 *
+	 * @since 5.2
+	 */
+	public function sign( $url, $expiration ) {
+		$secret_key = \GPDFAPI::get_plugin_option( 'signed_secret_token', '' );
+
+		/* If no secret key exists, generate it */
+		if ( empty( $secret_key ) ) {
+			$secret_key = wp_generate_password( 64 );
+			\GPDFAPI::update_plugin_option( 'signed_secret_token', $secret_key );
+		}
+
+		$url_signer = new Helper_Sha256_Url_Signer( $secret_key );
+
+		if ( empty( $expiration ) ) {
+			$expiration = intval( \GPDFAPI::get_plugin_option( 'logged_out_timeout', '20' ) ) . ' minutes';
+		}
+
+		$date    = new \DateTime();
+		$timeout = $date->modify( $expiration );
+
+		return $url_signer->sign( $url, $timeout );
+	}
+
+	/**
+	 * Verify if the signed URL is valid
+	 *
+	 * @param string $url
+	 *
+	 * @return bool
+	 *
+	 * @since 5.2
+	 */
+	public function verify( $url ) {
+		$secret_key = \GPDFAPI::get_plugin_option( 'signed_secret_token', '' );
+
+		try {
+			$url_signer = new Helper_Sha256_Url_Signer( $secret_key );
+			return $url_signer->validate( $url );
+		} catch ( InvalidSignatureKey $e ) {
+			return false;
+		}
+	}
+}

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -3,7 +3,9 @@
 namespace GFPDF\Tests;
 
 use GFPDF\Controller\Controller_PDF;
+use GFPDF\Helper\Helper_Url_Signer;
 use GFPDF\Model\Model_PDF;
+use GFPDF\Plugins\DeveloperToolkit\Loader\Helper;
 use GFPDF\View\View_PDF;
 use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Fields\Field_Products;
@@ -98,7 +100,7 @@ class Test_PDF extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->model = new Model_PDF( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices, $gfpdf->templates );
+		$this->model = new Model_PDF( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices, $gfpdf->templates, new Helper_Url_Signer() );
 		$this->view  = new View_PDF( [], $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->templates );
 
 		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->misc );

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -3,6 +3,7 @@
 namespace GFPDF\Tests;
 
 use GFPDF\Controller\Controller_PDF;
+use GFPDF\Helper\Helper_Url_Signer;
 use GFPDF\Model\Model_PDF;
 use GFPDF\View\View_PDF;
 use GFPDF\Helper\Helper_PDF;
@@ -91,7 +92,7 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 		parent::setUp();
 
 		/* Setup our test classes */
-		$this->model = new Model_PDF( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices, $gfpdf->templates );
+		$this->model = new Model_PDF( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices, $gfpdf->templates, new Helper_Url_Signer() );
 		$this->view  = new View_PDF( [], $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->templates );
 
 		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->misc );

--- a/tests/phpunit/unit-tests/test-url-signer.php
+++ b/tests/phpunit/unit-tests/test-url-signer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace GFPDF\Tests;
+
+
+use GFPDF\Helper\Helper_Url_Signer;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.2
+ */
+
+/*
+	This file is part of Gravity PDF.
+
+	Gravity PDF – Copyright (c) 2019, Blue Liquid Designs
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/**
+ * @since 5.2
+ * @group url-signer
+ */
+class Test_Url_Signer extends WP_UnitTestCase {
+
+	/**
+	 * @throws \Spatie\UrlSigner\Exceptions\InvalidSignatureKey
+	 *
+	 * @since 5.2
+	 */
+	public function test_sign_and_verify() {
+		$signer = new Helper_Url_Signer();
+		$url    = 'https://test.com';
+
+		$this->assertNotEquals( $url, $signer->sign( $url, '+ 1 day' ) );
+		$this->assertTrue( $signer->verify( $signer->sign( $url, '+ 1 day' ) ) );
+		$this->assertFalse( $signer->verify( $url ) );
+	}
+}


### PR DESCRIPTION
## Description

Refractor the Shortcode class to make it easier to reuse the code for other similar shortcodes

## Testing instructions
Checkout the branch and use the [gravitypdf] shortcode like normal. None of the features have changed, just the underlying code structure. 

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
