### PR TITLE
Drop Siteground Buffer instead of outputting it

### DIFF
--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -317,7 +317,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			remove_action( 'shutdown', [ $minifier, 'end_html_minifier_buffer' ] );
 
 			while ( ob_get_level() > 0 ) {
-				ob_end_flush();
+				ob_end_clean();
 			}
 		}
 	}


### PR DESCRIPTION
Fixed #939

## Description
Users report PHP Generation Issue due to output already being sent

## Testing instructions
Need to be on Siteground host to replicate.

## Checklist:
- [ ] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
