### PR TITLE
Check for wperror

### DIFF
--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -163,8 +163,10 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 */
 	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
 
-		/* check if first parameter passed isn't a WP_Error */
-		/* https://github.com/GravityPDF/gravity-pdf/issues/999 */
+		/**
+		 * Check if first parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
 		if ( is_wp_error( $confirmation ) ) {
 			return $confirmation;
 		}
@@ -190,8 +192,10 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 */
 	public function gravitypdf_notification( $notification, $form, $entry ) {
 
-		/* check if first parameter passed isn't a WP_Error */
-		/* https://github.com/GravityPDF/gravity-pdf/issues/999 */
+		/**
+		 * Check if first parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
 		if ( is_wp_error( $notification ) ) {
 			return $notification;
 		}
@@ -348,8 +352,10 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 */
 	public function gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry ) {
 
-		/* check if first parameter passed isn't a WP_Error */
-		/* https://github.com/GravityPDF/gravity-pdf/issues/999 */
+		/**
+		 * Check if first parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
 		if ( is_wp_error( $confirmation ) ) {
 			return $confirmation;
 		}

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -171,6 +171,22 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 			return $confirmation;
 		}
 
+		/**
+		 * Check if second parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
+		if (is_wp_error ($form)){
+			return $form;
+		}
+
+		/**
+		 * Check if third parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
+		if (is_wp_error ($entry)){
+			return $entry;
+		}
+
 		/* check if confirmation is text-based */
 		if ( ! is_array( $confirmation ) ) {
 			$confirmation = $this->add_entry_id_to_shortcode( $confirmation, $entry['id'] );
@@ -198,6 +214,22 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 		 */
 		if ( is_wp_error( $notification ) ) {
 			return $notification;
+		}
+
+		/**
+		 * Check if second parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
+		if (is_wp_error ($form)){
+			return $form;
+		}
+
+		/**
+		 * Check if third parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
+		if (is_wp_error ($entry)){
+			return $entry;
 		}
 
 		if ( isset( $notification['message'] ) ) {
@@ -358,6 +390,22 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 		 */
 		if ( is_wp_error( $confirmation ) ) {
 			return $confirmation;
+		}
+
+		/**
+		 * Check if second parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
+		if (is_wp_error ($form)){
+			return $form;
+		}
+
+		/**
+		 * Check if third parameter passed isn't a WP_Error
+		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 */
+		if (is_wp_error ($entry)){
+			return $entry;
 		}
 
 		if ( isset( $confirmation['redirect'] ) ) {

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -30,6 +30,7 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 
 	/**
 	 * Set this constant to the Shortcode ID you're using
+	 *
 	 * @since 5.2
 	 */
 	const SHORTCODE = '';
@@ -164,6 +165,10 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
 
 		/* check if confirmation is text-based */
+		if ( is_wp_error( $confirmation ) ) {
+			return $confirmation;
+		}
+
 		if ( ! is_array( $confirmation ) ) {
 			$confirmation = $this->add_entry_id_to_shortcode( $confirmation, $entry['id'] );
 		}
@@ -183,6 +188,10 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function gravitypdf_notification( $notification, $form, $entry ) {
+		if ( is_wp_error( $notification ) ) {
+			return $notification;
+		}
+
 		if ( isset( $notification['message'] ) ) {
 			$notification['message'] = $this->add_entry_id_to_shortcode( $notification['message'], $entry['id'] );
 		}
@@ -334,6 +343,10 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 * @since 5.1
 	 */
 	public function gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry ) {
+
+		if ( is_wp_error( $confirmation ) ) {
+			return $confirmation;
+		}
 
 		if ( isset( $confirmation['redirect'] ) ) {
 			$shortcode_information = $this->get_shortcode_information( static::SHORTCODE, $form['confirmation']['url'] );

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -30,7 +30,6 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 
 	/**
 	 * Set this constant to the Shortcode ID you're using
-	 *
 	 * @since 5.2
 	 */
 	const SHORTCODE = '';
@@ -164,11 +163,13 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 */
 	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
 
-		/* check if confirmation is text-based */
+		/* check if first parameter passed isn't a WP_Error */
+		/* https://github.com/GravityPDF/gravity-pdf/issues/999 */
 		if ( is_wp_error( $confirmation ) ) {
 			return $confirmation;
 		}
 
+		/* check if confirmation is text-based */
 		if ( ! is_array( $confirmation ) ) {
 			$confirmation = $this->add_entry_id_to_shortcode( $confirmation, $entry['id'] );
 		}
@@ -188,6 +189,9 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function gravitypdf_notification( $notification, $form, $entry ) {
+
+		/* check if first parameter passed isn't a WP_Error */
+		/* https://github.com/GravityPDF/gravity-pdf/issues/999 */
 		if ( is_wp_error( $notification ) ) {
 			return $notification;
 		}
@@ -344,6 +348,8 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	 */
 	public function gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry ) {
 
+		/* check if first parameter passed isn't a WP_Error */
+		/* https://github.com/GravityPDF/gravity-pdf/issues/999 */
 		if ( is_wp_error( $confirmation ) ) {
 			return $confirmation;
 		}

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -30,6 +30,7 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 
 	/**
 	 * Set this constant to the Shortcode ID you're using
+	 *
 	 * @since 5.2
 	 */
 	const SHORTCODE = '';
@@ -164,27 +165,14 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	public function gravitypdf_confirmation( $confirmation, $form, $entry ) {
 
 		/**
-		 * Check if first parameter passed isn't a WP_Error
-		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 * Do nothing if WP_Error is passed
+		 *
+		 * This resolves a conflict with a third party GF plugin which was passing an error instead of the expected GF confirmation response
+		 *
+		 * @see https://github.com/GravityPDF/gravity-pdf/issues/999
 		 */
-		if ( is_wp_error( $confirmation ) ) {
+		if ( is_wp_error( $confirmation ) || is_wp_error( $form ) || is_wp_error( $entry ) ) {
 			return $confirmation;
-		}
-
-		/**
-		 * Check if second parameter passed isn't a WP_Error
-		 * https://github.com/GravityPDF/gravity-pdf/issues/999
-		 */
-		if (is_wp_error ($form)){
-			return $form;
-		}
-
-		/**
-		 * Check if third parameter passed isn't a WP_Error
-		 * https://github.com/GravityPDF/gravity-pdf/issues/999
-		 */
-		if (is_wp_error ($entry)){
-			return $entry;
 		}
 
 		/* check if confirmation is text-based */
@@ -209,27 +197,14 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	public function gravitypdf_notification( $notification, $form, $entry ) {
 
 		/**
-		 * Check if first parameter passed isn't a WP_Error
-		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 * Do nothing if WP_Error is passed
+		 *
+		 * This resolves a conflict with a third party GF plugin which was passing an error instead of the expected GF confirmation response
+		 *
+		 * @see https://github.com/GravityPDF/gravity-pdf/issues/999
 		 */
-		if ( is_wp_error( $notification ) ) {
+		if ( is_wp_error( $notification ) || is_wp_error( $entry ) ) {
 			return $notification;
-		}
-
-		/**
-		 * Check if second parameter passed isn't a WP_Error
-		 * https://github.com/GravityPDF/gravity-pdf/issues/999
-		 */
-		if (is_wp_error ($form)){
-			return $form;
-		}
-
-		/**
-		 * Check if third parameter passed isn't a WP_Error
-		 * https://github.com/GravityPDF/gravity-pdf/issues/999
-		 */
-		if (is_wp_error ($entry)){
-			return $entry;
 		}
 
 		if ( isset( $notification['message'] ) ) {
@@ -385,10 +360,12 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	public function gravitypdf_redirect_confirmation_shortcode_processing( $confirmation, $form, $entry ) {
 
 		/**
-		 * Check if first parameter passed isn't a WP_Error
-		 * https://github.com/GravityPDF/gravity-pdf/issues/999
+		 * Do nothing if WP_Error is passed
+		 *
+		 * This resolves a conflict with a third party GF plugin which was passing an error instead of the expected GF confirmation response
+		 * @see https://github.com/GravityPDF/gravity-pdf/issues/999
 		 */
-		if ( is_wp_error( $confirmation ) ) {
+		if ( is_wp_error( $confirmation ) || is_wp_error( $form ) || is_wp_error( $entry ) ) {
 			return $confirmation;
 		}
 
@@ -396,7 +373,7 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 		 * Check if second parameter passed isn't a WP_Error
 		 * https://github.com/GravityPDF/gravity-pdf/issues/999
 		 */
-		if (is_wp_error ($form)){
+		if ( is_wp_error( $form ) ) {
 			return $form;
 		}
 
@@ -404,7 +381,7 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 		 * Check if third parameter passed isn't a WP_Error
 		 * https://github.com/GravityPDF/gravity-pdf/issues/999
 		 */
-		if (is_wp_error ($entry)){
+		if ( is_wp_error( $entry ) ) {
 			return $entry;
 		}
 


### PR DESCRIPTION
Making sure all the parameter passed in the function wasn't AP_Error

-Added a filter for `$form` and `$entry` parameter wasn't WP_Error
- #1021 

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
