### PR TITLE
Convert all log methods to PSR-3 standard

### DIFF
--- a/api.php
+++ b/api.php
@@ -31,14 +31,14 @@ final class GPDFAPI {
 	 *
 	 * Log messages can be added with any of the following:
 	 *
-	 * $gfpdf->log->addDebug( $message, [$parameters = array()] )
-	 * $gfpdf->log->addInfo( $message, [$parameters = array()] )
-	 * $gfpdf->log->addNotice( $message, [$parameters = array()] )
-	 * $gfpdf->log->addWarning( $message, [$parameters = array()] )
-	 * $gfpdf->log->addError( $message, [$parameters = array()] )
-	 * $gfpdf->log->addCritical( $message, [$parameters = array()] )
-	 * $gfpdf->log->addAlert( $message, [$parameters = array()] )
-	 * $gfpdf->log->addEmergency( $message, [$parameters = array()] )
+	 * $gfpdf->log->debug( $message, [$parameters = array()] )
+	 * $gfpdf->log->info( $message, [$parameters = array()] )
+	 * $gfpdf->log->notice( $message, [$parameters = array()] )
+	 * $gfpdf->log->warning( $message, [$parameters = array()] )
+	 * $gfpdf->log->error( $message, [$parameters = array()] )
+	 * $gfpdf->log->critical( $message, [$parameters = array()] )
+	 * $gfpdf->log->alert( $message, [$parameters = array()] )
+	 * $gfpdf->log->emergency( $message, [$parameters = array()] )
 	 *
 	 * When in production Gravity PDF will only log to a file when the Gravity Forms Logging plugin is enabled and Gravity PDF is set to "Log errors only" ($log->addError() or higher) or "Log all messages" ($log->addNotice() or higher)
 	 *

--- a/src/Controller/Controller_Actions.php
+++ b/src/Controller/Controller_Actions.php
@@ -175,7 +175,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 				 call_user_func( $route['condition'] )
 			) {
 
-				$this->log->addNotice(
+				$this->log->notice(
 					'Trigger Action Notification.',
 					[
 						'route' => $route,
@@ -205,7 +205,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 				/* Check user capability */
 				if ( ! $this->gform->has_capability( $route['capability'] ) ) {
 
-					$this->log->addCritical(
+					$this->log->critical(
 						'Lack of User Capabilities.',
 						[
 							'user'      => wp_get_current_user(),
@@ -219,7 +219,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 				/* Check nonce is valid */
 				if ( ! wp_verify_nonce( rgpost( 'gfpdf_action_' . $route['action'] ), 'gfpdf_action_' . $route['action'] ) ) {
 
-					$this->log->addWarning( 'Nonce Verification Failed.' );
+					$this->log->warning( 'Nonce Verification Failed.' );
 					$this->notices->add_error( esc_html__( 'There was a problem processing the action. Please try again.', 'gravity-forms-pdf-extended' ) );
 
 					continue;
@@ -227,7 +227,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 
 				/* Check if the user wants to dismiss the notice, otherwise process the route */
 				if ( isset( $_POST['gfpdf-dismiss-notice'] ) ) {
-					$this->log->addNotice(
+					$this->log->notice(
 						'Dismiss Action.',
 						[
 							'route' => $route,
@@ -236,7 +236,7 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 
 					$this->model->dismiss_notice( $route['action'] );
 				} else {
-					$this->log->addNotice(
+					$this->log->notice(
 						'Trigger Action Process.',
 						[
 							'route' => $route,

--- a/src/Controller/Controller_Install.php
+++ b/src/Controller/Controller_Install.php
@@ -211,7 +211,7 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 			/* Check Nonce is valid */
 			if ( ! wp_verify_nonce( rgpost( 'gfpdf-uninstall-plugin' ), 'gfpdf-uninstall-plugin' ) ) {
 				$this->notices->add_error( esc_html__( 'There was a problem uninstalling Gravity PDF. Please try again.', 'gravity-forms-pdf-extended' ) );
-				$this->log->addWarning( 'Nonce Verification Failed.' );
+				$this->log->warning( 'Nonce Verification Failed.' );
 
 				return null;
 			}
@@ -227,7 +227,7 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 				 ( is_multisite() && ! is_super_admin() )
 			) {
 
-				$this->log->addCritical(
+				$this->log->critical(
 					'Lack of User Capabilities.',
 					[
 						'user'      => wp_get_current_user(),

--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -218,7 +218,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		$lid    = (int) $GLOBALS['wp']->query_vars['lid'];
 		$action = ( ( isset( $GLOBALS['wp']->query_vars['action'] ) ) && $GLOBALS['wp']->query_vars['action'] === 'download' ) ? 'download' : 'view';
 
-		$this->log->addNotice(
+		$this->log->notice(
 			'Processing PDF endpoint.',
 			[
 				'pid'    => $pid,
@@ -262,7 +262,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			'action'   => ( isset( $_GET['download'] ) ) ? 'download' : 'view',
 		];
 
-		$this->log->addNotice(
+		$this->log->notice(
 			'Processing Legacy PDF endpoint.',
 			[
 				'config' => $config,
@@ -349,7 +349,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	 */
 	private function pdf_error( $error ) {
 
-		$this->log->addError(
+		$this->log->error(
 			'PDF Generation Error.',
 			[
 				'WP_Error_Message' => $error->get_error_message(),

--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -186,7 +186,7 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller implements Helper_
 		/* Disable notification if PDF needs to be attached to it */
 		foreach ( $pdfs as $pdf ) {
 			if ( $this->model_pdf->maybe_attach_to_notification( $notification, $pdf, $entry, $form ) ) {
-				$this->log->addNotice(
+				$this->log->notice(
 					'Gravity Forms Notification Delayed for Async Processing',
 					[
 						'notification' => $notification,
@@ -293,7 +293,7 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller implements Helper_
 
 		$queue_data = apply_filters( 'gfpdf_queue_pre_dispatch', $queue_data, $entry, $form );
 
-		$this->log->addNotice(
+		$this->log->notice(
 			'PDF Background Processing Queue',
 			[
 				'queue' => $queue_data,

--- a/src/Controller/Controller_Save_Core_Fonts.php
+++ b/src/Controller/Controller_Save_Core_Fonts.php
@@ -129,7 +129,7 @@ class Controller_Save_Core_Fonts extends Helper_Abstract_Controller implements H
 
 		/* Check for errors and log them to file */
 		if ( is_wp_error( $res ) ) {
-			$this->log->addError(
+			$this->log->error(
 				'Core Font Download Failed',
 				[
 					'name'             => $fontname,
@@ -142,7 +142,7 @@ class Controller_Save_Core_Fonts extends Helper_Abstract_Controller implements H
 		}
 
 		if ( $res_code !== 200 ) {
-			$this->log->addError(
+			$this->log->error(
 				'Core Font API Response Failed',
 				[
 					'response_code' => wp_remote_retrieve_response_code( $res ),

--- a/src/Controller/Controller_Settings.php
+++ b/src/Controller/Controller_Settings.php
@@ -251,7 +251,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		/* because current_user_can() doesn't handle Gravity Forms permissions quite correct we'll do our checks here */
 		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
-			$this->log->addCritical(
+			$this->log->critical(
 				'Lack of User Capabilities.',
 				[
 					'user'      => wp_get_current_user(),
@@ -279,7 +279,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 	public function disable_tools_on_view_cap( $nav ) {
 
 		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-			$this->log->addNotice( 'Lack of User Capabilities' );
+			$this->log->notice( 'Lack of User Capabilities' );
 
 			unset( $nav[100] ); /* remove tools tab */
 		}
@@ -304,7 +304,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		/* check if the user has permission to copy the templates */
 		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
 
-			$this->log->addCritical(
+			$this->log->critical(
 				'Lack of User Capabilities.',
 				[
 					'user'      => wp_get_current_user(),
@@ -326,7 +326,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		if ( isset( $settings['setup_templates']['name'] ) && isset( $settings['setup_templates']['nonce'] ) ) {
 			/* verify the nonce */
 			if ( ! wp_verify_nonce( $settings['setup_templates']['nonce'], 'gfpdf_settings[setup_templates]' ) ) {
-				$this->log->addWarning( 'Nonce Verification Failed.' );
+				$this->log->warning( 'Nonce Verification Failed.' );
 				$this->notices->add_error( esc_html__( 'There was a problem installing the PDF templates. Please try again.', 'gravity-forms-pdf-extended' ) );
 
 				return null;

--- a/src/Helper/Helper_Abstract_Options.php
+++ b/src/Helper/Helper_Abstract_Options.php
@@ -348,7 +348,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			return $settings;
 		}
 
-		$this->log->addError(
+		$this->log->error(
 			'Settings Retreival Error',
 			[
 				'form_id'          => $form_id,
@@ -385,7 +385,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 		if ( 0 === $form_id ) {
 
 			$error = new WP_Error( 'invalid_id', esc_html__( 'You must pass in a valid form ID', 'gravity-forms-pdf-extended' ) );
-			$this->log->addError(
+			$this->log->error(
 				'Error Getting Settings.',
 				[
 					'WP_Error_Message' => $error->get_error_message(),
@@ -404,7 +404,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			if ( empty( $form ) ) {
 
 				$error = new WP_Error( 'invalid_id', esc_html__( 'You must pass in a valid form ID', 'gravity-forms-pdf-extended' ) );
-				$this->log->addError(
+				$this->log->error(
 					'Error Getting Settings.',
 					[
 						'WP_Error_Message' => $error->get_error_message(),
@@ -494,7 +494,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			if ( $results ) {
 
 				/* return the ID if successful */
-				$this->log->addNotice(
+				$this->log->notice(
 					'Successfuly Added New PDF',
 					[
 						'pdf' => $pdf,
@@ -504,7 +504,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 				return $pdf['id'];
 			}
 
-			$this->log->addError(
+			$this->log->error(
 				'Error Saving New PDF',
 				[
 					'error' => $results,
@@ -535,7 +535,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	 */
 	public function update_pdf( $form_id, $pdf_id, $pdf = '', $update_db = true, $filters = true ) {
 
-		$this->log->addNotice(
+		$this->log->notice(
 			'Begin Updating PDF Settings',
 			[
 				'form_id'      => $form_id,
@@ -558,7 +558,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 
 			/* Don't run when adding a new PDF */
 			if ( $filters ) {
-				$this->log->addNotice( 'Run PDF Update Filters' );
+				$this->log->notice( 'Run PDF Update Filters' );
 
 				/* See https://gravitypdf.com/documentation/v5/gfpdf_form_update_pdf/ for more details about these filters */
 				$pdf = apply_filters( 'gfpdf_form_update_pdf', $pdf, $form_id, $pdf_id );
@@ -577,7 +577,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			$did_update = false;
 			if ( $update_db ) {
 
-				$this->log->addNotice(
+				$this->log->notice(
 					'Updating PDF Settings in Form Object',
 					[
 						'form_id' => $form['id'],
@@ -596,7 +596,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			return $did_update;
 		}
 
-		$this->log->addNotice( 'Completed Updating PDF Settings' );
+		$this->log->notice( 'Completed Updating PDF Settings' );
 
 		return false;
 	}
@@ -615,7 +615,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	 */
 	public function delete_pdf( $form_id, $pdf_id ) {
 
-		$this->log->addNotice(
+		$this->log->notice(
 			'Begin Deleting PDF Setting',
 			[
 				'form_id' => $form_id,
@@ -645,7 +645,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			/* If it updated, let's update the global variable */
 			if ( $did_update !== false ) {
 
-				$this->log->addNotice(
+				$this->log->notice(
 					'Completed Deleting PDF Setting',
 					[
 						'form_id' => $form_id,
@@ -661,7 +661,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 			return $did_update;
 		}
 
-		$this->log->addError(
+		$this->log->error(
 			'Failed Deleting PDF Setting',
 			[
 				'form_id' => $form_id,
@@ -714,7 +714,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	public function update_option( $key = '', $value = false ) {
 
 		if ( empty( $key ) ) {
-			$this->log->addError(
+			$this->log->error(
 				'Empty Option Key',
 				[
 					'value' => $value,
@@ -769,7 +769,7 @@ abstract class Helper_Abstract_Options implements Helper_Interface_Filters {
 	public function delete_option( $key = '' ) {
 
 		if ( empty( $key ) ) {
-			$this->log->addError( 'Option Delete Error' );
+			$this->log->error( 'Option Delete Error' );
 
 			return false;
 		}

--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -315,7 +315,7 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 		/* check if the confirmation is currently being saved */
 		if ( isset( $_POST['form_confirmation_url'] ) ) {
 
-			$this->log->addNotice(
+			$this->log->notice(
 				'Begin Converting Shortcode to URL for Redirect Confirmation',
 				[
 					'form_id' => $form['id'],

--- a/src/Helper/Helper_Migration.php
+++ b/src/Helper/Helper_Migration.php
@@ -132,7 +132,7 @@ class Helper_Migration {
 			$raw_config = $this->load_old_configuration();
 		} catch ( Exception $e ) {
 
-			$this->log->addError(
+			$this->log->error(
 				'Migration Error',
 				[
 					'exception' => $e->getMessage(),
@@ -517,7 +517,7 @@ class Helper_Migration {
 
 					if ( $results ) {
 						/* return the ID if successful */
-						$this->log->addNotice(
+						$this->log->notice(
 							'Successfully Imported v3 Node',
 							[
 								'pdf' => $node,
@@ -525,7 +525,7 @@ class Helper_Migration {
 						);
 					} else {
 						/* Log errors */
-						$this->log->addError(
+						$this->log->error(
 							'Error Importing v3 Node',
 							[
 								'error' => $results,

--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -372,7 +372,7 @@ class Helper_Misc {
 				}
 			}
 		} catch ( Exception $e ) {
-			$this->log->addError(
+			$this->log->error(
 				'Filesystem Delete Error',
 				[
 					'dir'       => $dir,
@@ -414,7 +414,7 @@ class Helper_Misc {
 		try {
 			if ( ! is_dir( $destination ) ) {
 				if ( ! wp_mkdir_p( $destination ) ) {
-					$this->log->addError(
+					$this->log->error(
 						'Failed Creating Folder Structure',
 						[
 							'dir' => $destination,
@@ -433,7 +433,7 @@ class Helper_Misc {
 			foreach ( $files as $fileinfo ) {
 				if ( $fileinfo->isDir() && ! file_exists( $destination . $files->getSubPathName() ) ) {
 					if ( ! @mkdir( $destination . $files->getSubPathName() ) ) {
-						$this->log->addError(
+						$this->log->error(
 							'Failed Creating Folder',
 							[
 								'dir' => $destination . $files->getSubPathName(),
@@ -444,7 +444,7 @@ class Helper_Misc {
 					}
 				} elseif ( ! $fileinfo->isDir() ) {
 					if ( ! copy( $fileinfo, $destination . $files->getSubPathName() ) ) {
-						$this->log->addError(
+						$this->log->error(
 							'Failed Creating File',
 							[
 								'file' => $destination . $files->getSubPathName(),
@@ -456,7 +456,7 @@ class Helper_Misc {
 			}
 		} catch ( Exception $e ) {
 
-			$this->log->addError(
+			$this->log->error(
 				'Filesystem Copy Error',
 				[
 					'source'      => $source,
@@ -939,7 +939,7 @@ class Helper_Misc {
 	 */
 	public function handle_ajax_authentication( $endpoint_desc, $capability = 'gravityforms_edit_settings', $nonce_name = 'gfpdf_ajax_nonce' ) {
 
-		$this->log->addNotice(
+		$this->log->notice(
 			'Running AJAX Endpoint',
 			[
 				'type' => $endpoint_desc,
@@ -953,7 +953,7 @@ class Helper_Misc {
 		$nonce = ( isset( $_POST['nonce'] ) ) ? $_POST['nonce'] : '';
 		if ( ! wp_verify_nonce( $nonce, $nonce_name ) ) {
 
-			$this->log->addWarning( 'Nonce Verification Failed' );
+			$this->log->warning( 'Nonce Verification Failed' );
 
 			/* Unauthorized response */
 			wp_die( '401', 401 );
@@ -962,7 +962,7 @@ class Helper_Misc {
 		/* prevent unauthorized access */
 		if ( $capability !== false && ! $this->gform->has_capability( $capability ) ) {
 
-			$this->log->addCritical(
+			$this->log->critical(
 				'Lack of User Capabilities',
 				[
 					'user'              => wp_get_current_user(),

--- a/src/Helper/Helper_Pdf_Queue.php
+++ b/src/Helper/Helper_Pdf_Queue.php
@@ -87,7 +87,7 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 	public function task( $callbacks ) {
 		$callback = array_shift( $callbacks );
 
-		$this->log->addNotice(
+		$this->log->notice(
 			sprintf(
 				'Begin async PDF task for %s',
 				$callback['id']
@@ -102,7 +102,7 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 			} catch ( Exception $e ) {
 
 				/* Log Error */
-				$this->log->addError(
+				$this->log->error(
 					sprintf(
 						'Async PDF task error for %s',
 						$callback['id']
@@ -121,7 +121,7 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 			}
 		}
 
-		$this->log->addNotice(
+		$this->log->notice(
 			sprintf(
 				'End async PDF task for %s',
 				$callback['id']

--- a/src/Helper/Helper_Templates.php
+++ b/src/Helper/Helper_Templates.php
@@ -312,7 +312,7 @@ class Helper_Templates {
 
 			return $this->get_template_info_by_path( $template_path );
 		} catch ( Exception $e ) {
-			$this->log->addWarning( $e->getMessage() );
+			$this->log->warning( $e->getMessage() );
 
 			return [
 				'group' => esc_html__( 'Legacy', 'gravity-forms-pdf-extended' ),
@@ -526,7 +526,7 @@ class Helper_Templates {
 
 			return $this->load_template_config_file( $class_path );
 		} catch ( Exception $e ) {
-			$this->log->addWarning( $e->getMessage() );
+			$this->log->warning( $e->getMessage() );
 		}
 
 		/* If class still empty it's either a legacy template or doesn't have a config. Check for legacy templates which support certain fields */
@@ -543,7 +543,7 @@ class Helper_Templates {
 			try {
 				$class = $this->load_template_config_file( PDF_PLUGIN_DIR . 'src/templates/config/legacy.php' );
 			} catch ( Exception $e ) {
-				$this->log->addError( 'Legacy Template Configuration Failed to Load' );
+				$this->log->error( 'Legacy Template Configuration Failed to Load' );
 			}
 		}
 

--- a/src/Model/Model_Actions.php
+++ b/src/Model/Model_Actions.php
@@ -334,7 +334,7 @@ class Model_Actions extends Helper_Abstract_Model {
 				'error' => sprintf( esc_html__( 'No configuration.php file found for site #%s', 'gravity-forms-pdf-extended' ), $blog_id ),
 			];
 
-			$log->addError( 'AJAX Endpoint Failed', $return );
+			$log->error( 'AJAX Endpoint Failed', $return );
 
 			echo json_encode( [ 'results' => $return ] );
 			wp_die();
@@ -354,13 +354,13 @@ class Model_Actions extends Helper_Abstract_Model {
 				'error' => sprintf( esc_html__( 'Database import problem for site #%s', 'gravity-forms-pdf-extended' ), $blog_id ),
 			];
 
-			$log->addError( 'AJAX Endpoint Failed', $return );
+			$log->error( 'AJAX Endpoint Failed', $return );
 
 			echo json_encode( [ 'results' => $return ] );
 			wp_die();
 		}
 
-		$log->addError( 'AJAX Endpoint Failed' );
+		$log->error( 'AJAX Endpoint Failed' );
 
 		/* Internal Server Error */
 		wp_die( '500', 500 );

--- a/src/Model/Model_Form_Settings.php
+++ b/src/Model/Model_Form_Settings.php
@@ -164,7 +164,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* prevent unauthorized access */
 		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-			$this->log->addWarning( 'Lack of User Capabilities.' );
+			$this->log->warning( 'Lack of User Capabilities.' );
 			wp_die( esc_html__( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
 		}
 
@@ -201,7 +201,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* prevent unauthorized access */
 		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-			$this->log->addWarning( 'Lack of User Capabilities.' );
+			$this->log->warning( 'Lack of User Capabilities.' );
 			wp_die( esc_html__( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
 		}
 
@@ -264,7 +264,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* prevent unauthorized access */
 		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-			$this->log->addCritical(
+			$this->log->critical(
 				'Lack of User Capabilities.',
 				[
 					'user'      => wp_get_current_user(),
@@ -277,7 +277,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* Check Nonce is valid */
 		if ( ! wp_verify_nonce( rgpost( 'gfpdf_save_pdf' ), 'gfpdf_save_pdf' ) ) {
-			$this->log->addWarning( 'Nonce Verification Failed.' );
+			$this->log->warning( 'Nonce Verification Failed.' );
 			$this->notices->add_error( esc_html__( 'There was a problem saving your PDF settings. Please try again.', 'gravity-forms-pdf-extended' ) );
 
 			return false;
@@ -292,7 +292,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* check appropriate settings */
 		if ( ! is_array( $input ) || ! $pdf_id ) {
-			$this->log->addError(
+			$this->log->error(
 				'Invalid Data.',
 				[
 					'post' => $input,
@@ -334,7 +334,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* If it updated, let's update the global variable */
 		if ( $did_update !== false ) {
-			$this->log->addNotice(
+			$this->log->notice(
 				'Successfully Saved Global PDF Settings.',
 				[
 					'form_id'  => $form_id,
@@ -348,7 +348,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			return true;
 		}
 
-		$this->log->addError( 'Failed to Save Global PDF Settings.' );
+		$this->log->error( 'Failed to Save Global PDF Settings.' );
 		$this->notices->add_error( esc_html__( 'There was a problem saving your PDF settings. Please try again.', 'gravity-forms-pdf-extended' ) );
 
 		return false;
@@ -377,7 +377,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* Check we have a valid nonce, or throw an error */
 		if ( ! wp_verify_nonce( rgpost( 'gfpdf_save_pdf' ), 'gfpdf_save_pdf' ) ) {
-			$this->log->addWarning( 'Nonce Verification Failed.' );
+			$this->log->warning( 'Nonce Verification Failed.' );
 			$this->notices->add_error( esc_html__( 'There was a problem saving your PDF settings. Please try again.', 'gravity-forms-pdf-extended' ) );
 
 			return false;
@@ -596,7 +596,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 		/* If class isn't an instance of our interface return $settings */
 		if ( ! ( $class instanceof Helper_Interface_Config ) ) {
 
-			$this->log->addWarning(
+			$this->log->warning(
 				'Instanceof Failed.',
 				[
 					'object' => get_class( $class ),
@@ -758,7 +758,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		if ( $results && ! is_wp_error( $results ) ) {
 
-			$this->log->addNotice( 'AJAX – Successfully Deleted PDF Settings' );
+			$this->log->notice( 'AJAX – Successfully Deleted PDF Settings' );
 
 			$return = [
 				'msg' => esc_html__( 'PDF successfully deleted.', 'gravity-forms-pdf-extended' ),
@@ -776,7 +776,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			];
 		}
 
-		$this->log->addError( 'AJAX Endpoint Failed', $errors );
+		$this->log->error( 'AJAX Endpoint Failed', $errors );
 
 		/* Internal Server Error */
 		wp_die( '500', 500 );
@@ -814,7 +814,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			$results = $this->options->update_pdf( $fid, $config['id'], $config );
 
 			if ( $results ) {
-				$this->log->addNotice( 'AJAX – Successfully Duplicated PDF Setting' );
+				$this->log->notice( 'AJAX – Successfully Duplicated PDF Setting' );
 
 				/* @todo just use the same nonce for all requests since WP nonces aren't one-time user (time based) */
 				$dup_nonce   = wp_create_nonce( "gfpdf_duplicate_nonce_{$fid}_{$config['id']}" );
@@ -835,7 +835,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			}
 		}
 
-		$this->log->addError(
+		$this->log->error(
 			'AJAX Endpoint Failed',
 			[
 				'WP_Error_Message' => $config->get_error_message(),
@@ -880,7 +880,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			$results = $this->options->update_pdf( $fid, $config['id'], $config );
 
 			if ( $results ) {
-				$this->log->addNotice( 'AJAX – Successfully Updated PDF State' );
+				$this->log->notice( 'AJAX – Successfully Updated PDF State' );
 
 				$return = [
 					'state' => $state,
@@ -894,7 +894,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			}
 		}
 
-		$this->log->addError(
+		$this->log->error(
 			'AJAX Endpoint Failed',
 			[
 				'WP_Error_Message' => $config->get_error_message(),
@@ -981,7 +981,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 			'template_type' => $template_type,
 		];
 
-		$this->log->addNotice( 'AJAX – Successfully Rendered Template Custom Fields', $return );
+		$this->log->notice( 'AJAX – Successfully Rendered Template Custom Fields', $return );
 
 		echo json_encode( $return );
 

--- a/src/Model/Model_Install.php
+++ b/src/Model/Model_Install.php
@@ -119,7 +119,7 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function install_plugin() {
-		$this->log->addNotice( 'Gravity PDF Installed' );
+		$this->log->notice( 'Gravity PDF Installed' );
 		update_option( 'gfpdf_is_installed', true );
 		$this->data->is_installed = true;
 
@@ -285,7 +285,7 @@ class Model_Install extends Helper_Abstract_Model {
 		foreach ( $folders as $dir ) {
 			if ( ! is_dir( $dir ) ) {
 				if ( ! wp_mkdir_p( $dir ) ) {
-					$this->log->addError(
+					$this->log->error(
 						'Failed Creating Folder Structure',
 						[
 							'dir' => $dir,
@@ -297,7 +297,7 @@ class Model_Install extends Helper_Abstract_Model {
 			} else {
 				/* test the directory is currently writable by the web server, otherwise throw an error */
 				if ( ! wp_is_writable( $dir ) ) {
-					$this->log->addError(
+					$this->log->error(
 						'Failed Write Permissions Check.',
 						[
 							'dir' => $dir,
@@ -321,7 +321,7 @@ class Model_Install extends Helper_Abstract_Model {
 			}
 
 			if ( ! is_file( $this->data->template_tmp_location . '.htaccess' ) ) {
-				$this->log->addNotice( 'Create Apache .htaccess Security file' );
+				$this->log->notice( 'Create Apache .htaccess Security file' );
 				file_put_contents( $this->data->template_tmp_location . '.htaccess', 'deny from all' );
 			}
 		}
@@ -391,7 +391,7 @@ class Model_Install extends Helper_Abstract_Model {
 
 		foreach ( $regex as $rule ) {
 			if ( ! isset( $rules[ $rule ] ) ) {
-				$this->log->addNotice( 'Flushing WordPress Rewrite Rules.' );
+				$this->log->notice( 'Flushing WordPress Rewrite Rules.' );
 				flush_rewrite_rules( false );
 				break;
 			}
@@ -464,7 +464,7 @@ class Model_Install extends Helper_Abstract_Model {
 			if ( isset( $form['gfpdf_form_settings'] ) ) {
 				unset( $form['gfpdf_form_settings'] );
 				if ( $this->gform->update_form( $form ) !== true ) {
-					$this->log->addError(
+					$this->log->error(
 						'Cannot Remove PDF Settings from Form.',
 						[
 							'form_id' => $form['id'],
@@ -500,7 +500,7 @@ class Model_Install extends Helper_Abstract_Model {
 				$results = $this->misc->rmdir( $dir );
 
 				if ( is_wp_error( $results ) || ! $results ) {
-					$this->log->addError(
+					$this->log->error(
 						'Cannot Remove Folder Structure.',
 						[
 							'WP_Error_Message' => $results->get_error_message(),

--- a/src/Model/Model_Mergetags.php
+++ b/src/Model/Model_Mergetags.php
@@ -149,7 +149,7 @@ class Model_Mergetags extends Helper_Abstract_Model {
 		/* Verify we have a match */
 		if ( $results ) {
 
-			$this->log->addNotice(
+			$this->log->notice(
 				'Begin Converting PDF Mergetags',
 				[
 					'form_id'  => $form['id'],
@@ -170,7 +170,7 @@ class Model_Mergetags extends Helper_Abstract_Model {
 					 || $config['active'] !== true
 					 || ( isset( $config['conditionalLogic'] ) && ! $this->misc->evaluate_conditional_logic( $config['conditionalLogic'], $entry ) )
 				) {
-					$this->log->addError(
+					$this->log->error(
 						'PDF Mergetag is not valid',
 						[
 							'form_id'  => $form['id'],

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -160,7 +160,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		/* not a valid entry */
 		if ( is_wp_error( $entry ) ) {
-			$this->log->addError(
+			$this->log->error(
 				'Invalid Entry.',
 				[
 					'entry' => $entry,
@@ -175,7 +175,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		/* Not valid settings */
 		if ( is_wp_error( $settings ) ) {
 
-			$this->log->addError(
+			$this->log->error(
 				'Invalid PDF Settings.',
 				[
 					'entry'            => $entry,
@@ -204,7 +204,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		/* Throw error */
 		if ( is_wp_error( $middleware ) ) {
 
-			$this->log->addError(
+			$this->log->error(
 				'PDF Authentication Failure.',
 				[
 					'entry'            => $entry,
@@ -429,7 +429,7 @@ class Model_PDF extends Helper_Abstract_Model {
 
 			if ( $owner_restriction === 'Yes' && ! is_user_logged_in() ) {
 
-				$this->log->addNotice(
+				$this->log->notice(
 					'Security – Owner Restrictions: Redirecting to Login.',
 					[
 						'entry'    => $entry,
@@ -481,7 +481,7 @@ class Model_PDF extends Helper_Abstract_Model {
 							return new WP_Error( 'timeout_expired', esc_html__( 'Your PDF is no longer accessible.', 'gravity-forms-pdf-extended' ) );
 						} else {
 
-							$this->log->addNotice(
+							$this->log->notice(
 								'Security – Logged Out Timeout: Redirecting to Login.',
 								[
 									'entry'    => $entry,
@@ -520,7 +520,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				/* check if there is actually a user who owns entry */
 				if ( ! empty( $entry['created_by'] ) ) {
 
-					$this->log->addNotice(
+					$this->log->notice(
 						'Security – Auth Logged Out User: Redirecting to Login.',
 						[
 							'entry'    => $entry,
@@ -531,7 +531,7 @@ class Model_PDF extends Helper_Abstract_Model {
 					/* prompt user to login to get access */
 					auth_redirect();
 				} else {
-					$this->log->addWarning(
+					$this->log->warning(
 						'Access denied.',
 						[
 							'entry'    => $entry,
@@ -888,7 +888,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				return true;
 			} catch ( Exception $e ) {
 
-				$this->log->addError(
+				$this->log->error(
 					'PDF Generation Error',
 					[
 						'pdf'       => $pdf,
@@ -1013,7 +1013,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				}
 			}
 
-			$this->log->addNotice(
+			$this->log->notice(
 				'Gravity Forms Attachments',
 				[
 					'attachments'  => $notifications['attachments'],
@@ -1181,7 +1181,7 @@ class Model_PDF extends Helper_Abstract_Model {
 					}
 				}
 			} catch ( Exception $e ) {
-				$this->log->addError(
+				$this->log->error(
 					'Filesystem Delete Error',
 					[
 						'dir'       => $tmp_directory,
@@ -1227,7 +1227,7 @@ class Model_PDF extends Helper_Abstract_Model {
 							$this->misc->rmdir( $pdf_generator->get_path() );
 						} catch ( Exception $e ) {
 
-							$this->log->addError(
+							$this->log->error(
 								'Cleanup PDF Error',
 								[
 									'pdf'       => $pdf,
@@ -1866,7 +1866,7 @@ class Model_PDF extends Helper_Abstract_Model {
 			}
 		} catch ( Exception $e ) {
 
-			$this->log->addError(
+			$this->log->error(
 				'Invalid Field Class.',
 				[
 					'exception' => $e->getMessage(),

--- a/src/Model/Model_Settings.php
+++ b/src/Model/Model_Settings.php
@@ -194,7 +194,7 @@ class Model_Settings extends Helper_Abstract_Model {
 		$destination = $this->templates->get_template_path();
 		$copy        = $this->misc->copyr( PDF_PLUGIN_DIR . 'src/templates/', $destination );
 		if ( is_wp_error( $copy ) ) {
-			$this->log->addError( 'Template Installation Error.' );
+			$this->log->error( 'Template Installation Error.' );
 			$this->notices->add_error( sprintf( esc_html__( 'There was a problem copying all PDF templates to %s. Please try again.', 'gravity-forms-pdf-extended' ), '<code>' . $this->misc->relative_path( $destination ) . '</code>' ) );
 
 			return false;
@@ -335,7 +335,7 @@ class Model_Settings extends Helper_Abstract_Model {
 
 		/* If errors were found then return */
 		if ( sizeof( $errors ) > 0 ) {
-			$this->log->addError(
+			$this->log->error(
 				'Install Error.',
 				[
 					'errors' => $errors,
@@ -402,7 +402,7 @@ class Model_Settings extends Helper_Abstract_Model {
 		$results = $this->process_font( $payload );
 
 		/* If we reached this point the results were successful so return the new object */
-		$this->log->addNotice(
+		$this->log->notice(
 			'AJAX – Successfully Saved Font',
 			[
 				'results' => $results,
@@ -440,7 +440,7 @@ class Model_Settings extends Helper_Abstract_Model {
 
 				if ( $this->options->update_option( 'custom_fonts', $fonts ) ) {
 					/* Success */
-					$this->log->addNotice( 'AJAX – Successfully Deleted Font' );
+					$this->log->notice( 'AJAX – Successfully Deleted Font' );
 					echo json_encode( [ 'success' => true ] );
 					wp_die();
 				}
@@ -451,7 +451,7 @@ class Model_Settings extends Helper_Abstract_Model {
 			'error' => esc_html__( 'Could not delete Gravity PDF font correctly. Please try again.', 'gravity-forms-pdf-extended' ),
 		];
 
-		$this->log->addError( 'AJAX Endpoint Error', $return );
+		$this->log->error( 'AJAX Endpoint Error', $return );
 
 		echo json_encode( $return );
 
@@ -482,7 +482,7 @@ class Model_Settings extends Helper_Abstract_Model {
 				'error' => esc_html__( 'Required fields have not been included.', 'gravity-forms-pdf-extended' ),
 			];
 
-			$this->log->addWarning( 'Font Validation Failed', $return );
+			$this->log->warning( 'Font Validation Failed', $return );
 
 			echo json_encode( $return );
 
@@ -499,7 +499,7 @@ class Model_Settings extends Helper_Abstract_Model {
 				'error' => esc_html__( 'Font name is not valid. Only alphanumeric characters and spaces are accepted.', 'gravity-forms-pdf-extended' ),
 			];
 
-			$this->log->addWarning( 'Font Validation Failed', $return );
+			$this->log->warning( 'Font Validation Failed', $return );
 
 			echo json_encode( $return );
 
@@ -517,7 +517,7 @@ class Model_Settings extends Helper_Abstract_Model {
 				'error' => esc_html__( 'A font with the same name already exists. Try a different name.', 'gravity-forms-pdf-extended' ),
 			];
 
-			$this->log->addWarning( 'Font Validation Failed', $return );
+			$this->log->warning( 'Font Validation Failed', $return );
 
 			echo json_encode( $return );
 
@@ -535,7 +535,7 @@ class Model_Settings extends Helper_Abstract_Model {
 				'error' => $installation,
 			];
 
-			$this->log->addWarning( 'Font Validation Failed', $return );
+			$this->log->warning( 'Font Validation Failed', $return );
 
 			echo json_encode( $return );
 
@@ -827,7 +827,7 @@ class Model_Settings extends Helper_Abstract_Model {
 		/* Check add-on currently installed */
 		if ( ! empty( $addon ) ) {
 			if ( $this->deactivate_license_key( $addon, $license ) ) {
-				$this->log->addNotice( 'AJAX – Successfully Deactivated License' );
+				$this->log->notice( 'AJAX – Successfully Deactivated License' );
 				echo json_encode(
 					[
 						'success' => esc_html__( 'License deactivated.', 'gravity-forms-pdf-extended' ),
@@ -848,7 +848,7 @@ class Model_Settings extends Helper_Abstract_Model {
 			}
 		}
 
-		$this->log->addError( 'AJAX Endpoint Error' );
+		$this->log->error( 'AJAX Endpoint Error' );
 
 		echo json_encode(
 			[
@@ -899,7 +899,7 @@ class Model_Settings extends Helper_Abstract_Model {
 		/* Remove license data from database */
 		$addon->delete_license_info();
 
-		$this->log->addNotice(
+		$this->log->notice(
 			'License successfully deactivated',
 			[
 				'slug'    => $addon->get_slug(),

--- a/src/Model/Model_Shortcodes.php
+++ b/src/Model/Model_Shortcodes.php
@@ -107,7 +107,7 @@ class Model_Shortcodes extends Helper_Abstract_Pdf_Shortcode {
 				$attributes['url'] = $this->url_signer->sign( $attributes['url'], $attributes['expires'] );
 			}
 
-			$this->log->addNotice( 'Generating Shortcode Markup', [ 'attr' => $attributes ] );
+			$this->log->notice( 'Generating Shortcode Markup', [ 'attr' => $attributes ] );
 
 			if ( $raw ) {
 				return $attributes['url'];

--- a/src/Model/Model_Templates.php
+++ b/src/Model/Model_Templates.php
@@ -113,7 +113,7 @@ class Model_Templates extends Helper_Abstract_Model {
 			$file     = new File( 'template', $storage );
 			$zip_path = $this->move_template_to_tmp_dir( $file );
 		} catch ( Exception $e ) {
-			$this->log->addWarning(
+			$this->log->warning(
 				'File validation and move failed',
 				[
 					'file'  => $_FILES,
@@ -131,7 +131,7 @@ class Model_Templates extends Helper_Abstract_Model {
 		} catch ( Exception $e ) {
 			$this->cleanup_template_files( $zip_path );
 
-			$this->log->addWarning(
+			$this->log->warning(
 				'File validation and move failed',
 				[
 					'file'  => $_FILES,

--- a/src/Statics/Queue_Callbacks.php
+++ b/src/Statics/Queue_Callbacks.php
@@ -42,7 +42,7 @@ class Queue_Callbacks {
 		$results = GPDFAPI::create_pdf( $entry_id, $pdf_id );
 
 		if ( is_wp_error( $results ) ) {
-			$log->addError(
+			$log->error(
 				'PDF Generation Error',
 				[
 					'code'    => $results->get_error_code(),
@@ -72,13 +72,13 @@ class Queue_Callbacks {
 		$entry = $gform->get_entry( $entry_id );
 
 		if ( $form === null ) {
-			$log->addError( 'Could not locate form', [ 'id' => $form_id ] );
+			$log->error( 'Could not locate form', [ 'id' => $form_id ] );
 
 			throw new Exception();
 		}
 
 		if ( is_wp_error( $entry ) ) {
-			$log->addError(
+			$log->error(
 				'Entry Error',
 				[
 					'code'    => $entry->get_error_code(),
@@ -114,13 +114,13 @@ class Queue_Callbacks {
 		$entry = $gform->get_entry( $entry_id );
 
 		if ( $form === null ) {
-			$log->addError( 'Could not locate form', [ 'id' => $form_id ] );
+			$log->error( 'Could not locate form', [ 'id' => $form_id ] );
 
 			throw new Exception();
 		}
 
 		if ( is_wp_error( $entry ) ) {
-			$log->addError(
+			$log->error(
 				'Entry Error',
 				[
 					'code'    => $entry->get_error_code(),

--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -226,7 +226,7 @@ class View_PDF extends Helper_Abstract_View {
 
 		} catch ( Exception $e ) {
 
-			$this->log->addError(
+			$this->log->error(
 				'PDF Generation Error',
 				[
 					'entry'     => $entry,
@@ -490,7 +490,7 @@ class View_PDF extends Helper_Abstract_View {
 				$container->maybe_display_faux_column( $field );
 			}
 		} catch ( Exception $e ) {
-			$this->log->addError(
+			$this->log->error(
 				'PDF Generation Error',
 				[
 					'field'     => $field,

--- a/src/View/View_Settings.php
+++ b/src/View/View_Settings.php
@@ -291,7 +291,7 @@ class View_Settings extends Helper_Abstract_View {
 
 		/* prevent unauthorized access */
 		if ( ! $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
-			$this->log->addWarning( 'Lack of User Capabilities.' );
+			$this->log->warning( 'Lack of User Capabilities.' );
 
 			wp_die( esc_html__( 'You do not have permission to access this page', 'gravity-forms-pdf-extended' ) );
 		}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -922,7 +922,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		if ( is_wp_error( $settings ) ) {
 
-			$this->log->addError(
+			$this->log->error(
 				'Invalid PDF Settings.',
 				[
 					'form_id'          => $form_id,


### PR DESCRIPTION
## Description

This ensures forward compatibility with Monolog v2 (even though we aren't doing a depedancy bump). 

## Testing instructions
Enable logging. Verify log file still written to.

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
