### PR TITLE
Add support for GP Populate Anything's Live Merge Tags

### DIFF
--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -133,6 +133,12 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_action( 'gform_after_submission', [ $this->model, 'cleanup_pdf' ], 9999, 2 );
 		add_action( 'gform_after_update_entry', [ $this->model, 'cleanup_pdf_after_submission' ], 9999, 2 );
 		add_action( 'gfpdf_cleanup_tmp_dir', [ $this->model, 'cleanup_tmp_dir' ] );
+
+		/* Add Gravity Perk Population Anything Support */
+		if ( class_exists( '\GP_Populate_Anything_Live_Merge_Tags' ) ) {
+			add_action( 'gfpdf_pre_pdf_generation_initilise', [ $this->model, 'enable_gp_populate_anything' ] );
+			add_action( 'gfpdf_pre_pdf_generation_output', [ $this->model, 'disable_gp_populate_anything' ] );
+		}
 	}
 
 	/**

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -2106,4 +2106,44 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		return $mpdf;
 	}
+
+	/**
+	 * At the start of the PDF generation, filter all Gravity Perk Populate Anything merge tag replacement calls
+	 *
+	 * @since 5.3
+	 */
+	public function enable_gp_populate_anything() {
+		remove_filter( 'gppa_allow_all_lmts', '__return_true' );
+		add_filter( 'gform_pre_replace_merge_tags', [ $this, 'process_gp_populate_anything' ], 10, 3 );
+	}
+
+	/**
+	 * Replace any Gravity Perk Populate Anything live merge tags with their standard equivilant (i.e without the @ symbol)
+	 * Include support for the `fallback` option
+	 *
+	 * @param string $text
+	 *
+	 * @return string
+	 *
+	 * @since 5.3
+	 */
+	public function process_gp_populate_anything( $text, $form, $entry ) {
+		$gp = \GP_Populate_Anything_Live_Merge_Tags::get_instance();
+
+		$this->disable_gp_populate_anything();
+		$text = $gp->replace_live_merge_tags_static( $text, $form, $entry );
+		$this->enable_gp_populate_anything();
+
+		return $text;
+	}
+
+	/**
+	 * At the end of the PDF generation, remove filter to replace merge tags for Gravity Perk Populate Anything
+	 *
+	 * @since 5.3
+	 */
+	public function disable_gp_populate_anything() {
+		add_filter( 'gppa_allow_all_lmts', '__return_true' );
+		remove_filter( 'gform_pre_replace_merge_tags', [ $this, 'process_gp_populate_anything' ] );
+	}
 }


### PR DESCRIPTION
## Description

Resolves #985

## Testing instructions
Install Gravity Wiz and then the GP Populate Anything plugin. Use live merge tags `@{:1}` or `@{:1:fallback[value]}` in the form then view the PDF. No display issues will be present with these field types anymore. 

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
