### PR TITLE
Fix up E2E test suite

### DIFF
--- a/bin/download-wordpress.sh
+++ b/bin/download-wordpress.sh
@@ -2,11 +2,11 @@
 
 # Download and unpack WordPress.
 mkdir tmp > /dev/null 2>&1
-rm -Rf wordpress && rm -Rf tmp/WordPress-master && rm -Rf tmp/wordpress-develop-master > /dev/null 2>&1
-curl -L https://github.com/WordPress/WordPress/archive/master.zip -o ./tmp/wordpress-latest.zip
-unzip -q ./tmp/wordpress-latest.zip -d ./tmp
+rm -Rf wordpress && rm -Rf tmp/wordpress-develop-master > /dev/null 2>&1
+curl -L https://wordpress.org/latest.zip -o ./tmp/latest.zip
+unzip -q ./tmp/latest.zip -d ./tmp
 mkdir -p wordpress/src
-mv ./tmp/WordPress-master/* wordpress/src
+mv ./tmp/wordpress/* wordpress/src
 
 # Create the upload/wp-config.php directory with permissions that Travis can handle.
 mkdir -p wordpress/src/wp-content/uploads

--- a/tests/e2e/page-model/helpers/page.js
+++ b/tests/e2e/page-model/helpers/page.js
@@ -4,7 +4,7 @@ import { button, link } from './field'
 
 class Page {
   constructor () {
-    this.closePopupButton = Selector('button').withAttribute('aria-label', 'Close dialog')
+    this.closePopupButton = Selector('button').withAttribute('aria-label', 'Disable tips')
     this.titleField = Selector('.editor-post-title').find('textarea').withAttribute('placeholder', 'Add title')
     this.addBlockIcon = Selector('button').withAttribute('aria-label', 'Add block')
     this.searchBlock = Selector('input').withAttribute('placeholder', 'Search for a block')


### PR DESCRIPTION
## Description

Fix up E2E test suite. Only pull the latest WordPress production version.

## Testing instructions

yarn run test:e2e
yarn run test:e2e:headless

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
