### PR TITLE
Check variable exists before usage

### DIFF
--- a/src/Helper/Fields/Field_Quiz.php
+++ b/src/Helper/Fields/Field_Quiz.php
@@ -103,7 +103,7 @@ class Field_Quiz extends Helper_Abstract_Fields {
 				if ( $choice['value'] === $item ) {
 					$formatted[] = [
 						'text'      => esc_html( $choice['text'] ),
-						'isCorrect' => $choice['gquizIsCorrect'],
+						'isCorrect' => isset( $choice['gquizIsCorrect'] ) ? $choice['gquizIsCorrect'] : '',
 						'weight'    => ( isset( $choice['gquizWeight'] ) ) ? $choice['gquizWeight'] : '',
 					];
 				}


### PR DESCRIPTION
## Description

Prevents a PHP Notice

## Checklist:
- [X] I've tested the code.
- [X] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
