### PR TITLE
Inline the Font and Template Advanced buttons

### DIFF
--- a/src/assets/js/admin/settings/common/setupDynamicTemplateFields.js
+++ b/src/assets/js/admin/settings/common/setupDynamicTemplateFields.js
@@ -16,7 +16,7 @@ export function setupDynamicTemplateFields () {
   /* Add change listener to our template */
   $('#gfpdf_settings\\[template\\]').off('change').on('change', function () {
     /* Add spinner */
-    const $spinner = spinner('gfpdf-spinner')
+    const $spinner = spinner('gfpdf-spinner-template')
 
     $(this).next().after($spinner)
 

--- a/src/assets/js/react/bootstrap/fontManagerBootstrap.js
+++ b/src/assets/js/react/bootstrap/fontManagerBootstrap.js
@@ -50,13 +50,22 @@ export function fontManagerBootstrap (defaultFontField, buttonStyle) {
  * @since 6.0
  */
 export function createAdvancedButtonWrapper (defaultFontField, preventButtonReset) {
-  const wrapper = document.createElement('span')
-  wrapper.setAttribute('id', 'gpdf-advance-font-manager-selector' + preventButtonReset)
+  const fontWrapper = document.createElement('span')
+  fontWrapper.setAttribute('id', 'gpdf-advance-font-manager-selector' + preventButtonReset)
 
   const popupWrapper = document.createElement('div')
   popupWrapper.setAttribute('id', 'font-manager-overlay')
   popupWrapper.setAttribute('class', 'theme-overlay')
 
-  defaultFontField.appendChild(wrapper)
-  defaultFontField.appendChild(popupWrapper)
+  if (defaultFontField.nodeName === 'SELECT') {
+    const wrapper = document.createElement('div')
+    wrapper.setAttribute('id', 'gfpdf-settings-field-wrapper-font-container')
+    wrapper.innerHTML = defaultFontField.outerHTML
+    wrapper.appendChild(fontWrapper)
+    wrapper.appendChild(popupWrapper)
+    defaultFontField.outerHTML = wrapper.outerHTML
+  } else {
+    defaultFontField.appendChild(fontWrapper)
+    defaultFontField.appendChild(popupWrapper)
+  }
 }

--- a/src/assets/js/react/bootstrap/templateBootstrap.js
+++ b/src/assets/js/react/bootstrap/templateBootstrap.js
@@ -59,6 +59,7 @@ export default function templateBootstrap ($templateField) {
  */
 export function createTemplateMarkup ($templateField) {
   $templateField
+    .wrap('<div id="gfpdf-settings-field-wrapper-template-container" />')
     .parent()
     .append('<span id="gpdf-advance-template-selector">')
     .append('<div id="gfpdf-overlay" class="theme-overlay">')

--- a/src/assets/js/react/gfpdf-main.js
+++ b/src/assets/js/react/gfpdf-main.js
@@ -54,9 +54,9 @@ $(function () {
     helpBootstrap()
   }
 
-  const fmGeneralSettingsTab = document.querySelector('#gfpdf-settings-field-wrapper-default_font')
+  const fmGeneralSettingsTab = document.querySelector('#gfpdf-settings-field-wrapper-default_font select')
   const fmToolsTab = document.querySelector('#gfpdf-settings-field-wrapper-manage_fonts')
-  const fmPdfSettings = document.querySelector('#gfpdf-settings-field-wrapper-font')
+  const fmPdfSettings = document.querySelector('#gfpdf-settings-field-wrapper-font select')
 
   /* Initialize font manager under general settings tab */
   if (fmGeneralSettingsTab !== null) {

--- a/src/assets/scss/Component/_font-manager.scss
+++ b/src/assets/scss/Component/_font-manager.scss
@@ -7,6 +7,10 @@
     margin: 0 0.2rem 0.2rem 0;
   }
 
+  #gfpdf_pdf_form #gfpdf-settings-field-wrapper-font-container {
+    display: flex;
+  }
+
   #font-manager-overlay {
     .font-manager {
       overflow: hidden;

--- a/src/assets/scss/Component/_spinner.scss
+++ b/src/assets/scss/Component/_spinner.scss
@@ -19,6 +19,13 @@
     }
   }
 
+  /* Form PDF Settings */
+  .gfpdf-spinner-template {
+    width: 23px;
+    height: 23px;
+    padding: 10px 0px 0px 10px;
+  }
+
   /* PDF List Page */
   #gfpdf_list_form, button {
 

--- a/src/assets/scss/Component/_template-manager.scss
+++ b/src/assets/scss/Component/_template-manager.scss
@@ -5,6 +5,10 @@
     margin: 0 0.2rem 0.2rem 0;
   }
 
+  #gfpdf_pdf_form #gfpdf-settings-field-wrapper-template-container {
+    display: flex;
+  }
+
   .theme-wrap {
 
     /* Header section */

--- a/src/assets/scss/MediaQueries/_min-1200.scss
+++ b/src/assets/scss/MediaQueries/_min-1200.scss
@@ -21,9 +21,14 @@
   }
 }
 
-/* 1201px up to 1470px */
-@media only screen and (min-width: 1201px) and (max-width: 1470px) {
+/* 1201px up */
+@media only screen and (min-width: 1201px) {
   #tab_pdf, #tab_PDF {
+
+    #gfpdf-settings-field-wrapper-template-container,
+    #gfpdf-settings-field-wrapper-font-container {
+      display: flex;
+    }
 
     /* Font manager modal */
     #font-manager-overlay {


### PR DESCRIPTION
## Description

Create a better experience for users by inlining the Advanced buttons for the Font and Template Managers.

Resolves #1124

## Testing instructions
1. View Global PDF Settings page
2. View Form PDF Settings page
3. View Tools tab (to check the Font Manager)

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/2918419/98333042-04837d80-2054-11eb-9b53-f1042679ce23.png)
![image](https://user-images.githubusercontent.com/2918419/98333072-1107d600-2054-11eb-89e6-fd0f8124105e.png)
![image](https://user-images.githubusercontent.com/2918419/98333088-17964d80-2054-11eb-9bb9-cfc4d53c6b09.png)
![image](https://user-images.githubusercontent.com/2918419/98333099-1b29d480-2054-11eb-8d13-75e6ffa874cb.png)

## Checklist:
- [X] I've tested the code.
- [X] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->
