### PR TITLE
Fix font list radio button keyboard accessibility bug

### DIFF
--- a/src/assets/js/react/components/FontManager/FontListItems.js
+++ b/src/assets/js/react/components/FontManager/FontListItems.js
@@ -286,6 +286,19 @@ export class FontListItems extends Component {
    */
   handleSelectFont = e => {
     this.props.selectFont(e.target.value)
+
+    const installedFonts = document.querySelectorAll('.select-font-name')
+
+    /* Handle font list keyboard accessibility thing */
+    installedFonts.forEach(item => {
+      if (item.value === e.target.value) {
+        item.checked = true
+
+        return
+      }
+
+      item.checked = false
+    })
   }
 
   /**
@@ -337,8 +350,8 @@ export class FontListItems extends Component {
                 {!disableSelectFontName && (
                   <input
                     type='radio'
-                    className='selectFontName'
-                    name='selectFontName'
+                    className='select-font-name'
+                    name={'select-font-name-' + font.id}
                     value={font.id}
                     onChange={e => this.handleSelectFont(e)}
                     onClick={e => e.stopPropagation()}

--- a/src/assets/scss/Component/FontManager/_font-manager.scss
+++ b/src/assets/scss/Component/FontManager/_font-manager.scss
@@ -71,7 +71,7 @@
                 text-align: left;
                 word-break: break-all;
 
-                .selectFontName {
+                .select-font-name {
                   width: 1rem;
                   height: 1rem;
                   margin-right: 0.5rem;

--- a/tests/js-unit/react/components/FontManager/FontListItems.test.js
+++ b/tests/js-unit/react/components/FontManager/FontListItems.test.js
@@ -283,8 +283,9 @@ describe('FontManager - FontListItems.js', () => {
 
     test('render radio button for select font name', () => {
       const wrapper = shallow(<FontListItems {...props} />)
+      const data = 'select-font-name-' + props.fontList[0].id
 
-      expect(wrapper.find('input[name="selectFontName"]').length).toBe(1)
+      expect(wrapper.find(`input[name="${data}"]`).length).toBe(1)
     })
 
     test('render font name', () => {


### PR DESCRIPTION
## Description

Issue: #1195 

To be able to tab through each font in the list and mark it as selected. Should also receive screenreader output on the radio field selector explaining what it is.

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
