### PR TITLE
Resolve PHP error when Category field is blank

### DIFF
--- a/src/Helper/Fields/Field_Post_Category.php
+++ b/src/Helper/Fields/Field_Post_Category.php
@@ -163,7 +163,7 @@ class Field_Post_Category extends Helper_Abstract_Fields {
 		 * while checkbox and multiselect will not.
 		 */
 		$single_dimension = false;
-		if ( ! isset( $items[0] ) ) { /* convert single-dimensional array to multi-dimensional */
+		if ( isset( $items['label'] ) ) { /* convert single-dimensional array to multi-dimensional */
 			$items            = [ $items ];
 			$single_dimension = true;
 		}


### PR DESCRIPTION
## Description

Prevents error with Category checkbox fields when no value is passed.

## Testing instructions
Before PR

1. Add Category Checkbox field to Gravity Form
1. Configure Core template
1. Submit test entry
1 View PDF
1. Error will either show on screen (or when you download the PDF and open it up in a text editor the error will show up at the beginning of the file). If no error, double check `WP_DEBUG` set to `true` in `wp-config.php` file

After PR there will be no error.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
