### PR TITLE
Fix up unit tests for PHP7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,8 @@ jobs:
       env: INSTALL_WORDPRESS=false INSTALL_COMPOSER=1
       script:
         - |
-          npm run env docker-run -- php composer format &&
-          npm run env docker-run -- php composer lint:errors
+          npm run lint:php:format &&
+          npm run lint:php
 
     - name: PHP Compatibility
       env: INSTALL_WORDPRESS=false INSTALL_COMPOSER=1

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
   },
   "scripts": {
     "lint:js": "eslint src/**/*.js",
+    "lint:php": "npm run env docker-run -- php composer lint:errors",
+    "lint:php:format": "npm run env docker-run -- php composer format",
 
     "test:php": "wp-scripts env test-php",
     "test:php:multisite": "cross-env WP_MULTISITE=1 wp-scripts env test-php",

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -916,7 +916,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 */
 	public function get_default_config_data( $form_id ) {
 
-		$pid = $GLOBALS['wp']->query_vars['pid'];
+		$pid = isset( $GLOBALS['wp']->query_vars['pid'] ) ? $GLOBALS['wp']->query_vars['pid'] : '';
 
 		$settings = $this->options->get_pdf( $form_id, $pid );
 

--- a/tests/phpunit/unit-tests/test-form-settings.php
+++ b/tests/phpunit/unit-tests/test-form-settings.php
@@ -304,7 +304,8 @@ class Test_Form_Settings extends WP_UnitTestCase {
 
 		require_once( GFCommon::get_base_path() . '/form_settings.php' );
 
-		$form_id = $this->form_id;
+		$form_id    = $this->form_id;
+		$_GET['id'] = $form_id;
 
 		/* Test capability security */
 		try {
@@ -339,8 +340,9 @@ class Test_Form_Settings extends WP_UnitTestCase {
 
 		require_once( GFCommon::get_base_path() . '/form_settings.php' );
 
-		$form_id = $this->form_id;
-		$pid     = '555ad84787d7e';
+		$form_id    = $this->form_id;
+		$_GET['id'] = $form_id;
+		$pid        = '555ad84787d7e';
 
 		/* Test capability security */
 		try {

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -1851,7 +1851,7 @@ class Test_PDF extends WP_UnitTestCase {
 			'first_footer'     => 'This is the first footer',
 
 			'background_image' => '/path/image.png',
-			'background_color' => 'red',
+			'background_color' => '#FF2222',
 		];
 
 		ob_start();
@@ -1877,7 +1877,7 @@ class Test_PDF extends WP_UnitTestCase {
 		$this->assertNotFalse( strpos( $results, 'background-image: url(/path/image.png) no-repeat 0 0;' ) );
 		$this->assertNotFalse( strpos( $results, 'background-image-resize: 4;' ) );
 
-		$this->assertNotFalse( strpos( $results, 'background-color: red;' ) );
+		$this->assertNotFalse( strpos( $results, 'background-color: #FF2222;' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Correct issues with Gravity PDF when running unit tests under PHP7.4

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
