### PR TITLE
Allow Field_Container class to be more extensible

### DIFF
--- a/src/Helper/Fields/Field_Form.php
+++ b/src/Helper/Fields/Field_Form.php
@@ -2,14 +2,12 @@
 
 namespace GFPDF\Helper\Fields;
 
+use Exception;
+use GFPDF\Helper\Helper_Abstract_Fields;
 use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Field_Container;
 use GFPDF\Helper\Helper_Misc;
-use GFPDF\Helper\Helper_Abstract_Fields;
-
 use GP_Field_Nested_Form;
-
-use Exception;
 
 /**
  * @package     Gravity PDF
@@ -100,6 +98,8 @@ class Field_Form extends Helper_Abstract_Fields {
 		ob_start();
 
 		$container = new Helper_Field_Container( [ 'class_map' => [] ] );
+		$container = apply_filters( 'gfpdf_field_container_class', $container );
+
 		$pdf_model = \GPDFAPI::get_mvc_class( 'Model_PDF' );
 		$products  = new Field_Products( new \GF_Field(), $entry, $this->gform, $this->misc );
 

--- a/src/Helper/Fields/Field_Repeater.php
+++ b/src/Helper/Fields/Field_Repeater.php
@@ -2,14 +2,12 @@
 
 namespace GFPDF\Helper\Fields;
 
+use Exception;
+use GF_Field_Repeater;
+use GFPDF\Helper\Helper_Abstract_Fields;
 use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Field_Container;
 use GFPDF\Helper\Helper_Misc;
-use GFPDF\Helper\Helper_Abstract_Fields;
-
-use GF_Field_Repeater;
-
-use Exception;
 
 /**
  * @package     Gravity PDF
@@ -134,9 +132,12 @@ class Field_Repeater extends Helper_Abstract_Fields {
 	 */
 	public function get_repeater_html( $value, $field ) {
 		$is_top_level = $field === $this->field;
-		$container    = new Helper_Field_Container();
-		$pdf_model    = \GPDFAPI::get_mvc_class( 'Model_PDF' );
-		$products     = new Field_Products( new \GF_Field(), $this->entry, $this->gform, $this->misc );
+
+		$container = new Helper_Field_Container();
+		$container = apply_filters( 'gfpdf_field_container_class', $container );
+
+		$pdf_model = \GPDFAPI::get_mvc_class( 'Model_PDF' );
+		$products  = new Field_Products( new \GF_Field(), $this->entry, $this->gform, $this->misc );
 
 		/* Output the Repeater Label if a sub Repeater */
 		if ( ! $is_top_level ) {

--- a/src/Helper/Helper_Field_Container.php
+++ b/src/Helper/Helper_Field_Container.php
@@ -28,7 +28,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private $current_width = 0;
+	protected $current_width = 0;
 
 	/**
 	 * Boolean value to tell if the element is currently opened
@@ -37,7 +37,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private $currently_open = false;
+	protected $currently_open = false;
 
 	/**
 	 * Matches class names to width percentages
@@ -46,7 +46,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private $class_map = [
+	protected $class_map = [
 		'gf_left_half'      => 50,
 		'gf_right_half'     => 50,
 		'gf_left_third'     => 33.3,
@@ -65,7 +65,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private $open_tag = '<div class="row-separator">';
+	protected $open_tag = '<div class="row-separator">';
 
 	/**
 	 * The HTML tag used when closing the container
@@ -74,7 +74,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private $close_tag = '</div>';
+	protected $close_tag = '</div>';
 
 	/**
 	 * Whether to enable/disable the faux column feature
@@ -83,7 +83,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 5.0
 	 */
-	private $faux_column = true;
+	protected $faux_column = true;
 
 	/**
 	 * The Gravity Form fields we should not wrap in a container
@@ -92,7 +92,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private $skip_fields = [
+	protected $skip_fields = [
 		'page',
 		'section',
 		'html',
@@ -105,7 +105,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.2
 	 */
-	private $row_stopper_classes = [
+	protected $row_stopper_classes = [
 		'pagebreak',
 	];
 
@@ -116,7 +116,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private $counter = 0;
+	protected $counter = 0;
 
 	/**
 	 * Set up the object
@@ -242,7 +242,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function handle_closed_container( GF_Field $field ) {
+	protected function handle_closed_container( GF_Field $field ) {
 		$this->start();
 		$this->open_container();
 		$this->increment_width( $field->cssClass );
@@ -257,7 +257,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function handle_open_container( GF_Field $field ) {
+	protected function handle_open_container( GF_Field $field ) {
 
 		/* if the current field width is more than 100 we will close the container */
 		if ( false === $this->does_fit_in_row( $field ) || $this->does_field_have_stopper_class( $field ) ) {
@@ -276,7 +276,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function process_skipped_fields( GF_Field $field ) {
+	protected function process_skipped_fields( GF_Field $field ) {
 		/* if we have a skipped field and the container is open we will close it */
 		if ( in_array( $field->type, $this->skip_fields, true ) ) {
 			$this->strip_field_of_any_classmaps( $field );
@@ -297,7 +297,7 @@ class Helper_Field_Container {
 	 *
 	 * @since  4.0
 	 */
-	private function strip_field_of_any_classmaps( GF_Field $field ) {
+	protected function strip_field_of_any_classmaps( GF_Field $field ) {
 		$field->cssClass = str_replace( array_keys( $this->class_map ), ' ', $field->cssClass );
 	}
 
@@ -308,7 +308,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function open_container() {
+	protected function open_container() {
 
 		$class = $this->is_row_odd_or_even();
 		echo str_replace( 'row-separator', 'row-separator ' . $class, $this->open_tag );
@@ -323,7 +323,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function close_container() {
+	protected function close_container() {
 		echo $this->close_tag;
 	}
 
@@ -334,7 +334,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function start() {
+	protected function start() {
 		$this->currently_open = true;
 	}
 
@@ -345,7 +345,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function reset() {
+	protected function reset() {
 		$this->currently_open = false;
 		$this->current_width  = 0;
 	}
@@ -359,7 +359,7 @@ class Helper_Field_Container {
 	 *
 	 * @since  4.0
 	 */
-	private function increment_width( $classes ) {
+	protected function increment_width( $classes ) {
 		$this->current_width += $this->get_field_width( $classes );
 	}
 
@@ -372,7 +372,7 @@ class Helper_Field_Container {
 	 *
 	 * @since  4.0
 	 */
-	private function get_field_width( $classes ) {
+	protected function get_field_width( $classes ) {
 		$classes = $this->get_field_classes( $classes );
 
 		foreach ( $classes as $class ) {
@@ -394,7 +394,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function is_row_odd_or_even() {
+	protected function is_row_odd_or_even() {
 		return ( $this->counter % 2 ) ? 'even' : 'odd';
 	}
 
@@ -405,7 +405,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.0
 	 */
-	private function increment_row_counter() {
+	protected function increment_row_counter() {
 		$this->counter++;
 	}
 
@@ -418,7 +418,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.2
 	 */
-	private function get_field_classes( $classes ) {
+	protected function get_field_classes( $classes ) {
 		return array_filter( explode( ' ', $classes ) );
 	}
 
@@ -431,7 +431,7 @@ class Helper_Field_Container {
 	 *
 	 * @since 4.2
 	 */
-	private function does_field_have_stopper_class( GF_Field $field ) {
+	protected function does_field_have_stopper_class( GF_Field $field ) {
 		$field_classes = array_flip( $this->get_field_classes( $field->cssClass ) );
 
 		foreach ( $this->row_stopper_classes as $class ) {

--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -2,27 +2,20 @@
 
 namespace GFPDF\View;
 
+use Exception;
+use GF_Field;
+use GFPDF\Helper\Fields\Field_Products;
+use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Abstract_Model;
+use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Abstract_View;
+use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Field_Container;
 use GFPDF\Helper\Helper_Field_Container_Void;
-use GFPDF\Helper\Helper_Abstract_Form;
-use GFPDF\Helper\Helper_PDF;
-use GFPDF\Helper\Helper_Abstract_Options;
-use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Misc;
+use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Templates;
-
 use Psr\Log\LoggerInterface;
-
-use GFPDF\Helper\Fields\Field_Products;
-
-use GFFormsModel;
-use GFCommon;
-use GF_Field;
-
-use mPDF;
-use Exception;
 
 /**
  * @package     Gravity PDF
@@ -369,7 +362,9 @@ class View_PDF extends Helper_Abstract_View {
 		$form        = $this->gform->get_form( $entry['form_id'] );
 		$products    = new Field_Products( new GF_Field(), $entry, $this->gform, $this->misc );
 		$page_number = 0;
-		$container   = ( isset( $config['meta']['enable_css_ready_classes'] ) && false === $config['meta']['enable_css_ready_classes'] ) ? new Helper_Field_Container_Void() : new Helper_Field_Container();
+
+		$container = ( isset( $config['meta']['enable_css_ready_classes'] ) && false === $config['meta']['enable_css_ready_classes'] ) ? new Helper_Field_Container_Void() : new Helper_Field_Container();
+		$container = apply_filters( 'gfpdf_field_container_class', $container );
 
 		/* Allow the config to be changed through a filter */
 		$config['meta'] = ( isset( $config['meta'] ) ) ? $config['meta'] : [];


### PR DESCRIPTION
## Description

This PR makes the following changes:
- Set all `private` properties to `protected`
- Add new filter `gfpdf_field_container_class`

Refer to  https://github.com/GravityPDF/gravity-pdf/pull/1048 for the reason(s) why this change came about.

Devs who want to change how the `Helper_Field_Container` class works can now use the filter `gfpdf_field_container_class` to inject their own class (either an entirely new class, or one that extends the existing one and tweaks the functionality). 

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
