### PR TITLE
Swap Background Processing checks to new toggle Yes/No options

### DIFF
--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -344,9 +344,10 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller implements Helper_
 			foreach ( $notifications as $notification ) {
 				if ( $this->model_pdf->maybe_always_save_pdf( $pdf ) || $this->model_pdf->maybe_attach_to_notification( $notification, $pdf, $entry, $form ) ) {
 					$queue_data[] = [
-						'id'   => $this->get_queue_id( $form, $entry, $pdf ),
-						'func' => '\GFPDF\Statics\Queue_Callbacks::create_pdf',
-						'args' => [ $entry['id'], $pdf['id'] ],
+						'id'            => $this->get_queue_id( $form, $entry, $pdf ),
+						'func'          => '\GFPDF\Statics\Queue_Callbacks::create_pdf',
+						'args'          => [ $entry['id'], $pdf['id'] ],
+						'unrecoverable' => true,
 					];
 
 					/* Only queue each PDF once (even if attached to multiple notifications) */

--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -44,6 +44,7 @@ class Controller_Upgrade_Routines {
 	public function maybe_run_upgrade( string $old_version, string $current_version ): void {
 		if ( version_compare( $current_version, '6.0.0-beta1', '>=' ) && version_compare( $old_version, '6.0.0-beta1', '<' ) ) {
 			$this->enable_vendor_aliasing();
+			$this->update_background_processing_values();
 		}
 	}
 
@@ -54,6 +55,18 @@ class Controller_Upgrade_Routines {
 	 */
 	protected function enable_vendor_aliasing(): void {
 		$this->options->update_option( 'vendor_aliasing', true );
+	}
+
+	/**
+	 * Update Background Processing values to new Toggle button format
+	 *
+	 * @since 6.0
+	 */
+	protected function update_background_processing_values(): void {
+		$value     = $this->options->get_option( 'background_processing' );
+		$new_value = $value === 'Enable' ? 'Yes' : 'No';
+
+		$this->options->update_option( 'background_processing', $new_value );
 	}
 
 }

--- a/src/Helper/Helper_Pdf_Queue.php
+++ b/src/Helper/Helper_Pdf_Queue.php
@@ -115,6 +115,24 @@ class Helper_Pdf_Queue extends GF_Background_Process {
 				if ( empty( $callback['retry'] ) || $callback['retry'] < 2 ) {
 					$callback['retry'] = isset( $callback['retry'] ) ? $callback['retry'] + 1 : 1;
 					array_unshift( $callbacks, $callback );
+				} else {
+					$this->log->error(
+						sprintf(
+							'Async PDF task retry limit reached for %s.',
+							$callback['id']
+						)
+					);
+
+					if ( $callback['unrecoverable'] ?? false ) {
+						$this->log->critical(
+							'Cancel async queue due to retry limit reached on unrecoverable callback.',
+							[
+								'callbacks' => $callbacks,
+							]
+						);
+
+						$callbacks = [];
+					}
 				}
 			}
 		}

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -1712,7 +1712,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	public function maybe_save_pdf( $entry, $form ) {
 
 		/* Exit early if background processing is enabled */
-		if ( $this->options->get_option( 'background_processing', 'Disable' ) === 'Enable' ) {
+		if ( $this->options->get_option( 'background_processing', 'No' ) === 'Yes' ) {
 			return;
 		}
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -919,7 +919,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$model_pdf = $this->singleton->get_class( 'Model_PDF' );
 		$class     = new Controller\Controller_Pdf_Queue( $queue, $model_pdf, $this->log );
 
-		if ( $this->options->get_option( 'background_processing', 'Disable' ) === 'Enable' ) {
+		if ( $this->options->get_option( 'background_processing', 'No' ) === 'Yes' ) {
 			$class->init();
 		}
 

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
@@ -54,4 +54,20 @@ class Test_Controller_Upgrade_Routines extends WP_UnitTestCase {
 		];
 	}
 
+	public function test_6_0_0_background_process_upgrade_routine() {
+		/* Check for enabled status */
+		$this->options->update_option( 'background_processing', 'Enable' );
+
+		do_action( 'gfpdf_version_changed', '5.3', '6.0.0-beta1' );
+
+		$this->assertSame( 'Yes', $this->options->get_option( 'background_processing' ) );
+
+		/* Check for disabled status */
+		$this->options->update_option( 'background_processing', 'Disable' );
+
+		do_action( 'gfpdf_version_changed', '5.3', '6.0.0-beta1' );
+
+		$this->assertSame( 'No', $this->options->get_option( 'background_processing' ) );
+	}
+
 }

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -212,7 +212,7 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 		unlink( $file );
 
 		/* Ensure function doesn't run when background processing enabled */
-		$gfpdf->options->update_option( 'background_processing', 'Enable' );
+		$gfpdf->options->update_option( 'background_processing', 'Yes' );
 
 		$this->model->maybe_save_pdf( $entry, $form );
 		$this->assertFileNotExists( $file );


### PR DESCRIPTION
## Description

We changed the Background Process toggle from a Radio field to a Toggle. The Radio field had the values Enable and Disable, but the Toggle uses Yes and No. This update uses the new values and includes an upgrade routine from v5. 

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
