### PR TITLE
Add upgrade routine and enable vendor aliases for pre6.0 users only

### DIFF
--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use GFPDF\Helper\Helper_Abstract_Options;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Controller_Upgrade_Routines
+ *
+ * @package GFPDF\Controller
+ */
+class Controller_Upgrade_Routines {
+
+	/**
+	 * @var Helper_Abstract_Options
+	 */
+	protected $options;
+
+	public function __construct( Helper_Abstract_Options $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * @since 6.0
+	 */
+	public function init(): void {
+		add_action( 'gfpdf_version_changed', [ $this, 'maybe_run_upgrade' ], 10, 2 );
+	}
+
+	/**
+	 * @since 6.0
+	 */
+	public function maybe_run_upgrade( string $old_version, string $current_version ): void {
+		if ( version_compare( $current_version, '6.0.0-beta1', '>=' ) && version_compare( $old_version, '6.0.0-beta1', '<' ) ) {
+			$this->enable_vendor_aliasing();
+		}
+	}
+
+	/**
+	 * Add global flag to enable vendor aliasing
+	 *
+	 * @since 6.0
+	 */
+	protected function enable_vendor_aliasing(): void {
+		$this->options->update_option( 'vendor_aliasing', true );
+	}
+
+}

--- a/src/Deprecated/Vendor_Aliasing.php
+++ b/src/Deprecated/Vendor_Aliasing.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace GFPDF\Deprecated;
+
+/**
+ * Class Vendor_Aliasing
+ *
+ * @package GFPDF\Deprecated
+ */
+class Vendor_Aliasing {
+
+	/**
+	 * All vendor packages are moved under the namespace \GFPDF_Vendor\* in v6.0
+	 * To reduce the likelihood of problems, common functions and classes are aliased back to their original
+	 * namespace if a user has upgraded from a pre-6.0 release.
+	 *
+	 * @internal can be disabled with the filter `gfpdf_disable_vendor_aliasing`
+	 *
+	 * @since 6.0
+	 */
+	public static function maybe_alias_vendor_packages(): bool {
+		if (
+			! \GPDFAPI::get_plugin_option( 'vendor_aliasing', false ) ||
+			apply_filters( 'gfpdf_disable_vendor_aliasing', false )
+		) {
+			return false;
+		}
+
+		if ( ! function_exists( 'qp' ) ) {
+			require_once( PDF_PLUGIN_DIR . 'vendor_prefixed/querypath/querypath/src/qp_functions.php' );
+
+			function qp() {
+				return \GFPDF_Vendor\qp( ...func_get_args() );
+			}
+
+			function htmlqp() {
+				return \GFPDF_Vendor\htmlqp( ...func_get_args() );
+			}
+
+			function html5qp() {
+				return \GFPDF_Vendor\html5qp( ...func_get_args() );
+			}
+		}
+
+		if ( ! class_exists( '\Mpdf\Mpdf' ) ) {
+			class_alias( 'GFPDF_Vendor\\Mpdf\\Mpdf', 'Mpdf\\Mpdf' );
+			class_alias( 'GFPDF_Vendor\\Mpdf\\MpdfException', 'Mpdf\\MpdfException' );
+			class_alias( 'GFPDF_Vendor\\Mpdf\\Config\\ConfigVariables', 'Mpdf\\Config\\ConfigVariables' );
+			class_alias( 'GFPDF_Vendor\\Mpdf\\Config\\FontVariables', 'Mpdf\\Config\\FontVariables' );
+		}
+
+		return true;
+	}
+
+}

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -15,37 +15,4 @@ require_once( PDF_PLUGIN_DIR . 'vendor/autoload.php' );
 require_once( PDF_PLUGIN_DIR . 'src/deprecated.php' );
 require_once( PDF_PLUGIN_DIR . 'api.php' );
 
-/**
- * < v6 Backwards compatibility for common-use non-scoped vendor packages
- *
- * @internal load after other WordPress plugins so they can define these functions beforehand
- *
- * @TODO - only load this if the user upgraded
- */
-add_action(
-	'init',
-	function() {
-		if ( ! function_exists( 'qp' ) ) {
-			require_once( PDF_PLUGIN_DIR . 'vendor_prefixed/querypath/querypath/src/qp_functions.php' );
-
-			function qp() {
-				return \GFPDF_Vendor\qp( ...func_get_args() );
-			}
-
-			function htmlqp() {
-				return \GFPDF_Vendor\htmlqp( ...func_get_args() );
-			}
-
-			function html5qp() {
-				return \GFPDF_Vendor\html5qp( ...func_get_args() );
-			}
-		}
-
-		if ( ! class_exists( '\Mpdf\Mpdf' ) ) {
-			class_alias( 'GFPDF_Vendor\\Mpdf\\Mpdf', 'Mpdf\\Mpdf' );
-			class_alias( 'GFPDF_Vendor\\Mpdf\\Config\\ConfigVariables', 'Mpdf\\Config\\ConfigVariables' );
-			class_alias( 'GFPDF_Vendor\\Mpdf\\Config\\FontVariables', 'Mpdf\\Config\\FontVariables' );
-		}
-	},
-	9999
-);
+add_action( 'init', '\GFPDF\Deprecated\Vendor_Aliasing::maybe_alias_vendor_packages', 9999 );

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -211,6 +211,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 
 		/* Load modules */
 		$this->installer();
+		$this->upgrade_routine();
 		$this->gf_settings();
 		$this->gf_form_settings();
 		$this->pdf();
@@ -604,6 +605,16 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		/* Add to our singleton controller */
 		$this->singleton->add_class( $class );
 		$this->singleton->add_class( $model );
+	}
+
+	/**
+	 * @since 6.0
+	 */
+	public function upgrade_routine(): void {
+		$class = new Controller\Controller_Upgrade_Routines( $this->options );
+		$class->init();
+
+		$this->singleton->add_class( $class );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Controller_Upgrade_Routines
+ *
+ * @package GFPDF\Controller
+ *
+ * @group   controller
+ * @group   upgrade
+ */
+class Test_Controller_Upgrade_Routines extends WP_UnitTestCase {
+
+	/**
+	 * @var \GFPDF\Helper\Helper_Options_Fields
+	 */
+	protected $options;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options = \GPDFAPI::get_options_class();
+		$this->options->delete_option( 'vendor_aliasing' );
+	}
+
+	/**
+	 * @dataProvider data_provider_6_0_0_upgrade_routine
+	 */
+	public function test_6_0_0_upgrade_routine( bool $expected, string $old_version, string $current_version ) {
+		do_action( 'gfpdf_version_changed', $old_version, $current_version );
+
+		$this->assertSame( $expected, $this->options->get_option( 'vendor_aliasing', false ) );
+	}
+
+	public function data_provider_6_0_0_upgrade_routine(): array {
+		return [
+			[ true, '5.3', '6.0.0-beta1' ],
+			[ true, '4.5.2', '6.0.0' ],
+			[ true, '5.3.2', '6.0.5' ],
+			[ true, '5', '6.2.3-RC2' ],
+			[ false, '5.3.2', '5.4.0' ],
+			[ false, '6.0.0', '5.3.2' ],
+			[ false, '6.0.0', '6.3.1' ],
+			[ false, '6.0.0-beta1', '6.0.5' ],
+		];
+	}
+
+}

