### PR TITLE
Only show the template installer box if user has the privileges for it

### DIFF
--- a/src/Helper/Helper_Data.php
+++ b/src/Helper/Helper_Data.php
@@ -198,6 +198,7 @@ class Helper_Data {
 	public function get_localised_script_data( Helper_Abstract_Options $options, Helper_Abstract_Form $gform ) {
 
 		$custom_fonts = array_values( $options->get_custom_fonts() );
+		$user_data    = get_userdata( get_current_user_id() );
 
 		/* See https://gravitypdf.com/documentation/v5/gfpdf_localised_script_array/ for more details about this filter */
 
@@ -211,6 +212,7 @@ class Helper_Data {
 				'pluginUrl'                            => PDF_PLUGIN_URL,
 				'pluginPath'                           => PDF_PLUGIN_DIR,
 				'customFontData'                       => json_encode( $custom_fonts ),
+				'userCapabilities'                     => is_object( $user_data ) ? $user_data->allcaps : [],
 
 				'spinnerUrl'                           => admin_url( 'images/spinner-2x.gif' ),
 				'spinnerAlt'                           => esc_html__( 'Loading...', 'gravity-forms-pdf-extended' ),

--- a/src/assets/js/react/components/Template/TemplateList.js
+++ b/src/assets/js/react/components/Template/TemplateList.js
@@ -48,6 +48,7 @@ export class TemplateList extends React.Component {
    */
   render () {
     const header = <TemplateHeaderTitle header={this.props.templateHeaderText} />
+    const hasUserPrivs = GFPDF.userCapabilities.administrator || GFPDF.userCapabilities.gravityforms_edit_settings || false
 
     return (
       <TemplateContainer header={header} closeRoute="/">
@@ -63,18 +64,21 @@ export class TemplateList extends React.Component {
             })
           }
 
-          <TemplateUploader
-            ajaxUrl={this.props.ajaxUrl}
-            ajaxNonce={this.props.ajaxNonce}
-            addTemplateText={this.props.addTemplateText}
-            genericUploadErrorText={this.props.genericUploadErrorText}
-            filenameErrorText={this.props.filenameErrorText}
-            filesizeErrorText={this.props.filesizeErrorText}
-            installSuccessText={this.props.installSuccessText}
-            installUpdatedText={this.props.installUpdatedText}
-            templateSuccessfullyInstalledUpdated={this.props.templateSuccessfullyInstalledUpdated}
-            templateInstallInstructions={this.props.templateInstallInstructions}
-          />
+          {
+            hasUserPrivs &&
+            <TemplateUploader
+              ajaxUrl={this.props.ajaxUrl}
+              ajaxNonce={this.props.ajaxNonce}
+              addTemplateText={this.props.addTemplateText}
+              genericUploadErrorText={this.props.genericUploadErrorText}
+              filenameErrorText={this.props.filenameErrorText}
+              filesizeErrorText={this.props.filesizeErrorText}
+              installSuccessText={this.props.installSuccessText}
+              installUpdatedText={this.props.installUpdatedText}
+              templateSuccessfullyInstalledUpdated={this.props.templateSuccessfullyInstalledUpdated}
+              templateInstallInstructions={this.props.templateInstallInstructions}
+            />
+          }
 
         </div>
       </TemplateContainer>

--- a/tests/mocha/tests.bundle.js
+++ b/tests/mocha/tests.bundle.js
@@ -18,6 +18,9 @@ window.GFPDF = {
   coreFontItemPendingMessage: '%s',
   coreFontItemSuccessMessage: '%s',
   coreFontItemErrorMessage: '%s',
+  userCapabilities: {
+    administrator: true
+  }
 }
 
 window.gfpdf_migration_multisite_ids = []


### PR DESCRIPTION
## Description

Resolves an issue when the user did not have the `gravityforms_edit_settings` capability and tried to upload a template.

Resolves https://github.com/GravityPDF/gravity-pdf/issues/1039

## Testing instructions
Create a new role on the site and don't include the `gravityforms_edit_settings`  capability. Switch to this user and try upload a template.

## Checklist:
- [X] I've tested the code.
- [X] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
