### PR TITLE
Fix bug with displaying Categories with commas in the label/value

### DIFF
--- a/src/Helper/Fields/Field_Post_Category.php
+++ b/src/Helper/Fields/Field_Post_Category.php
@@ -170,28 +170,10 @@ class Field_Post_Category extends Helper_Abstract_Fields {
 
 		/* Loop through standardised array and convert the label / value to their appropriate category */
 		foreach ( $items as &$val ) {
+			$cat = explode( ':', $val['label'] );
 
-			/* Process the category label */
-			if ( isset( $val['label'] ) ) {
-				$val['label'] = GFCommon::prepare_post_category_value( $val['label'], $this->field );
-
-				if ( is_array( $val['label'] ) ) {
-					$val['label'] = ( isset( $val['label'][0] ) ) ? $val['label'][0] : '';
-				}
-
-				$val['label'] = esc_html( $val['label'] );
-			}
-
-			/* process the category value */
-			if ( isset( $val['value'] ) ) {
-				$val['value'] = GFCommon::prepare_post_category_value( $val['value'], $this->field, 'conditional_logic' );
-
-				if ( is_array( $val['value'] ) ) {
-					$val['value'] = ( isset( $val['value'][0] ) ) ? $val['value'][0] : '';
-				}
-
-				$val['value'] = esc_html( $val['value'] );
-			}
+			$val['label'] = count( $cat ) > 0 ? esc_html( $cat[0] ) : '';
+			$val['value'] = count( $cat ) > 1 ? $cat[1] : $cat[0];
 		}
 
 		/**


### PR DESCRIPTION
## Description

When a Category field contained a category with a comma included, everything after the first comma would be removed. This patch ensures the full string gets displayed.

## Testing instructions
Go to Posts -> Categories in your admin area, then add a new category title containing a comma. In your Gravity Form, add a Category field.

After submission with the comma-category option selected, view a Core PDF. Before the patch the category string would be truncated. Afterwards, it gets displayed correctly. 

You can also use the `?data=1` helper parameter to inspect the label / value we process. 

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
