### PR TITLE
Unit test pdf metabox 2.5

### DIFF
--- a/tests/phpunit/unit-tests/Model/TestModelPDFMetaBox.php
+++ b/tests/phpunit/unit-tests/Model/TestModelPDFMetaBox.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace GFPDF\Model;
+
+use GFPDF\Controller\Controller_PDF;
+use GFPDF\Helper\Helper_Url_Signer;
+use GFPDF\View\View_PDF;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class TestModelPDFSuccess
+ *
+ * @package GFPDF\Model
+ *
+ * @group   pdf
+ */
+class TestModelPDFMetaBox extends WP_UnitTestCase {
+
+	/**
+	 * @var Controller_PDF
+	 */
+	protected $controller;
+
+	/**
+	 * @var Model_PDF
+	 */
+	protected $model;
+
+	/**
+	 * @var View_PDF
+	 */
+	protected $view;
+
+	/**
+	 * The WP Unit Test Set up function
+	 *
+	 * @since 6.0
+	 */
+	public function setUp() {
+		global $gfpdf;
+
+		/* run parent method */
+		parent::setUp();
+
+		/* Setup our test classes */
+		$this->model      = new Model_PDF( $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->notices, $gfpdf->templates, new Helper_Url_Signer() );
+		$this->view       = new View_PDF( [], $gfpdf->gform, $gfpdf->log, $gfpdf->options, $gfpdf->data, $gfpdf->misc, $gfpdf->templates );
+		$this->controller = new Controller_PDF( $this->model, $this->view, $gfpdf->gform, $gfpdf->log, $gfpdf->misc );
+		$this->controller->init();
+	}
+
+	/**
+	 * Create our testing data
+	 *
+	 * @since 4.0
+	 */
+	protected function create_form_and_entries() {
+		global $gfpdf;
+
+		$form  = $GLOBALS['GFPDF_Test']->form['all-form-fields'];
+		$entry = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
+
+		$gfpdf->data->form_settings[ $form['id'] ] = $form['gfpdf_form_settings'];
+
+		return [ $form, $entry ];
+	}
+
+	/**
+	 * Check our PDF detail list is displaying correctly
+	 *
+	 * @since 4.0
+	 */
+	public function test_view_pdf_entry_detail_success() {
+
+		/* Setup some test data */
+		[ $form, $entry['entry'] ] = $this->create_form_and_entries();
+
+		ob_start();
+		$this->model->view_pdf_entry_detail( $entry );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( '<div class="gfpdf_detailed_pdf_cta">', $html );
+	}
+
+	/**
+	 * Check our PDF detail list is displaying correctly when there is no entry passed
+	 *
+	 * @since 4.0
+	 */
+	public function test_view_pdf_entry_detail_fail() {
+
+		ob_start();
+		$this->model->view_pdf_entry_detail( [ 'entry' => [ 'form_id' => 0 ] ] );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'No PDFs available for this entry.', $html );
+	}
+
+	/**
+	 * Check if Metabox registration is working properly
+	 *
+	 * @since 6.0
+	 */
+	public function test_register_pdf_meta_box_success() {
+
+		/* Setup some test data */
+		[ $form, $entry ] = $this->create_form_and_entries();
+
+		$this->assertArrayHasKey( 'gfpdf-entry-details-list', $this->model->register_pdf_meta_box( [], $entry, $form ) );
+
+		/*  Get all PDFs ID */
+		$pdf_ids = array_keys( $form['gfpdf_form_settings'] );
+
+		/* Test if metabox is  registered when there is atleast 2 active PDFs */
+		$active_pdfs = array_rand( $pdf_ids, 2 );
+
+		foreach ( $active_pdfs as $id ) {
+			$form['gfpdf_form_settings'][ $pdf_ids[ $id ] ]['active'] = false;
+		}
+
+		$this->assertArrayHasKey( 'gfpdf-entry-details-list', $this->model->register_pdf_meta_box( [], $entry, $form ) );
+	}
+
+	/**
+	 * Check if Metabox registration is working properly when there is no active PDFs
+	 *
+	 * @since 6.0
+	 */
+	public function test_register_pdf_meta_box_fail() {
+
+		/* Setup some test data */
+		[ $form, $entry ] = $this->create_form_and_entries();
+
+		/*  Set all pdfs to inactive */
+		$pdf_ids = array_keys( $form['gfpdf_form_settings'] );
+
+		/* Test if metabox is not registered when there is no active PDFs */
+		foreach ( $pdf_ids as $id ) {
+			$form['gfpdf_form_settings'][ $id ]['active'] = false;
+		}
+
+		$this->assertEmpty( $this->model->register_pdf_meta_box( [], $entry, $form ) );
+	}
+}

