### PR TITLE
Add allow_url_fopen status to System Status

### DIFF
--- a/src/Controller/Controller_Install.php
+++ b/src/Controller/Controller_Install.php
@@ -160,6 +160,7 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 		$this->data->settings_url   = $this->model->get_settings_url();
 
 		$this->data->memory_limit             = ini_get( 'memory_limit' );
+		$this->data->allow_url_fopen          = (bool) ini_get( 'allow_url_fopen' );
 		$this->data->template_transient_cache = 'gfpdf_template_info';
 
 		$upload_details             = $this->misc->get_upload_details();

--- a/src/Controller/Controller_System_Report.php
+++ b/src/Controller/Controller_System_Report.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use GFPDF\Helper\Helper_Abstract_Controller;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Controller_System_Report
+ *
+ * @package GFPDF\Controller
+ *
+ * @since 5.3
+ */
+class Controller_System_Report extends Helper_Abstract_Controller {
+
+	/**
+	 * Holds our $allow_url_fopen value
+	 *
+	 * @since 5.3
+	 *
+	 * @var bool $allow_url_data
+	 */
+	protected $allow_url_data;
+
+	/**
+	 * Setup our class by injecting our dependencies
+	 *
+	 * @since 5.3
+	 *
+	 * @param boolean $allow_url_fopen
+	 */
+	public function __construct( $allow_url_fopen ) {
+		$this->allow_url_data = $allow_url_fopen;
+	}
+
+	/**
+	 * Initialise our class defaults
+	 *
+	 * @since 5.3
+	 */
+	public function init() {
+		$this->add_filters();
+	}
+
+	/**
+	 * Apply filters needed for the system status page
+	 *
+	 * @since 5.3
+	 */
+	public function add_filters() {
+		add_filter( 'gform_system_report', [ $this, 'system_report' ] );
+	}
+
+	/**
+	 * Include the add-on table in the PHP Server Environment system status.
+	 *
+	 * @since 5.3
+	 *
+	 * @param array $system_report
+	 *
+	 * @return array
+	 */
+	public function system_report( $system_report ) {
+
+		if ( isset( $system_report[2]['tables'][1]['items'] ) && is_array( $system_report[2]['tables'][1]['items'] ) ) {
+			$is_enabled = $this->is_allow_url_fopen_enabled( $this->allow_url_data );
+
+			$insert_val[] = [
+				'label'        => 'allow_url_fopen',
+				'label_export' => 'allow_url_fopen',
+				'value'        => $is_enabled,
+				'value_export' => $is_enabled,
+			];
+
+			array_splice( $system_report[2]['tables'][1]['items'], 11, 0, $insert_val );
+		}
+
+		return $system_report;
+	}
+
+	/**
+	 * Yes or No status for allow_url_fopen
+	 *
+	 * @since 5.3
+	 *
+	 * @param $allow_url_fopen
+	 *
+	 * @return string
+	 */
+	protected function is_allow_url_fopen_enabled( $allow_url_fopen ) {
+		return isset( $allow_url_fopen ) ? esc_html__( 'Yes', 'gravity-forms-pdf-extended' ) : esc_html__( 'No', 'gravity-forms-pdf-extended' );
+	}
+}

--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -37,6 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @property string  $multisite_template_location     The current path to the multisite PDF working directory
  * @property string  $multisite_template_location_url The current URL to the multisite PDF working directory
  * @property string  $template_transient_cache        The ID for the template header transient cache
