### PR TITLE
Re-write the timezone logic to work correctly with Monolog v1 and v2

### DIFF
--- a/src/Helper/Helper_Logger.php
+++ b/src/Helper/Helper_Logger.php
@@ -2,17 +2,16 @@
 
 namespace GFPDF\Helper;
 
+use DateTimeZone;
+use Exception;
+use GFFormsModel;
+use GFLogging;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\IntrospectionProcessor;
 use Monolog\Processor\MemoryPeakUsageProcessor;
-
-use DateTimeZone;
-use Exception;
-use GFLogging;
-use GFFormsModel;
 
 /**
  * @package     Gravity PDF
@@ -107,25 +106,24 @@ class Helper_Logger {
 	 * @since 4.2
 	 */
 	protected function setup_logger() {
-		static $timezone;
-
-		/* Set the logger timezone once (if needed) */
-		if ( ! $timezone ) {
-			$offset = (float) get_option( 'gmt_offset' );
-
-			if ( $offset !== 0.0 ) {
-				try {
-					$timezone = new DateTimeZone( ( $offset > 0 ) ? '+' . $offset : $offset );
-					Logger::setTimezone( $timezone );
-				} catch ( Exception $e ) {
-					/* do nothing */
-				}
-			}
-			$timezone = true;
-		}
 
 		/* Initialise our logger */
 		$this->log = new Logger( $this->slug );
+
+		/* Set the logger timezone */
+		$offset = (float) get_option( 'gmt_offset' );
+
+		try {
+			$timezone = new DateTimeZone( ( $offset >= 0 ) ? '+' . $offset : $offset );
+
+			if ( Logger::API > 1 ) {
+				$this->log->setTimezone( $timezone );
+			} else {
+				Logger::setTimezone( $timezone );
+			}
+		} catch ( Exception $e ) {
+			/* do nothing */
+		}
 
 		/* Setup our Gravity Forms local file logger, if enabled */
 		try {
@@ -185,7 +183,7 @@ class Helper_Logger {
 				$monolog_level = ( $log_level === 4 ) ? Logger::ERROR : Logger::DEBUG;
 
 				/* Setup our stream and change the format to more-suit Gravity Forms */
-				$formatter = new LineFormatter( "%datetime% - %level_name% --> %message% %context% %extra%\n" );
+				$formatter = new LineFormatter( "%datetime% - %level_name% --> %message%\n|--> %context%\n|--> %extra%\n", 'Y-m-d H:i:s (P)' );
 				$stream    = new StreamHandler( $log_filename, $monolog_level );
 				$stream->setFormatter( $formatter );
 


### PR DESCRIPTION
## Description

Resolves a fatal error when using Monolog v2 with Gravity PDF, and you have your timezone offset setup.

Also corrected the log date and made it easier to read the log messages

## Testing instructions
- Bump Monolog composer constraints to v2 and do `composer update`
- Set timezone offset in WordPress Admin `Settings -> General`
- Enable Gravity Forms Logging
- Generate a PDF
- View Log file

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