--- a/tests/phpunit/unit-tests/Deprecated/Test_Vendor_Aliasing.php
+++ b/tests/phpunit/unit-tests/Deprecated/Test_Vendor_Aliasing.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace GFPDF\Deprecated;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Vendor_Aliasing
+ *
+ * @package GFPDF\Deprecated
+ *
+ * @group   deprecated
+ */
+class Test_Vendor_Aliasing extends WP_UnitTestCase {
+
+	/**
+	 * @var \GFPDF\Helper\Helper_Options_Fields
+	 */
+	protected $options;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options = \GPDFAPI::get_options_class();
+		$this->options->delete_option( 'vendor_aliasing' );
+	}
+
+	/**
+	 * @since 6.0
+	 */
+	public function test_maybe_alias_vendor_packages_skipped() {
+		$this->assertFalse( Vendor_Aliasing::maybe_alias_vendor_packages() );
+
+		$this->options->update_option( 'vendor_aliasing', true );
+		add_filter( 'gfpdf_disable_vendor_aliasing', '__return_true' );
+
+		$this->assertFalse( Vendor_Aliasing::maybe_alias_vendor_packages() );
+	}
+
+	/**
+	 * @since 6.0
+	 */
+	public function test_maybe_alias_vendor_packages_run() {
+		$this->assertFalse( class_exists( 'Mpdf\\Mpdf' ) );
+
+		$this->options->update_option( 'vendor_aliasing', true );
+		$this->assertTrue( Vendor_Aliasing::maybe_alias_vendor_packages() );
+		$this->assertTrue( class_exists( 'Mpdf\\Mpdf' ) );
+	}
+}

--- a/tests/phpunit/unit-tests/test-installer.php
+++ b/tests/phpunit/unit-tests/test-installer.php
@@ -335,7 +335,7 @@ class Test_Installer extends WP_UnitTestCase {
 		}
 
 		wp_set_current_user( $user_id );
-		update_option( 'gfpdf_settings', 'test' );
+		update_option( 'gfpdf_settings', [] );
 
 		$this->controller->check_install_status();
 

--- a/tests/phpunit/unit-tests/test-query-path.php
+++ b/tests/phpunit/unit-tests/test-query-path.php
@@ -38,6 +38,6 @@ class Test_QueryPath extends WP_UnitTestCase {
 		$this->assertEquals( 'ã   Ã   ╚   ╔   ╩   ╦   ╠   ═   ╬   ¤', $qp->html5( $html, 'div' )->innerHTML5() );
 
 		/* Using the standard HTML parser these characters will not be correctly displayed when output */
-		$this->assertNotEquals( 'ã   Ã   ╚   ╔   ╩   ╦   ╠   ═   ╬   ¤', htmlqp( $html, 'div' )->innerHTML5() );
+		$this->assertNotEquals( 'ã   Ã   ╚   ╔   ╩   ╦   ╠   ═   ╬   ¤', \GFPDF_Vendor\htmlqp( $html, 'div' )->innerHTML5() );
 	}
 }


### PR DESCRIPTION
## Description

Finalises the Vendor scoping feature.

## Testing instructions

`qp`, `htmlqp` and `html5qp` functions, and the `\Mpdf\Mpdf` class are available after the `init` hook is fired if you upgrade from a version prior to 6.0.

## Screenshots <!-- if applicable -->

## Checklist:
- [X] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
