### PR TITLE
Add type check to get_shortcode_information

### DIFF
--- a/src/Helper/Helper_Abstract_Pdf_Shortcode.php
+++ b/src/Helper/Helper_Abstract_Pdf_Shortcode.php
@@ -405,6 +405,18 @@ abstract class Helper_Abstract_Pdf_Shortcode extends Helper_Abstract_Model {
 	public function get_shortcode_information( $shortcode, $text ) {
 		$shortcodes = [];
 
+		if ( ! is_string( $text ) ) {
+			$this->log->error(
+				'The $text parameter is not a string',
+				[
+					'shortcode' => $shortcode,
+					'text'      => $text,
+				]
+			);
+
+			return $shortcodes;
+		}
+
 		if ( has_shortcode( $text, $shortcode ) ) {
 			/* our shortcode exists so parse the shortcode data and return an easy-to-use array */
 			preg_match_all( '/' . get_shortcode_regex( [ $shortcode ] ) . '/', $text, $matches, PREG_SET_ORDER );

--- a/tests/phpunit/unit-tests/test-shortcodes.php
+++ b/tests/phpunit/unit-tests/test-shortcodes.php
@@ -477,10 +477,12 @@ class Test_Shortcode extends WP_UnitTestCase {
 	public function test_get_shortcode_information() {
 		$content = json_decode( trim( file_get_contents( dirname( __FILE__ ) . '/json/shortcode-data.json' ) ), true );
 
+		$this->assertCount( 0, $this->model->get_shortcode_information( 'gravitypdf', [] ) );
+
 		$shortcodes = $this->model->get_shortcode_information( 'gravitypdf', $content );
 
 		/* Test the results */
-		$this->assertSame( 4, sizeof( $shortcodes ) );
+		$this->assertCount( 4, $shortcodes );
 
 		$this->assertEquals( '[gravitypdf]', $shortcodes[0]['shortcode'] );
 		$this->assertEquals( '', $shortcodes[0]['attr_raw'] );


### PR DESCRIPTION
## Description

Fixes #1025

## Testing instructions
Unit tested

## Checklist:
- [X] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->