### PR TITLE
Add Add/Update button below open PDF Setting container automatically

### DIFF
--- a/src/assets/js/react/gfpdf-main.js
+++ b/src/assets/js/react/gfpdf-main.js
@@ -3,6 +3,7 @@ import templateBootstrap from './bootstrap/templateBootstrap'
 import { fontManagerBootstrap } from './bootstrap/fontManagerBootstrap'
 import coreFontBootstrap from './bootstrap/coreFontBootstrap'
 import helpBootstrap from './bootstrap/helpBootstrap'
+import addEditButton from './utilities/PdfSettings/addEditButton'
 import '../../scss/gfpdf-styles.scss'
 
 /**
@@ -57,6 +58,8 @@ $(function () {
   const fmGeneralSettingsTab = document.querySelector('#gfpdf-settings-field-wrapper-default_font select')
   const fmToolsTab = document.querySelector('#gfpdf-settings-field-wrapper-manage_fonts')
   const fmPdfSettings = document.querySelector('#gfpdf-settings-field-wrapper-font select')
+  const pdfSettingsForm = document.querySelector('#gfpdf_pdf_form')
+  const pdfSettingFieldSets = document.querySelectorAll('fieldset.gform-settings-panel--full')
 
   /* Initialize font manager under general settings tab */
   if (fmGeneralSettingsTab !== null) {
@@ -71,5 +74,10 @@ $(function () {
   /* Initialize font manager under PDF settings */
   if (fmPdfSettings !== null) {
     fontManagerBootstrap(fmPdfSettings)
+  }
+
+  /* Initialize additional add/update buttons on PDF setting panels */
+  if (pdfSettingsForm && pdfSettingFieldSets.length === 4) {
+    addEditButton(pdfSettingFieldSets, pdfSettingsForm)
   }
 })

--- a/src/assets/js/react/utilities/PdfSettings/addEditButton.js
+++ b/src/assets/js/react/utilities/PdfSettings/addEditButton.js
@@ -1,0 +1,38 @@
+export default function addEditButton (pdfSettingFieldSets, form) {
+  const items = Array.from(pdfSettingFieldSets)
+  /* Remove last element of the array */
+  items.pop()
+
+  items.map((fieldset, index) => {
+    const collapsibleToggleIcon = fieldset.querySelector('.gform-settings-panel__collapsible-toggle-checkbox')
+
+    window.addEventListener('load', function () {
+      insertAfter(fieldset, form, index, 'firstLoad')
+    })
+
+    collapsibleToggleIcon.addEventListener('click', function () {
+      insertAfter(fieldset, form, index)
+    })
+  })
+}
+
+export function insertAfter (fieldset, form, index, firstLoad) {
+  const wrapperClass = 'submit-container-' + index
+
+  if (!fieldset.classList.contains('gform-settings-panel--collapsed')) {
+    const submitButton = form.querySelector('#submit')
+    const submitButtonClone = submitButton.cloneNode(true)
+    const wrapper = document.createElement('div')
+    wrapper.setAttribute('class', wrapperClass)
+    wrapper.innerHTML = submitButtonClone.outerHTML
+
+    return fieldset.parentNode.insertBefore(wrapper, fieldset.nextSibling)
+  }
+
+  if (firstLoad) {
+    return
+  }
+
+  /* Remove button when fieldset collapsed */
+  document.querySelector(`.${wrapperClass}`).remove()
+}


### PR DESCRIPTION
## Description

Issue: #1152 

Add Add/Update button below open PDF Setting container automatically

## Testing instructions

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
