### PR TITLE
Add additional error handling to queue Queue

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,6 +37,7 @@
         <exclude name="WordPress.WhiteSpace.PrecisionAlignment"/>
         <exclude name="WordPress.NamingConventions.ValidVariableName"/>
         <exclude name="WordPress.NamingConventions.ValidFunctionName"/>
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
     </rule>
 
     <!-- Include the best parts of PSR-1 -->

--- a/src/Statics/Queue_Callbacks.php
+++ b/src/Statics/Queue_Callbacks.php
@@ -72,7 +72,7 @@ class Queue_Callbacks {
 		$entry = $gform->get_entry( $entry_id );
 
 		if ( $form === null ) {
-			$log->addError( 'Could not locate form', [ 'id' => $form_id, ] );
+			$log->addError( 'Could not locate form', [ 'id' => $form_id ] );
 
 			throw new Exception();
 		}
@@ -98,6 +98,8 @@ class Queue_Callbacks {
 	 * @param $form_id
 	 * @param $entry_id
 	 *
+	 * @throws Exception
+	 *
 	 * @since 5.0
 	 */
 	public static function cleanup_pdfs( $form_id, $entry_id ) {
@@ -112,7 +114,7 @@ class Queue_Callbacks {
 		$entry = $gform->get_entry( $entry_id );
 
 		if ( $form === null ) {
-			$log->addError( 'Could not locate form', [ 'id' => $form_id, ] );
+			$log->addError( 'Could not locate form', [ 'id' => $form_id ] );
 
 			throw new Exception();
 		}


### PR DESCRIPTION
## Description

Add checks in case the form or entry could not be retrieved. It might have been deleted, or the database is just inaccessible.

## Testing instructions
1. Install Crontrol plugin
1. Enable Background Processing
1. Add breakpoint in Queue_Callbacks.php on line 68
1. Submit form with PDF attached to notification
1. When breakpoint triggered stop the running process
1. Delete entry
1. Go to Control plugin and run the gravitypdf queue item
1. Verify an Exception is thrown

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
