### PR TITLE
Allow HTML in Consent Label

### DIFF
--- a/src/Helper/Fields/Field_Consent.php
+++ b/src/Helper/Fields/Field_Consent.php
@@ -95,7 +95,7 @@ class Field_Consent extends Helper_Abstract_Fields {
 
 		$consent = [
 			'value'       => $value[0],
-			'label'       => esc_html( $value[1] ),
+			'label'       => wp_kses_post( $this->gform->process_tags( $value[1], $this->form, $this->entry ) ),
 			'description' => wp_kses_post(
 				wpautop(
 					$this->gform->process_tags( $this->field->get_field_description_from_revision( $value[2] ), $this->form, $this->entry )


### PR DESCRIPTION
## Description

The label is set by an authenticated user, and is not defined by the public. We'll allow any HTML that passes wp_kses_post().

## Testing instructions

Add Consent field with HTML in label then view Core PDF

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
