### PR TITLE
Only allow font to be installed via template if not already exists

### DIFF
--- a/api.php
+++ b/api.php
@@ -604,6 +604,11 @@ final class GPDFAPI {
 	 */
 	public static function add_pdf_font( $font ) {
 
+		$installed_fonts = static::get_pdf_fonts();
+		if ( array_search( $font['font_name'] ?? '', $installed_fonts[ esc_html__( 'User-Defined Fonts', 'gravity-forms-pdf-extended' ) ] ?? [], true ) !== false ) {
+			return true;
+		}
+
 		$files_backup = $_FILES;
 		$_FILES       = [];
 

--- a/tests/phpunit/unit-tests/test-api.php
+++ b/tests/phpunit/unit-tests/test-api.php
@@ -253,6 +253,20 @@ class Test_API extends WP_UnitTestCase {
 		GPDFAPI::delete_pdf_font( 'test' );
 	}
 
+	public function test_add_pdf_font_duplicate() {
+		$ttf_file = __DIR__ . '/fonts/Chewy.ttf';
+
+		$font = [
+			'font_name' => 'Test',
+			'regular'   => $ttf_file,
+		];
+
+		$this->assertTrue( GPDFAPI::add_pdf_font( $font ) );
+		$this->assertTrue( GPDFAPI::add_pdf_font( $font ) );
+
+		$this->assertCount( 1, GPDFAPI::get_pdf_fonts()['User-Defined Fonts'] ?? [] );
+	}
+
 	/**
 	 * Test we can correctly delete the font
 	 *


### PR DESCRIPTION
## Description

This prevents a font being auto-installed multiple times when a template is reinstalled / upgraded.

Resolves #1151

## Testing instructions
1. Install template zip file that contains font
2. Check font has been installed
3. Reinstall same zip file
4. Check that installed font only appears once.

## Checklist:
- [X] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
