### PR TITLE
Always parse Core Font payload as JSON

### DIFF
--- a/src/assets/js/react/api/coreFonts.js
+++ b/src/assets/js/react/api/coreFonts.js
@@ -19,6 +19,10 @@ export function apiGetFilesFromGitHub () {
     .get(GFPDF.pluginUrl + 'dist/payload/core-fonts.json')
     .accept('application/json')
     .type('json')
+    .buffer(true)
+    .parse(function(response) {
+      return JSON.parse(response.text)
+    })
 }
 
 /**

--- a/src/assets/js/react/api/coreFonts.js
+++ b/src/assets/js/react/api/coreFonts.js
@@ -19,10 +19,7 @@ export function apiGetFilesFromGitHub () {
     .get(GFPDF.pluginUrl + 'dist/payload/core-fonts.json')
     .accept('application/json')
     .type('json')
-    .buffer(true)
-    .parse(function(response) {
-      return JSON.parse(response.text)
-    })
+    .parse(response => JSON.parse(response.text))
 }
 
 /**


### PR DESCRIPTION
## Description

Regardless of the `Content-Type` header sent back when accessing the `/dist/payload/core-fonts.json` file, we should always parse a successful API request as JSON. 

Resolves #1069

## Testing instructions

1. Open the `.htaccess` file at the root of your WordPress directory and add `AddType none .json` to the top
2. In the `gf-2.5` branch if you run the Core Font Installer now you will get an error
3. If you checkout this branch and rerun the installer it will function as expected
4. If you remove the line added to `.htaccess` it will still function correctly

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
