### PR TITLE
Set valid HTML input field for font manager list

### DIFF
--- a/src/assets/js/react/components/FontManager/FontListItems.js
+++ b/src/assets/js/react/components/FontManager/FontListItems.js
@@ -353,8 +353,8 @@ export class FontListItems extends Component {
                 {!disableSelectFontName && (
                   <input
                     type='radio'
-                    id='selectFontName'
-                    name={font.id}
+                    className='selectFontName'
+                    name='selectFontName'
                     value={font.id}
                     onChange={e => this.handleSelectFont(e, 'click')}
                     onClick={e => e.stopPropagation()}

--- a/src/assets/scss/Component/_font-manager.scss
+++ b/src/assets/scss/Component/_font-manager.scss
@@ -71,7 +71,7 @@
                 text-align: left;
                 word-break: break-all;
 
-                #selectFontName {
+                .selectFontName {
                   width: 1rem;
                   height: 1rem;
                   margin-right: 0.5rem;

--- a/tests/js-unit/react/components/FontManager/FontListItems.test.js
+++ b/tests/js-unit/react/components/FontManager/FontListItems.test.js
@@ -282,7 +282,7 @@ describe('FontManager - FontListItems.js', () => {
     test('render radio button for select font name', () => {
       const wrapper = shallow(<FontListItems {...props} />)
 
-      expect(wrapper.find('input#selectFontName').length).toBe(1)
+      expect(wrapper.find('input[name="selectFontName"]').length).toBe(1)
     })
 
     test('render font name', () => {


### PR DESCRIPTION
## Description

Issue: #1171 

## Testing instructions

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