+ * @property bool    $allow_url_fopen                 The current PHP allow_url_fopen ini setting status
  *
  */
 class Helper_Data {

--- a/src/View/View_Settings.php
+++ b/src/View/View_Settings.php
@@ -220,10 +220,11 @@ class View_Settings extends Helper_Abstract_View {
 		$status = new GFPDF_Major_Compatibility_Checks();
 
 		$vars = [
-			'memory' => $status->get_ram( $this->data->memory_limit ),
-			'wp'     => $wp_version,
-			'php'    => phpversion(),
-			'gf'     => $this->gform->get_version(),
+			'memory'    => $status->get_ram( $this->data->memory_limit ),
+			'wp'        => $wp_version,
+			'php'       => phpversion(),
+			'gf'        => $this->gform->get_version(),
+			'allow_url' => $this->data->allow_url_fopen,
 		];
 
 		/* load the system status view */
@@ -321,6 +322,7 @@ class View_Settings extends Helper_Abstract_View {
 
 		$tooltips['pdf_status_wp_memory'] = '<h6>' . esc_html__( 'WP Memory Available', 'gravity-forms-pdf-extended' ) . '</h6>' . sprintf( esc_html__( 'Producing PDF documents is hard work and Gravity PDF requires more resources than most plugins. We strongly recommend you have at least 128MB, but you may need more.', 'gravity-forms-pdf-extended' ) );
 		$tooltips['pdf_protection']       = '<h6>' . esc_html__( 'Direct PDF Protection', 'gravity-forms-pdf-extended' ) . '</h6>' . esc_html__( 'Your PDFs might be saved to a temporary directory that is publicly accessible. We will check if your PDFs are automatically protected, and let you know what you can do if they are not.', 'gravity-forms-pdf-extended' );
+		$tooltips['pdf_allow_url_fopen']  = '<h6>allow_url_fopen</h6>' . esc_html__( 'Having trouble displaying images in PDFs? If this PHP setting is disabled it could be the cause.', 'gravity-forms-pdf-extended' );
 
 		return apply_filters( 'gravitypdf_registered_tooltips', $tooltips );
 	}

--- a/src/View/html/Settings/system_status.php
+++ b/src/View/html/Settings/system_status.php
@@ -33,9 +33,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</th>
 
 		<td>
-
 			<?php
-				$ram_icon = 'fa fa-check-circle';
+			$ram_icon = 'fa fa-check-circle';
 			if ( $args['memory'] < 128 && $args['memory'] !== -1 ) {
 				$ram_icon = 'fa fa-exclamation-triangle';
 			}
@@ -84,6 +83,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<td>
 			<?php echo $args['php']; ?>
+		</td>
+	</tr>
+
+	<tr>
+		<th scope="row">
+			<?php esc_html_e( 'allow_url_fopen', 'gravity-forms-pdf-extended' ); ?> <?php gform_tooltip( 'pdf_allow_url_fopen' ); ?>
+		</th>
+
+		<td>
+			<?php
+			$allow_url_fopen_icon = 'fa fa-check-circle';
+			if ( ! $args['allow_url'] ) {
+				$allow_url_fopen_icon = 'fa fa-exclamation-triangle';
+			}
+			?>
+
+			<?= $args['allow_url'] ? esc_html__( 'Enabled', 'gravity-forms-pdf-extended' ) : esc_html__( 'Disabled', 'gravity-forms-pdf-extended' ) ?>
+
+			<span class="<?php echo $allow_url_fopen_icon; ?>"></span>
+
+			<?php if ( ! $args['allow_url'] ): ?>
+				<span class="gf_settings_description">
+					<?php echo sprintf( esc_html__( 'We detected the PHP runtime configuration setting %1$sallow_url_fopen%2$s is disabled.', 'gravity-forms-pdf-extended' ), '<a href="https://www.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen"><code>', '</code></a>' ); ?> <br>
+					<?php echo esc_html__( 'You may notice image display issues in your PDFs. Contact your web hosting provider for assistance enabling this feature.', 'gravity-forms-pdf-extended' ); ?>
+				</span>
+			<?php endif; ?>
 		</td>
 	</tr>
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -213,6 +213,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$this->template_manager();
 		$this->load_core_font_handler();
 		$this->load_debug();
+		$this->check_system_status();
 
 		/* Add localisation support */
 		$this->add_localization_support();
@@ -866,6 +867,20 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	public function load_debug() {
 		$class = new Controller\Controller_Debug( $this->data, $this->options, $this->templates );
 
+		$class->init();
+
+		$this->singleton->add_class( $class );
+	}
+
+	/**
+	 * Initialise our system status code
+	 *
+	 * @since 5.3
+	 *
+	 * @return void
+	 */
+	public function check_system_status() {
+		$class = new Controller\Controller_System_Report( $this->data->allow_url_fopen );
 		$class->init();
 
 		$this->singleton->add_class( $class );

--- a/tests/phpunit/unit-tests/Controller/TestControllerSystemReport.php
+++ b/tests/phpunit/unit-tests/Controller/TestControllerSystemReport.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class TestControllerSystemReport
+ *
+ * @package GFPDF\Controller
+ *
+ * @group   system-report
+ */
+class TestControllerSystemReport extends WP_UnitTestCase {
+
+	/**
+	 * @var Controller_System_Report
+	 */
+	protected $controller;
+
+	public function setUp() {
+		$this->controller = new Controller_System_Report( false );
+		$this->controller->init();
+	}
+
+	public function test_filters() {
+		$this->assertSame( 10, has_filter( 'gform_system_report', [ $this->controller, 'system_report' ] ) );
+	}
+
+	public function test_system_report() {
+		require_once( \GFCommon::get_base_path() . '/includes/system-status/class-gf-system-status.php' );
+		require_once( \GFCommon::get_base_path() . '/includes/system-status/class-gf-system-report.php' );
+		require_once( \GFCommon::get_base_path() . '/includes/system-status/class-gf-update.php' );
+
+		$system_report = \GF_System_Report::get_system_report();
+
+		$this->assertEquals( 'allow_url_fopen', $system_report[2]['tables'][1]['items'][11]['label'] );
+	}
+}

--- a/tests/phpunit/unit-tests/View/TestViewSettings.php
+++ b/tests/phpunit/unit-tests/View/TestViewSettings.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace GFPDF\View;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class TestViewSettings
+ *
+ * @package GFPDF\Viewr
+ */
+class TestViewSettings extends WP_UnitTestCase {
+
+	/**
+	 * @var View_Settings
+	 */
+	protected $view;
+
+	public function setUp() {
+		global $gfpdf;
+
+		$this->view = new View_Settings( [], $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->templates );
+	}
+
+	/**
+	 * @since system-report
+	 */
+	public function test_allow_url_fopen_status() {
+		global $gfpdf;
+
+		require_once( \GFCommon::get_base_path() . '/tooltips.php' );
+
+		ob_start();
+		$gfpdf->data->allow_url_fopen = false;
+		$this->view->system_status();
+
+		$html = ob_get_clean();
+		$this->assertRegExp( '/allow_url_fopen/', $html );
+		$this->assertRegExp( '/You may notice image display issues/', $html );
+
+		ob_start();
+		$gfpdf->data->allow_url_fopen = true;
+		$this->view->system_status();
+
+		$html = ob_get_clean();
+		$this->assertRegExp( '/allow_url_fopen/', $html );
+		$this->assertNotRegExp( '/You may notice image display issues/', $html );
+	}
+}


### PR DESCRIPTION
## Description

Allow users to easily see if the `allow_url_fopen` setting is enabled or not on the web server. 

Resolves https://github.com/GravityPDF/gravity-pdf/issues/967

## Testing instructions
Go to Forms -> Settings -> PDF and navigate to the bottom

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/2918419/64217656-97310580-cf01-11e9-84e5-efd6006a592c.png)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->

@jakejackson1 to refine text copy displayed to the user
