### PR TITLE
Set curl to follow redirects

### DIFF
--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -630,6 +630,7 @@ class Helper_PDF {
 					'tempDir'                => $this->data->mpdf_tmp_location,
 
 					'curlCaCertificate'      => ABSPATH . WPINC . '/certificates/ca-bundle.crt',
+					'curlFollowLocation'     => true,
 
 					'allow_output_buffering' => true,
 					'autoLangToFont'         => true,

--- a/src/deprecated.php
+++ b/src/deprecated.php
@@ -737,6 +737,7 @@ if ( ! class_exists( 'mPDF' ) ) {
 					'tempDir'                => $data->mpdf_tmp_location,
 
 					'curlCaCertificate'      => ABSPATH . WPINC . '/certificates/ca-bundle.crt',
+					'curlFollowLocation'     => true,
 
 					'allow_output_buffering' => true,
 					'autoLangToFont'         => true,


### PR DESCRIPTION
## Description

When loading images in the PDF which have a redirect, cURL will now follow that redirect automatically.

## Testing instructions
Include a image in the PDF which has a URL that 301 redirects. The image will now load correctly. 

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
