### PR TITLE
Download and load GitHub Core Font JSON Payload during build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ node_modules/*
 *.min.js
 chunk-*.js
 *.map
+dist/*
 
 # Unit tests
 /tmp

--- a/bin/json-payload.sh
+++ b/bin/json-payload.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [[ -z "$1" ]]; then
+	echo "Missing Payload URL" 1>&2
+	exit 1
+fi
+
+if [[ -z "$2" ]]; then
+	echo "Missing output filename " 1>&2
+	exit 1
+fi
+
+
+mkdir -p dist/payload
+curl -L $1 -o dist/payload/$2

--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "test:js:watch": "cross-env NODE_ENV=test karma start --auto-watch --no-single-run --log-level error",
     "test:js:all": "cross-env NODE_ENV=test karma start --browsers Firefox,Chrome,IE",
 
-    "prebuild": "yarn global add gulp-cli && yarn",
+    "prebuild": "yarn global add gulp-cli && yarn && yarn prebuild:core-fonts",
+    "prebuild:core-fonts": "bash bin/json-payload.sh https://api.github.com/repos/GravityPDF/mpdf-core-fonts/contents/ core-fonts.json",
+
     "build:production": "gulp && cross-env NODE_ENV=production webpack --mode production",
     "build:dev": "gulp && cross-env NODE_ENV=development webpack --mode development",
     "build:watch:css": "gulp watch",

--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -267,7 +267,6 @@ class Helper_Data {
 				'couldNotDeleteTemplate'               => esc_html__( 'Could not delete template.', 'gravity-forms-pdf-extended' ),
 				'templateInstallInstructions'          => esc_html__( 'If you have a PDF template in .zip format you may install it here. You can also update an existing PDF template (this will override any changes you have made).', 'gravity-forms-pdf-extended' ),
 
-				'coreFontListUrl'                      => 'https://api.github.com/repos/GravityPDF/mpdf-core-fonts/contents/',
 				'coreFontSuccess'                      => esc_html__( 'ALL CORE FONTS SUCCESSFULLY INSTALLED', 'gravity-forms-pdf-extended' ),
 				'coreFontError'                        => esc_html__( '%s CORE FONT(S) DID NOT INSTALL CORRECTLY', 'gravity-forms-pdf-extended' ),
 				'coreFontGithubError'                  => esc_html__( 'Could not download Core Font list. Try again.', 'gravity-forms-pdf-extended' ),

--- a/src/assets/js/react/api/coreFonts.js
+++ b/src/assets/js/react/api/coreFonts.js
@@ -36,8 +36,8 @@ import request from 'superagent'
  */
 export function apiGetFilesFromGitHub () {
   return request
-    .get(GFPDF.coreFontListUrl)
-    .accept('application/vnd.github.v3+json')
+    .get(GFPDF.pluginUrl + 'dist/payload/core-fonts.json')
+    .accept('application/json')
     .type('json')
 }
 

--- a/src/assets/js/react/router/coreFontRouter.js
+++ b/src/assets/js/react/router/coreFontRouter.js
@@ -83,7 +83,6 @@ const CoreFont = ({ history, button }) => (
     location={history.location}
     buttonClassName={button.className}
     buttonText={button.innerText}
-    listUrl={GFPDF.coreFontListUrl}
     success={GFPDF.coreFontSuccess}
     error={GFPDF.coreFontError}
     githubError={GFPDF.coreFontGithubError}


### PR DESCRIPTION
## Description

Instead of calling the GitHub API directly, during the plugin build process we will save the payload locally and then use it. This circumvent API restrictions by GitHub for unauthenticated users. 

Resolves #974

## Testing instructions
Run `yarn prebuild` to save the GitHub API JSON. Then use the Core Font Installer. 

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
