### PR TITLE
Ensure the gfpdf_post_save_pdf action isn't run twice

### DIFF
--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -125,8 +125,9 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_action( 'gform_entries_first_column_actions', [ $this->model, 'view_pdf_entry_list' ], 10, 4 );
 		add_action( 'gform_entry_info', [ $this->model, 'view_pdf_entry_detail' ], 10, 2 );
 
-		/* Add save PDF filter */
+		/* Add save PDF actions */
 		add_action( 'gform_after_submission', [ $this->model, 'maybe_save_pdf' ], 10, 2 );
+		add_action( 'gfpdf_post_pdf_generation', [ $this->model, 'trigger_post_save_pdf' ], 10, 4 );
 
 		/* Clean-up actions */
 		add_action( 'gform_after_submission', [ $this->model, 'cleanup_pdf' ], 9999, 2 );

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -2,38 +2,28 @@
 
 namespace GFPDF\Model;
 
-use GFPDF\Helper\Helper_Abstract_Model;
-use GFPDF\Helper\Helper_Interface_Url_Signer;
-use GFPDF\Helper\Helper_PDF;
-
-use GFPDF\Helper\Helper_Abstract_Fields;
-use GFPDF\Helper\Helper_Abstract_Field_Products;
+use Exception;
+use GF_Field;
+use GFCommon;
+use GFFormsModel;
 use GFPDF\Helper\Fields\Field_Default;
 use GFPDF\Helper\Fields\Field_Products;
-
+use GFPDF\Helper\Helper_Abstract_Field_Products;
+use GFPDF\Helper\Helper_Abstract_Fields;
 use GFPDF\Helper\Helper_Abstract_Form;
+use GFPDF\Helper\Helper_Abstract_Model;
 use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Data;
+use GFPDF\Helper\Helper_Interface_Url_Signer;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
-use GFPDF\Helper\Helper_Sha256_Url_Signer;
+use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Templates;
-
-use Spatie\UrlSigner\Exceptions\InvalidSignatureKey;
-
-use Psr\Log\LoggerInterface;
-
-use GFFormsModel;
-use GFCommon;
-use GF_Field;
 use GFQuiz;
-use GFSurvey;
-use GFPolls;
 use GFResults;
-
+use Psr\Log\LoggerInterface;
+use Spatie\UrlSigner\Exceptions\InvalidSignatureKey;
 use WP_Error;
-
-use Exception;
 
 /**
  * @package     Gravity PDF
@@ -965,19 +955,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		if ( $this->process_and_save_pdf( $pdf_generator ) ) {
 			$pdf_path = $pdf_generator->get_full_pdf_path();
-
 			if ( is_file( $pdf_path ) ) {
-
-				/* Add appropriate filters so developers can access the PDF when it is generated */
-				$form     = $this->gform->get_form( $entry['form_id'] );
-				$filename = basename( $pdf_path );
-
-				do_action( 'gfpdf_post_pdf_save', $form['id'], $entry['id'], $settings, $pdf_path ); /* Backwards compatibility */
-
-				/* See https://gravitypdf.com/documentation/v5/gfpdf_post_save_pdf/ for more details about these actions */
-				do_action( 'gfpdf_post_save_pdf', $pdf_path, $filename, $settings, $entry, $form );
-				do_action( 'gfpdf_post_save_pdf_' . $form['id'], $pdf_path, $filename, $settings, $entry, $form );
-
 				return $pdf_path;
 			}
 		}
@@ -1130,6 +1108,32 @@ class Model_PDF extends Helper_Abstract_Model {
 					$this->generate_and_save_pdf( $entry, $settings );
 				}
 			}
+		}
+	}
+
+	/**
+	 * Trigger Post PDF Generation Action
+	 *
+	 * @param array      $form     The Gravity Form
+	 * @param array      $entry    The Gravity Form Entry
+	 * @param array      $settings The Gravity PDF Settings
+	 * @param Helper_PDF $pdf      The Helper_PDF object
+	 *
+	 * @since 5.2
+	 */
+	public function trigger_post_save_pdf( $form, $entry, $settings, $pdf ) {
+		$pdf_path = $pdf->get_full_pdf_path();
+
+		if ( is_file( $pdf_path ) ) {
+			/* Add appropriate filters so developers can access the PDF when it is generated */
+			$form     = $this->gform->get_form( $entry['form_id'] );
+			$filename = basename( $pdf_path );
+
+			do_action( 'gfpdf_post_pdf_save', $form['id'], $entry['id'], $settings, $pdf_path ); /* Backwards compatibility */
+
+			/* See https://gravitypdf.com/documentation/v5/gfpdf_post_save_pdf/ for more details about these actions */
+			do_action( 'gfpdf_post_save_pdf', $pdf_path, $filename, $settings, $entry, $form );
+			do_action( 'gfpdf_post_save_pdf_' . $form['id'], $pdf_path, $filename, $settings, $entry, $form );
 		}
 	}
 

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -2,27 +2,20 @@
 
 namespace GFPDF\Tests;
 
