### PR TITLE
Security JavaScript Toggle not showing/hidding PDF Settings

### DIFF
--- a/src/assets/js/admin/settings/pdf/handleSecurityConditionals.js
+++ b/src/assets/js/admin/settings/pdf/handleSecurityConditionals.js
@@ -11,7 +11,7 @@ export function handleSecurityConditionals () {
   const $pdfSecurity = $secTable.find('input[name="gfpdf_settings[security]"]')
   const $format = $secTable.find('input[name="gfpdf_settings[format]"]')
   const $securityQuestion = $secTable.find('#gfpdf-settings-field-wrapper-security')
-  const $securityFields = $secTable.find('#gfpdf-settings-field-wrapper-password,#gfpdf-settings-field-wrapper-privileges,gfpdf-settings-field-wrapper-master_password:not(.gfpdf-hidden)')
+  const $securityFields = $secTable.find('#gfpdf-settings-field-wrapper-password,#gfpdf-settings-field-wrapper-privileges,#gfpdf-settings-field-wrapper-master_password:not(.gfpdf-hidden)')
 
   /* Add change event to admin restrictions to show/hide dependant fields */
   $pdfSecurity.on('change', function () {
@@ -22,8 +22,12 @@ export function handleSecurityConditionals () {
       /* hide security password / privileges */
       $securityFields.hide()
     } else {
-      /* show security password / privileges */
-      $securityFields.show()
+      /* Show/hide security password / privileges fields under 'Enable PDF Security' */
+      if ($(this).is(':checked')) {
+        $securityFields.show()
+      } else {
+        $securityFields.hide()
+      }
     }
 
     if (format !== 'Standard') {


### PR DESCRIPTION
## Description

Issue: #1173 
Toggle show/hide security password and privileges fields under 'Enable PDF Security'

![1](https://user-images.githubusercontent.com/10412650/104975692-56725780-5a36-11eb-8a3b-c11b89ee98c1.png)

<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
