### PR TITLE
Refine the URL builder for the signed PDF requests

### DIFF
--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -312,10 +312,15 @@ class Model_PDF extends Helper_Abstract_Model {
 	 */
 	public function middle_signed_url_access( $action, $entry, $settings ) {
 
-		if ( isset( $_GET['expires'] ) && isset( $_GET['signature'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
+		if ( isset( $_GET['expires'] ) && isset( $_GET['signature'] ) && isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 			try {
-				$home_url = untrailingslashit( strtok( home_url(), '?' ) );
-				if ( $this->url_signer->verify( $home_url . $_SERVER['REQUEST_URI'] ) ) {
+				$protocol = isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://';
+				$domain   = $_SERVER['HTTP_HOST'];
+				$request  = $_SERVER['REQUEST_URI'];
+
+				$url = $protocol . $domain . $request;
+
+				if ( $this->url_signer->verify( $url ) ) {
 					remove_filter( 'gfpdf_pdf_middleware', [ $this, 'middle_owner_restriction' ], 40 );
 					remove_filter( 'gfpdf_pdf_middleware', [ $this, 'middle_logged_out_timeout' ], 50 );
 					remove_filter( 'gfpdf_pdf_middleware', [ $this, 'middle_auth_logged_out_user' ], 60 );


### PR DESCRIPTION
## Description

This resolve an issue when WordPress is running a subdirectory multisite, or it is installed in a subdirectory.

## Testing instructions
1. Fire up a Subdirectory multisite on your local machine
2. Create a signed PDF URL shortcode on the subsite
3. Submit the form
4. Try access the URL in an incognito browser window

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