+use Exception;
+use GF_Field;
+use GFCache;
 use GFPDF\Controller\Controller_PDF;
+use GFPDF\Helper\Fields\Field_Products;
+use GFPDF\Helper\Helper_Field_Container;
+use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Url_Signer;
 use GFPDF\Model\Model_PDF;
 use GFPDF\Plugins\DeveloperToolkit\Loader\Helper;
 use GFPDF\View\View_PDF;
-use GFPDF\Helper\Helper_PDF;
-use GFPDF\Helper\Fields\Field_Products;
-use GFPDF\Helper\Helper_Field_Container;
-
-use GFAPI;
-use GFFormsModel;
-use GF_Field;
-use GFForms;
-use GFCache;
-
-use WP_UnitTestCase;
-use WP_Error;
-use WP_Rewrite;
-
-use Exception;
 use ReflectionMethod;
+use WP_Error;
+use WP_UnitTestCase;
 
 /**
  * Test Gravity PDF Endpoint Functionality
@@ -1957,7 +1950,24 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertRegExp( '/\<p style="page-break-inside: avoid"\>\<\/p\>/', $html );
 		$this->assertRegExp( '/\<barcode code="04210000526" type="UPCE" \/\>/', $html );
 
-		do_action( 'gfpdf_post_pdf_generation' );
+		do_action(
+			'gfpdf_post_pdf_generation',
+			[],
+			[],
+			[],
+			new Helper_PDF(
+				[
+					'id'      => 1,
+					'form_id' => 1,
+				],
+				[],
+				\GPDFAPI::get_form_class(),
+				\GPDFAPI::get_data_class(),
+				\GPDFAPI::get_misc_class(),
+				\GPDFAPI::get_templates_class(),
+				\GPDFAPI::get_log_class()
+			)
+		);
 
 		/* Verify they are stripped out at all other times */
 		$html = wp_kses_post( $html );

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -2,18 +2,14 @@
 
 namespace GFPDF\Tests;
 
+use Exception;
 use GFPDF\Controller\Controller_PDF;
+use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Url_Signer;
 use GFPDF\Model\Model_PDF;
 use GFPDF\View\View_PDF;
-use GFPDF\Helper\Helper_PDF;
-
-use GFForms;
-
 use GPDFAPI;
 use WP_UnitTestCase;
-
-use Exception;
 
 /**
  * Any slow PDF-generation related tests should be included here. By default, this is excluded from the usual tests
@@ -76,7 +72,6 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 		$this->view  = new View_PDF( [], $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->templates );
 
 		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->misc );
-		$this->controller->init();
 
 		$fonts = glob( dirname( __FILE__ ) . '/fonts/' . '*.[tT][tT][fF]' );
 		$fonts = ( is_array( $fonts ) ) ? $fonts : [];
@@ -344,12 +339,15 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 			unlink( $filename );
 		}
 
+		$this->assertSame( 1, did_action( 'gfpdf_post_save_pdf' ) );
+
 		$settings['template'] = 'doesntexist';
 
 		/* Trigger an error */
 		$error = $this->model->generate_and_save_pdf( $entry, $settings );
 
 		$this->assertTrue( is_wp_error( $error ) );
+		$this->assertSame( 1, did_action( 'gfpdf_post_save_pdf' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Move the action so it runs only when the PDF is created and saved to disk. The PDF generation logic already includes the ability to only generate if the PDF doesn't already exist on disk (in the standard flow the PDF is cleaned up after the form submission process, so it's effectively run once).

Resolves #948

## Testing instructions
Configure a PDF on your form so that it will be automatically attached to a Notification. Also enable the "Always Save PDF" option.

Add the following filter to a MU Plugin or theme's `functions.php` file and add a breakpoint on the `$test = '';` line.

```
add_action( 'gfpdf_post_save_pdf', function( $pdf_path, $filename, $settings, $entry, $form ) {

	$test = '';

}, 10, 5 );
```

Prior to the patch, Xdebug would stop on this line twice during form submission. After the patch, it only runs once.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
