### PR TITLE
Do not generate field container for skipped types

### DIFF
--- a/src/Helper/Helper_Field_Container.php
+++ b/src/Helper/Helper_Field_Container.php
@@ -162,7 +162,9 @@ class Helper_Field_Container {
 	public function generate( GF_Field $field ) {
 
 		/* Check if we are processing a field that should not be floated and treat it as a 100% field */
-		$this->process_skipped_fields( $field );
+		if( $this->process_skipped_fields( $field ) ) {
+			return;
+		}
 
 		/* Check if we need to close the container */
 		if ( $this->currently_open ) {


### PR DESCRIPTION
## Description
Previously, the `generate` function of `Helper_Field_Container` was not doing anything with the return value of `process_skipped_fields`. This causes field types which should not have a field container wrapped around them to have one wrapped around them.

This patch checks the return value of `process_skipped_fields` and stops generation if `true`. This will not leave the previous container open, because `process_skipped_fields` closes it if a skipped field is hit.

## Testing instructions
1. Add a field type to the skip_fields array via the `gfpdf_container_skip_fields` filter, enable a display of a skipped field type (such as HTML) via the settings, or create a class for a field type such as page.
2. Observe that the field container HTML is no longer erroneously being generated.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation / docblocks.