### PR TITLE
Add scripts to build Docker Test Site

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.1'
+
+services:
+
+  wordpress:
+    image: wordpress:5.2-php7.2
+    restart: always
+    ports:
+      - 8888:80
+    environment:
+      WORDPRESS_DB_HOST: mysql
+      WORDPRESS_DB_PASSWORD: example
+      WORDPRESS_DEBUG: 1
+    volumes:
+      - wordpress_data:/var/www/html
+      - ../:/var/www/html/wp-content/plugins/gravity-forms-pdf-extended
+      - ./mu-plugins:/var/www/html/wp-content/mu-plugins
+    depends_on:
+      - mysql
+
+  cli:
+    image: wordpress:cli
+    restart: always
+    user: xfs
+    volumes:
+      - wordpress_data:/var/www/html
+      - ../:/var/www/html/wp-content/plugins/gravity-forms-pdf-extended
+    depends_on:
+      - mysql
+      - wordpress
+    entrypoint: wp
+    command: "--info"
+
+  mysql:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: wordpress_test
+
+volumes:
+  wordpress_data:

--- a/.docker/mu-plugins/gravitypdf.php
+++ b/.docker/mu-plugins/gravitypdf.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * Add stubbing functionality for E2E testing
+ */
+
+use GFPDF\Helper\Helper_Logger;
+use GFPDF\Helper\Helper_Notices;
+use GFPDF\Helper\Helper_Singleton;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/* Register fake add-on */
+add_action(
+	'init',
+	function() {
+		include __DIR__ . '/src/Add_On_Bootstrap.php';
+
+		$name = 'Gravity PDF Core Booster';
+		$slug = 'gravity-pdf-core-booster';
+
+		$plugin = new GFPDF\Add_On_Bootstrap(
+			$slug,
+			$name,
+			'Gravity PDF',
+			'1.0',
+			'',
+			GPDFAPI::get_data_class(),
+			GPDFAPI::get_options_class(),
+			new Helper_Singleton(),
+			new Helper_Logger( $slug, $name ),
+			new Helper_Notices()
+		);
+
+		$plugin->set_edd_download_id( '' );
+		$plugin->set_addon_documentation_slug( '' );
+		$plugin->init();
+	}
+);
+
+/* Stub Gravity PDF remote requests */
+add_filter(
+	'pre_http_request',
+	function( $return, $req, $url ) {
+		/* Handle valid and invalid license responses */
+		if ( isset( $req['body']['edd_action'] ) && $req['body']['edd_action'] === 'activate_license' ) {
+			if ( $req['body']['license'] === '123456789' ) {
+				return [
+					'headers'  => [],
+					'body'     => '{"success":false}',
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			}
+
+			if ( $req['body']['license'] === '987654321' ) {
+				return [
+					'headers'  => [],
+					'body'     => '{"success":true}',
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			}
+		}
+
+		/* Handle License Deactivation */
+		if ( isset( $req['body']['edd_action'] ) && $req['body']['edd_action'] === 'deactivate_license' ) {
+			return [
+				'headers'  => [],
+				'body'     => '{"license":"deactivated"}',
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => '',
+			];
+		}
+
+		/* Handle Core Font Installer */
+		if ( strpos( $url, '/GravityPDF/mpdf-core-fonts/master/' ) !== false ) {
+			/* Throw error */
+			if ( substr( $url, -4 ) === '.txt' ) {
+				return [
+					'headers'  => [],
+					'body'     => '',
+					'response' => [ 'code' => 404 ],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			} else {
+				return [
+					'headers'  => [],
+					'body'     => '',
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			}
+
+			$counter++;
+		}
+
+		return $return;
+	},
+	10,
+	3
+);

--- a/.docker/mu-plugins/src/Add_On_Bootstrap.php
+++ b/.docker/mu-plugins/src/Add_On_Bootstrap.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace GFPDF;
+
+use GFPDF\Helper\Helper_Abstract_Addon;
+use GFPDF\Helper\Licensing\EDD_SL_Plugin_Updater;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2019, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+class Add_On_Bootstrap extends Helper_Abstract_Addon {
+	public function plugin_updater() {
+		$license_info = $this->get_license_info();
+
+		new EDD_SL_Plugin_Updater(
+			$this->data->store_url,
+			$this->get_main_plugin_file(),
+			[
+				'version'   => $this->get_version(),
+				'license'   => $license_info['license'],
+				'item_name' => $this->get_short_name(),
+				'author'    => $this->get_author(),
+				'beta'      => false,
+			]
+		);
+	}
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Add a valid Gravity Forms license key
+GF_LICENSE=0000000000000000

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.github export-ignore
+/.docker export-ignore
 /.travis.yml export-ignore
 /bin export-ignore
 /karma.conf.js export-ignore

--- a/.github/README.md
+++ b/.github/README.md
@@ -19,6 +19,15 @@ Before beginning, ensure you have [Git](https://git-scm.com/), [Composer](https:
 1. Open your terminal / command prompt to the Gravity PDF root directory and run `composer install`. This command will automatically download all the PHP and JS packages, and run the build tools.
 1. Copy the plugin to your WordPress plugin directory (if not there already) and active through your WordPress admin area
 
+# Setup Local Docker Environment
+
+A test site with Gravity PDF pre-configured can be automatically be built locally if you've Docker installed on available via the CLI. To setup:
+
+1. Start Docker. Note: if running Local By Flywheel (or you need to start Docker manually), first run `docker-machine start`, then `eval $(docker-machine env)`.
+1. Copy `.env.example` to `.env` and replace `0000000000000000` with a valid Elite license key in `.env`
+1. Run `./bin/setup-local-env.sh` from the command line
+1. Access test site at `http://localhost:8888`, or the domain shown in the CLI if different. The username is `admin` and the password is `password`
+
 # Documentation
 
 All documentation can be found at [https://gravitypdf.com/documentation/](https://gravitypdf.com/documentation/).

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ node_modules/*
 *.min.js
 *.map
 
-
 # Unit tests
 /tmp
 /tests/bin/
@@ -42,4 +41,7 @@ _notes
 _notes/*
 Thumbs.db
 *.pot
+
+# Environment File
+.env
 

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+WP_VERSION=${WP_VERSION-latest}
+WP_DEBUG=${WP_DEBUG-true}
+SCRIPT_DEBUG=${SCRIPT_DEBUG-true}
+DOCKER_COMPOSE_FILE_OPTIONS="-f .docker/docker-compose.yml"
+
+CLI='cli'
+CONTAINER='wordpress'
+SITE_TITLE='Gravity PDF'
+GF_LICENSE=$GF_LICENSE || $1
+
+# Get the host details for the WordPress container.
+HOST_IP='localhost'
+MACHINE_IP="$(docker-machine inspect "$(docker-machine active)" --format '{{ .Driver.IPAddress }}')"
+HOST_PORT="$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS port $CONTAINER 80 | awk -F : '{printf $2}')"
+
+# Add new variables / override existing if .env file exists
+if [ -f ".env" ]; then
+    set -a
+    source .env
+    set +a
+fi

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+##
+# Add error message formatting to a string, and echo it.
+#
+# @param {string} message The string to add formatting to.
+##
+error_message() {
+	echo -en "\033[31mERROR\033[0m: $1"
+}
+
+##
+# Add warning message formatting to a string, and echo it.
+#
+# @param {string} message The string to add formatting to.
+##
+warning_message() {
+	echo -en "\033[33mWARNING\033[0m: $1"
+}
+
+##
+# Add status message formatting to a string, and echo it.
+#
+# @param {string} message The string to add formatting to.
+##
+status_message() {
+	echo -en "\033[32mSTATUS\033[0m: $1"
+}
+
+##
+# Add formatting to an action string.
+#
+# @param {string} message The string to add formatting to.
+##
+action_format() {
+	echo -en "\033[32m$1\033[0m"
+}
+
+##
+# Check if the command exists as some sort of executable.
+#
+# The executable form of the command could be an alias, function, builtin, executable file or shell keyword.
+#
+# @param {string} command The command to check.
+#
+# @return {bool} Whether the command exists or not.
+##
+command_exists() {
+	type -t "$1" >/dev/null 2>&1
+}
+
+##
+# Check if a URL provided is a WordPress Website
+#
+# @param {string} a URL to the website
+#
+# @return {bool} Whether the command passed or not.
+##
+is_wordpress() {
+   return $(curl -L $1 -so - 2>&1 | grep -q "WordPress")
+}

--- a/bin/setup-docker.sh
+++ b/bin/setup-docker.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Include useful environmentals / functions
+. "$(dirname "$0")/env.sh"
+. "$(dirname "$0")/functions.sh"
+
+# Check that Docker is installed.
+if ! command_exists "docker"; then
+	echo -e $(error_message "Docker doesn't seem to be installed. Please head on over to the Docker site to download it: $(action_format "https://www.docker.com/products/docker-desktop")")
+	exit 1
+fi
+
+# Check that Docker is running.
+if ! docker info >/dev/null 2>&1; then
+	echo -e $(error_message "Docker isn't running. Please check that you've started your Docker app, and see it in your system tray.")
+	exit 1
+fi
+
+# Stop existing containers.
+echo -e $(status_message "Stopping Docker containers...")
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS down --remove-orphans >/dev/null 2>&1
+
+# Download image updates.
+echo -e $(status_message "Downloading Docker image updates...")
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS pull
+
+# Launch the containers.
+echo -e $(status_message "Starting Docker containers...")
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS up -d >/dev/null
+
+# Fix Permissions
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chown -R www-data:www-data wp-content

--- a/bin/setup-gravitypdf.sh
+++ b/bin/setup-gravitypdf.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Include useful environmentals / functions
+. "$(dirname "$0")/env.sh"
+. "$(dirname "$0")/functions.sh"
+
+# Check that Composer is installed.
+if ! command_exists "composer"; then
+	echo -e $(error_message "Composer doesn't seem to be installed. Please head on over to the Composer site to download it: $(action_format "https://getcomposer.org/download/")")
+	exit 1
+fi
+
+# Check that Yarn is installed.
+if ! command_exists "yarn"; then
+	echo -e $(error_message "Yarn doesn't seem to be installed. Please head on over to the Yarn site to download it: $(action_format "https://yarnpkg.com/en/docs/install")")
+	exit 1
+fi
+
+echo -e $(status_message "Building Gravity PDF...")
+composer install

--- a/bin/setup-local-env.sh
+++ b/bin/setup-local-env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Include useful environmentals / functions
+. "$(dirname "$0")/env.sh"
+. "$(dirname "$0")/functions.sh"
+
+# Check Docker is installed and running
+. "$(dirname "$0")/setup-docker.sh"
+
+# Build Gravity PDF
+. "$(dirname "$0")/setup-gravitypdf.sh"
+
+# Set up WordPress Development site.
+. "$(dirname "$0")/setup-wordpress.sh"

--- a/bin/setup-plugins.sh
+++ b/bin/setup-plugins.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Include useful environmentals / functions
+. "$(dirname "$0")/env.sh"
+. "$(dirname "$0")/functions.sh"
+
+# Setting up Gravity Forms
+echo -e $(status_message "Installing and configuring Gravity Forms")
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin install gravityformscli --activate --force --quiet
+
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI gf install --key=$GF_LICENSE --activate --force
+
+# Setting up Gravity PDF
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin activate gravity-forms-pdf-extended --quiet

--- a/bin/setup-wordpress.sh
+++ b/bin/setup-wordpress.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Include useful environmentals / functions
+. "$(dirname "$0")/env.sh"
+. "$(dirname "$0")/functions.sh"
+
+# Wait until the Docker containers are running and the WordPress site is responding to requests.
+echo -e $(status_message "Waiting for the Docker WordPress node to start...")
+
+until is_wordpress "http://$HOST_IP:$HOST_PORT"; do
+    if is_wordpress "http://$MACHINE_IP:$HOST_PORT"; then
+        HOST_IP=$MACHINE_IP
+    fi
+
+    echo -n '.'
+    sleep 5
+done
+echo ''
+
+HOST_URL="http://$HOST_IP:$HOST_PORT"
+
+# Save HOST to .env file
+if [ -f ".env" ] && [ -z "$E2E_TESTING_URL" ]; then
+    echo -e "\nE2E_TESTING_URL=$HOST_URL" >> .env
+fi
+
+# Install WordPress.
+echo -e $(status_message "Installing WordPress...")
+
+# The `-u 33` flag tells Docker to run the command as a particular user and
+# prevents permissions errors. See: https://github.com/WordPress/gutenberg/pull/8427#issuecomment-410232369
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI db reset --yes --quiet
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI core install --title="$SITE_TITLE" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=$HOST_URL --quiet
+
+# Make sure the uploads and upgrade folders exist and we have permissions to add files.
+echo -e $(status_message "Ensuring that files can be uploaded...")
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER mkdir -p /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade
+
+# Check the WordPress URL matches the current access URL
+echo -e $(status_message "Checking the site's url...")
+CURRENT_URL=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm $CLI option get siteurl)
+if [ "$CURRENT_URL" != "$HOST_URL" ]; then
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI option update home "$HOST_URL" --quiet
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI option update siteurl "$HOST_URL" --quiet
+fi
+
+# Configure site constants.
+echo -e $(status_message "Configuring site constants...")
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI config set WP_DEBUG $WP_DEBUG --raw --type=constant --quiet
+WP_DEBUG_RESULT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm -u 33 $CLI config get --type=constant --format=json WP_DEBUG)
+echo -e $(status_message "WP_DEBUG: $WP_DEBUG_RESULT...")
+
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI config set SCRIPT_DEBUG $SCRIPT_DEBUG --raw --type=constant --quiet
+SCRIPT_DEBUG_RESULT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm -u 33 $CLI config get --type=constant --format=json SCRIPT_DEBUG)
+echo -e $(status_message "SCRIPT_DEBUG: $SCRIPT_DEBUG_RESULT...")
+
+# Setup the Plugins
+. "$(dirname "$0")/setup-plugins.sh"
+
+echo -e $(status_message "WordPress is setup and accessible at $(action_format "$HOST_URL")")
+echo -e $(status_message "Access $(action_format "$HOST_URL/wp-admin/") using the following credentials:")
+echo -e $(status_message "Default username: $(action_format "admin"), password: $(action_format "password")")


### PR DESCRIPTION
## Description

Add build script to create Docker Test Site.

This will be eventually used for automated End To End Testing using TestCafe and Unit Testing. 

## Testing instructions
1. Start Docker. Note: if running Local By Flywheel, first run `docker-machine start`, then `docker-machine env` and run the command that gets spit out to configure your shell e.g `eval $(docker-machine env)`.
1. Copy `.env.example` to `.env` and replace `0000000000000000` with a valid Elite license key in `.env`
1. Run `./bin/setup-local-env.sh` from the command line
1. Access test site at `http://localhost:8888`, or the domain shown in the CLI if different. The username is `admin` and the password is `password`

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
