### PR TITLE
Enable MySQL in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 
 sudo: false
 
+services:
+  - mysql
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
## Description

Fixed Travis CI errors due to missing MySQL module.

## Testing instructions
See passing tests here: https://travis-ci.org/GravityPDF/gravity-pdf

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
