### PR TITLE
Run E2E tests in PHP7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,16 @@ jobs:
         - npm run lint:js
 
     - name: E2E Testing
+      env: LOCAL_PHP=7.4-fpm
       script:
         - npm run test:e2e:headless
+
+    - name: PHP 7.4 unit tests
+      env: LOCAL_PHP=7.4-fpm
+      script:
+        - |
+          npm run test:php &&
+          npm run test:php -- --group ajax
 
     - name: PHP 7.3 unit tests
       env: LOCAL_PHP=7.3-fpm
@@ -127,13 +135,6 @@ jobs:
 
     - name: PHP 5.6 unit tests
       env: LOCAL_PHP=5.6-fpm
-      script:
-        - |
-          npm run test:php &&
-          npm run test:php -- --group ajax
-
-    - name: PHP 7.4 unit tests
-      env: LOCAL_PHP=7.4-fpm
       script:
         - |
           npm run test:php &&


### PR DESCRIPTION
## Description

Run the E2E tests under PHP7.4 to determine if there are any issues. 

If this passes, fixes https://github.com/GravityPDF/gravity-pdf/issues/986

## Testing instructions
You can also manually test PHP7.4 locally running Gravity PDF. No issues caused by Gravity PDF found.

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
