### PR TITLE
Add hidden class

### DIFF
--- a/src/assets/scss/Component/_hidden.scss
+++ b/src/assets/scss/Component/_hidden.scss
@@ -1,0 +1,5 @@
+#tab_pdf, #tab_PDF {
+  .gfpdf-hidden {
+    display: none;
+  }
+}

--- a/src/assets/scss/gfpdf-styles.scss
+++ b/src/assets/scss/gfpdf-styles.scss
@@ -15,6 +15,7 @@
 @use 'Component/template-manager';
 @use 'Component/uninstaller';
 @use 'Component/upload';
+@use 'Component/hidden';
 
 /* Pages */
 @use 'Pages/entry-details';


### PR DESCRIPTION
## Description

Resolves #1128 

## Testing instructions
Load Global PDF Settings and notice the Custom Paper Size field doesn't flash on the screen before being hidden

## Screenshots <!-- if applicable -->

## Checklist:
- [X] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
