### PR TITLE
Fixed Welcome Screen logo in small screen & console warnings

### DIFF
--- a/src/assets/css/gfpdf-styles.css
+++ b/src/assets/css/gfpdf-styles.css
@@ -923,7 +923,10 @@ div img.gfpdf-image {
  }
 
  .about-wrap .gfpdf-badge {
-  margin-top: 1.5em;
+  display: block;
+  margin: 1.5em auto 1.5em auto;
+  padding-top: 170px;
+  width: 180px;
  }
 
  .gfpdf-two-col .col {

--- a/tests/mocha/unit-tests/react/components/Template/template.screenshot.spec.js
+++ b/tests/mocha/unit-tests/react/components/Template/template.screenshot.spec.js
@@ -12,8 +12,8 @@ describe('<TemplateScreenshot />', () => {
   })
 
   it('renders the screenshot', () => {
-    const comp = mount(<TemplateScreenshot image='base/src/assets/images/gravitypdf-logo.png' />)
+    const comp = mount(<TemplateScreenshot image='base/src/assets/images/cap-paws-sitting.png' />)
 
-    expect(comp.find('img').render().attr('src')).to.equal('base/src/assets/images/gravitypdf-logo.png')
+    expect(comp.find('img').render().attr('src')).to.equal('base/src/assets/images/cap-paws-sitting.png')
   })
 })

--- a/tests/mocha/unit-tests/react/components/Template/template.screenshots.spec.js
+++ b/tests/mocha/unit-tests/react/components/Template/template.screenshots.spec.js
@@ -19,8 +19,8 @@ describe('<TemplateScreenshots />', () => {
   })
 
   it('renders the screenshot', () => {
-    const comp = mount(<TemplateScreenshots image='base/src/assets/images/gravitypdf-logo.png' />)
+    const comp = mount(<TemplateScreenshots image='base/src/assets/images/cap-paws-sitting.png' />)
 
-    expect(comp.find('img').render().attr('src')).to.equal('base/src/assets/images/gravitypdf-logo.png')
+    expect(comp.find('img').render().attr('src')).to.equal('base/src/assets/images/cap-paws-sitting.png')
   })
 })


### PR DESCRIPTION
## Description

Resolve issue: #1010 
Adjusted CSS code to fix the Welcome Page logo view for small screen and fix up for JS unit test console warning.

## Testing instructions

Run:  yarn run test:js

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
