### PR TITLE
Resolve PHP Notice for non-likert survey fields

### DIFF
--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -1553,7 +1553,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				foreach ( $fields as $field ) {
 
 					/* Check if we have a multifield likert and replace the row key */
-					if ( isset( $field['gsurveyLikertEnableMultipleRows'] ) && $field['gsurveyLikertEnableMultipleRows'] === true ) {
+					if ( $field->get_input_type() === 'likert' && isset( $field['gsurveyLikertEnableMultipleRows'] ) && $field['gsurveyLikertEnableMultipleRows'] === true ) {
 
 						foreach ( $field['gsurveyLikertRows'] as $row ) {
 


### PR DESCRIPTION
## Description

Changing the type of a Survey Likert field can cause a PHP notice when viewing the PDF.

## Testing instructions
1. Install Survey Add-on
1. Add Survey field to form and save
1. Change survey field from Likert to Radio and save
1. View core PDF with Xdebug enabled

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
