### PR TITLE
Re-register font mime type with WordPress so TTF fonts can be correctly uploaded

### DIFF
--- a/src/Controller/Controller_Settings.php
+++ b/src/Controller/Controller_Settings.php
@@ -199,6 +199,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 		add_filter( 'gravitypdf_settings_navigation', [ $this, 'disable_tools_on_view_cap' ] );
 
 		/* allow TTF uploads */
+		add_filter( 'mime_types', [ $this, 'allow_font_uploads' ] );
 		add_filter( 'wp_check_filetype_and_ext', [ $this, 'validate_font_uploads' ], 10, 3 );
 
 		/* Register add-ons for licensing page */
@@ -350,9 +351,9 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 	 * @since 4.0
 	 */
 	public function allow_font_uploads( $mime_types = [] ) {
-		_deprecated_function( __METHOD__, '5.2.2' );
-
-		$mime_types['ttf'] = 'application/x-font-ttf';
+		if ( $this->gform->has_capability( 'gravityforms_edit_settings' ) ) {
+			$mime_types['ttf'] = 'font/ttf';
+		}
 
 		return $mime_types;
 	}
@@ -387,7 +388,7 @@ class Controller_Settings extends Helper_Abstract_Controller implements Helper_I
 			if ( strlen( $ttf->familyName ) > 0 ) {
 				return [
 					'ext'             => 'ttf',
-					'type'            => 'application/x-font-ttf',
+					'type'            => 'font/ttf',
 					'proper_filename' => false,
 				];
 			}

--- a/src/assets/js/admin/settings/common/doUploadListener.js
+++ b/src/assets/js/admin/settings/common/doUploadListener.js
@@ -29,7 +29,11 @@ export function doUploadListener () {
       button: {
         text: $button.data('uploader-button-text')
       },
-      multiple: false
+      multiple: false,
+
+      library: {
+        type: [ 'font/ttf', 'application/x-font-ttf', 'application/octet-stream' ]
+      }
     })
 
     /* When a file is selected, run a callback. */

--- a/tests/phpunit/unit-tests/test-settings.php
+++ b/tests/phpunit/unit-tests/test-settings.php
@@ -346,7 +346,7 @@ class Test_Settings extends WP_UnitTestCase {
 		$results = $this->controller->validate_font_uploads( false, $font, 'DejaVuSans.ttf' );
 
 		$this->assertEquals( 'ttf', $results['ext'] );
-		$this->assertEquals( 'application/x-font-ttf', $results['type'] );
+		$this->assertEquals( 'font/ttf', $results['type'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Prevents JS error about not allowing TTf fonts via the Media Library

## Testing instructions
Go to Font Installer and try upload a TTF font file via the media library

## Screenshots <!-- if applicable -->

## Checklist:
- [X] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
