### PR TITLE
Move noindex to beginning of PDF endpoint processing

### DIFF
--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -211,6 +211,8 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			return null;
 		}
 
+		$this->prevent_index();
+
 		$pid    = $GLOBALS['wp']->query_vars['pid'];
 		$lid    = (int) $GLOBALS['wp']->query_vars['lid'];
 		$action = ( ( isset( $GLOBALS['wp']->query_vars['action'] ) ) && $GLOBALS['wp']->query_vars['action'] === 'download' ) ? 'download' : 'view';
@@ -248,6 +250,8 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		if ( empty( $_GET['gf_pdf'] ) || empty( $_GET['fid'] ) || empty( $_GET['lid'] ) || empty( $_GET['template'] ) ) {
 			return null;
 		}
+
+		$this->prevent_index();
 
 		$config = [
 			'lid'      => (int) explode( ',', $_GET['lid'] )[0],
@@ -300,6 +304,17 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	public function remove_pre_pdf_hooks() {
 		remove_filter( 'wp_kses_allowed_html', [ $this->view, 'allow_pdf_html' ] );
 		remove_filter( 'safe_style_css', [ $this->view, 'allow_pdf_css' ] );
+	}
+
+	/**
+	 * Prevent the PDF Endpoints being indexed
+	 *
+	 * @since 5.2
+	 */
+	public function prevent_index() {
+		if ( ! headers_sent() ) {
+			header( 'X-Robots-Tag: noindex, nofollow', true );
+		}
 	}
 
 	/**

--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -301,11 +301,6 @@ class Helper_PDF {
 
 		do_action( 'gfpdf_pre_pdf_generation_output', $this->mpdf, $form, $this->entry, $this->settings, $this );
 
-		/* If a developer decides to disable all security protocols we don't want the PDF indexed */
-		if ( ! headers_sent() ) {
-			header( 'X-Robots-Tag: noindex, nofollow', true );
-		}
-
 		switch ( $this->output ) {
 			case 'DISPLAY':
 				$this->prevent_caching();


### PR DESCRIPTION
##  Description

By moving the noindex call to the start of the URL endpoint process, we can ensure any errors also have a noindex and nofollow header set, instead of just successful PDF endpoints.

Resolves #955

## Testing instructions
Submit a form as a logged out user. Because you're in localhost, when you try view the PDF as the logged out user, you'll trigger an error.

Open your Browser Developer Tools and go to the Network tab. Reload the page with the PDF error and view the Response Headers. A new `X-Robots-Tag` will be present with `noindex` and `nofollow`.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/2918419/61762655-0a7d2d00-ae16-11e9-890d-40a0c9865b4e.png)


## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->