### PR TITLE
Decode special characters for the password and master password values

### DIFF
--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -948,9 +948,9 @@ class Helper_PDF {
 		/* Security settings cannot be applied to pdfa1b or pdfx1a formats */
 		if ( strtolower( $this->settings['format'] ) === 'standard' && strtolower( $this->settings['security'] ) === 'yes' ) {
 
-			$password        = ( isset( $this->settings['password'] ) ) ? $this->gform->process_tags( $this->settings['password'], $this->form, $this->entry ) : '';
+			$password        = ( isset( $this->settings['password'] ) ) ? wp_specialchars_decode( $this->gform->process_tags( $this->settings['password'], $this->form, $this->entry ), ENT_QUOTES ) : '';
 			$privileges      = ( isset( $this->settings['privileges'] ) ) ? $this->settings['privileges'] : [];
-			$master_password = ( isset( $this->settings['master_password'] ) ) ? $this->gform->process_tags( $this->settings['master_password'], $this->form, $this->entry ) : '';
+			$master_password = ( isset( $this->settings['master_password'] ) ) ? wp_specialchars_decode( $this->gform->process_tags( $this->settings['master_password'], $this->form, $this->entry ), ENT_QUOTES ) : '';
 
 			/* GitHub Issue #662 - Fix issue with possibility of blank master password being set */
 			if ( strlen( $master_password ) === 0 ) {


### PR DESCRIPTION
## Description

When merge tags are processed, if they contained a special character < > & " ' then Gravity Forms would automatically encode it. To ensure the integrity of the password, we decode these settings before adding to mPDF.

Resolves #1058

## Testing instructions

1. Create form with Single Line Text field
2. Add Zadani PDF, enable security, and set the password to `{:1}`
3. Submit test entry and include special characters `< > & " '` in the field
4. View PDF and enter value entered into the field when prompted for the password

## Checklist:
- [X] I've tested the code.
- [X] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