--- a/tests/phpunit/unit-tests/Model/TestModelPDFMetaBox.php
+++ b/tests/phpunit/unit-tests/Model/TestModelPDFMetaBox.php
@@ -20,7 +20,7 @@ use WP_UnitTestCase;
  *
  * @group   pdf
  */
-class TestModelPDFMetaBox extends WP_UnitTestCase {
+class TestModelPdfMetaBox extends WP_UnitTestCase {
 
 	/**
 	 * @var Controller_PDF
@@ -39,13 +39,10 @@ class TestModelPDFMetaBox extends WP_UnitTestCase {
 
 	/**
 	 * The WP Unit Test Set up function
-	 *
-	 * @since 6.0
 	 */
 	public function setUp() {
 		global $gfpdf;
 
-		/* run parent method */
 		parent::setUp();
 
 		/* Setup our test classes */
@@ -57,8 +54,6 @@ class TestModelPDFMetaBox extends WP_UnitTestCase {
 
 	/**
 	 * Create our testing data
-	 *
-	 * @since 4.0
 	 */
 	protected function create_form_and_entries() {
 		global $gfpdf;
@@ -73,16 +68,12 @@ class TestModelPDFMetaBox extends WP_UnitTestCase {
 
 	/**
 	 * Check our PDF detail list is displaying correctly
-	 *
-	 * @since 4.0
 	 */
 	public function test_view_pdf_entry_detail_success() {
-
-		/* Setup some test data */
-		[ $form, $entry['entry'] ] = $this->create_form_and_entries();
+		[ ,$entry ] = $this->create_form_and_entries();
 
 		ob_start();
-		$this->model->view_pdf_entry_detail( $entry );
+		$this->model->view_pdf_entry_detail( [ 'entry' => $entry ] );
 		$html = ob_get_clean();
 
 		$this->assertStringContainsString( '<div class="gfpdf_detailed_pdf_cta">', $html );
@@ -90,8 +81,6 @@ class TestModelPDFMetaBox extends WP_UnitTestCase {
 
 	/**
 	 * Check our PDF detail list is displaying correctly when there is no entry passed
-	 *
-	 * @since 4.0
 	 */
 	public function test_view_pdf_entry_detail_fail() {
 
@@ -104,24 +93,15 @@ class TestModelPDFMetaBox extends WP_UnitTestCase {
 
 	/**
 	 * Check if Metabox registration is working properly
-	 *
-	 * @since 6.0
 	 */
 	public function test_register_pdf_meta_box_success() {
-
-		/* Setup some test data */
 		[ $form, $entry ] = $this->create_form_and_entries();
 
 		$this->assertArrayHasKey( 'gfpdf-entry-details-list', $this->model->register_pdf_meta_box( [], $entry, $form ) );
 
-		/*  Get all PDFs ID */
-		$pdf_ids = array_keys( $form['gfpdf_form_settings'] );
-
-		/* Test if metabox is  registered when there is atleast 2 active PDFs */
-		$active_pdfs = array_rand( $pdf_ids, 2 );
-
-		foreach ( $active_pdfs as $id ) {
-			$form['gfpdf_form_settings'][ $pdf_ids[ $id ] ]['active'] = false;
+		/* Disable two (out of four) PDFs and verify the meta box is still displayed */
+		foreach ( array_rand( array_keys( $form['gfpdf_form_settings'] ), 2 ) as $id ) {
+			$form['gfpdf_form_settings'][ $id ]['active'] = false;
 		}
 
 		$this->assertArrayHasKey( 'gfpdf-entry-details-list', $this->model->register_pdf_meta_box( [], $entry, $form ) );
@@ -129,19 +109,12 @@ class TestModelPDFMetaBox extends WP_UnitTestCase {
 
 	/**
 	 * Check if Metabox registration is working properly when there is no active PDFs
-	 *
-	 * @since 6.0
 	 */
 	public function test_register_pdf_meta_box_fail() {
-
-		/* Setup some test data */
 		[ $form, $entry ] = $this->create_form_and_entries();
 
-		/*  Set all pdfs to inactive */
-		$pdf_ids = array_keys( $form['gfpdf_form_settings'] );
-
-		/* Test if metabox is not registered when there is no active PDFs */
-		foreach ( $pdf_ids as $id ) {
+		/* Disable two (out of four) PDFs and verify the meta box is still displayed */
+		foreach ( array_keys( $form['gfpdf_form_settings'] ) as $id ) {
 			$form['gfpdf_form_settings'][ $id ]['active'] = false;
 		}
 

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -707,60 +707,6 @@ class Test_PDF extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Check our PDF detail list is displaying correctly
-	 *
-	 * @since 4.0
-	 */
-	public function test_view_pdf_entry_detail() {
-
-		/* Setup some test data */
-		$results = $this->create_form_and_entries();
-
-		ob_start();
-		$this->model->view_pdf_entry_detail( [ 'entry' => [ 'form_id' => 0 ] ] );
-		$html = ob_get_clean();
-		$this->assertNotFalse( strpos( $html, 'No PDFs available for this entry.' ) );
-
-		ob_start();
-		$this->model->view_pdf_entry_detail( $results );
-		$html = ob_get_clean();
-		$this->assertNotFalse( strpos( $html, '<div class="gfpdf_detailed_pdf_cta">' ) );
-	}
-
-	/**
-	 * Check if Metabox registration is working properly
-	 *
-	 * @since 6.0
-	 */
-	public function test_register_pdf_meta_box(){
-
-		/* Setup some test data */
-		$results = $this->create_form_and_entries();
-		$form    = $results['form'];
-		$entry   = $results['entry'];
-
-		$this->assertSame( true, array_key_exists( 'gfpdf-entry-details-list', $this->model->register_pdf_meta_box( [], $entry, $form ) ) );
-		/*  Set all pdfs to inactive */
-		$pdf_ids = array_keys( $form['gfpdf_form_settings'] );
-
-		/* Test if metabox is not registered when there is no active PDFs */
-		foreach ( $pdf_ids as $id ) {
-			$form['gfpdf_form_settings'][ $id ]['active'] = false;
-		}
-
-		$this->assertSame( true, empty( $this->model->register_pdf_meta_box( [], $entry, $form ) ) );
-
-		/* Test if metabox is  registered when there is atleast 2 active PDFs */
-		$active_pdfs = array_rand( $pdf_ids, 2);
-
-		foreach ( $active_pdfs as $id ) {
-			$form['gfpdf_form_settings'][ $pdf_ids[ $id ] ]['active'] = true;
-		}
-
-		$this->assertSame( true, array_key_exists( 'gfpdf-entry-details-list', $this->model->register_pdf_meta_box( [], $entry, $form ) ) );
-	}
-
-	/**
 	 * Check that an array of PDFs gets correctly returned in the right format
 	 *
 	 * @since 4.0


### PR DESCRIPTION
## Description
Moved the Metabox Unit Tests to each Test Files (Failure and Success).
<!-- Link to the support ticket(s) where appropriate. -->

## Testing instructions
Kindly run these following commands:
yarn test:php --filter=TestModelPDFMetaBox
Or PhpStorm's Unit test UI this class.
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/434866/89601251-b1543000-d896-11ea-9a13-6bb8acb8e5bd.png)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
This is the spearhead of micro-test.
Screenshot updated.
Instruction updated.