### PR TITLE
Resolves an issue redirecting to the PDF in AJAX mode

### DIFF
--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -164,7 +164,7 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
 
 		/* check if confirmation is text-based */
-		if ( ! is_array( $confirmation ) ) {
+		if ( isset( $form['confirmation']['type'] ) && $form['confirmation']['type'] === 'message' ) {
 			$confirmation = $this->add_entry_id_to_shortcode( $confirmation, $entry['id'] );
 		}
 
@@ -335,17 +335,22 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 */
 	public function gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry ) {
 
-		if ( isset( $confirmation['redirect'] ) ) {
+		if ( $form['confirmation']['type'] === 'redirect' ) {
 			$shortcode_information = $this->get_shortcode_information( static::SHORTCODE, $form['confirmation']['url'] );
 
 			if ( count( $shortcode_information ) > 0 ) {
+				$confirmation = [ 'redirect' => '' ];
+
 				foreach ( $shortcode_information as $shortcode ) {
 					$url = do_shortcode( str_replace( '{entry_id}', $entry['id'], $shortcode['shortcode'] ) );
 
 					/* Add Query string parameters if they exist (but not with signed URLs) */
-					$query_string = substr( $confirmation['redirect'], strrpos( $confirmation['redirect'], '?' ) + 1 );
-					if ( empty( $shortcode['attr']['signed'] ) && strlen( $query_string ) > 0 ) {
-						$url .= ( strpos( $url, '?' ) !== false ) ? '&' . $query_string : '?' . $query_string;
+					$has_query_string = strrpos( $form['confirmation']['url'], '?' );
+					if ( $has_query_string !== false ) {
+						$query_string = substr( $form['confirmation']['url'], $has_query_string + 1 );
+						if ( empty( $shortcode['attr']['signed'] ) && strlen( $query_string ) > 0 ) {
+							$url .= ( strpos( $url, '?' ) !== false ) ? '&' . $query_string : '?' . $query_string;
+						}
 					}
 
 					$form['confirmation']['url'] = str_replace( $shortcode['shortcode'], $url, $form['confirmation']['url'] );

--- a/tests/phpunit/unit-tests/test-shortcodes.php
+++ b/tests/phpunit/unit-tests/test-shortcodes.php
@@ -6,7 +6,6 @@ use GFPDF\Controller\Controller_Shortcodes;
 use GFPDF\Helper\Helper_Url_Signer;
 use GFPDF\Model\Model_Shortcodes;
 use GFPDF\View\View_Shortcodes;
-
 use WP_UnitTestCase;
 
 /**
@@ -330,9 +329,10 @@ class Test_Shortcode extends WP_UnitTestCase {
 	public function test_gravitypdf_confirmation() {
 
 		/* Setup test data */
-		$confirmation = 'Thanks for getting in touch. [gravitypdf id="555ad84787d7e"]';
-		$form         = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
-		$lead         = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+		$confirmation         = 'Thanks for getting in touch. [gravitypdf id="555ad84787d7e"]';
+		$form                 = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+		$form['confirmation'] = $form['confirmations']['54bca34973cdd'];
+		$lead                 = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
 
 		/* Check our entry ID is being automatically added */
 		$results = $this->model->gravitypdf_confirmation( $confirmation, $form, $lead );
@@ -343,8 +343,9 @@ class Test_Shortcode extends WP_UnitTestCase {
 		$results      = $this->model->gravitypdf_confirmation( $confirmation, $form, $lead );
 		$this->assertNotFalse( strpos( $results, '[gravitypdf id="555ad84787d7e" entry="5000"]' ) );
 
-		/* Check we pass when confirmation is an array */
-		$results = $this->model->gravitypdf_confirmation( [ 'data' ], $form, $lead );
+		/* Check we pass when confirmation is not a message */
+		$form['confirmation']['type'] = 'redirect';
+		$results                      = $this->model->gravitypdf_confirmation( [ 'data' ], $form, $lead );
 		$this->assertEquals( 'data', $results[0] );
 	}
 
@@ -456,8 +457,9 @@ class Test_Shortcode extends WP_UnitTestCase {
 
 		$this->assertTrue( $this->model->gravitypdf_redirect_confirmation_shortcode_processing( true, $form, $entry ) );
 
-		$confirmation = [ 'redirect' => '' ];
-		$results      = $this->model->gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry );
+		$form['confirmation']['type'] = 'redirect';
+		$confirmation                 = [ 'redirect' => '' ];
+		$results                      = $this->model->gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry );
 		$this->assertNotFalse( strpos( $results['redirect'], '?gpdf=1&pid=556690c67856b&lid=1&action=download' ) );
 
 		$form['confirmation']['url'] = '[gravitypdf id="556690c67856b" entry="{entry_id}" raw="1" signed="1"]';


### PR DESCRIPTION
## Description

When the AJAX redirect was used, GF generated the redirect JS string and passed it to the filter we tapped into. Because it was a string, it was being handled by our text confirmation code. This patch corrects that problem.

## Testing instructions
1. Embed a form (any) on a WordPress Page or Post and enable AJAX mode
1. Ensure a PDF is configured on the form, then copy the [gravitypdf] shortcode show on the PDF List page
1. Open up the default Confirmation, select Redirect mode, then paste in the shortcode and save.
1. Submit the form embedded on your post/page, it'll hang and the browser Console will show a JS error
1. When checking out this branch, the AJAX Confirmation will work correctly. 

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
When testing, you should double check the non-AJAX redirect, page redirect, and text redirect also work as expected and the shortcode generates correctly. 

I may need to add an additional unit test to cover this change, but will review after internal testing. 
