### PR TITLE
Update typecast from INT to FLOAT in custom paper size.

### DIFF
--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -805,8 +805,8 @@ class Helper_PDF {
 	 * @since  4.0
 	 */
 	protected function get_paper_size( $size ) {
-		$size[0] = ( $size[2] === 'inches' ) ? (int) $size[0] * 25.4 : (int) $size[0];
-		$size[1] = ( $size[2] === 'inches' ) ? (int) $size[1] * 25.4 : (int) $size[1];
+		$size[0] = ( $size[2] === 'inches' ) ? (float) $size[0] * 25.4 : (float) $size[0];
+		$size[1] = ( $size[2] === 'inches' ) ? (float) $size[1] * 25.4 : (float) $size[1];
 
 		/* tidy up custom paper size array */
 		unset( $size[2] );

--- a/src/Model/Model_Form_Settings.php
+++ b/src/Model/Model_Form_Settings.php
@@ -357,7 +357,7 @@ class Model_Form_Settings extends Helper_Abstract_Model {
 
 		/* Do validation */
 		if ( empty( $sanitized['name'] ) || empty( $sanitized['filename'] ) ||
-			 ( $sanitized['pdf_size'] === 'CUSTOM' && ( (int) $sanitized['custom_pdf_size'][0] === 0 || (int) $sanitized['custom_pdf_size'][1] === 0 ) )
+			 ( $sanitized['pdf_size'] === 'CUSTOM' && ( (float) $sanitized['custom_pdf_size'][0] === 0 || (float) $sanitized['custom_pdf_size'][1] === 0 ) )
 		) {
 			$this->notices->add_error( esc_html__( 'PDF could not be saved. Please enter all required information below.', 'gravity-forms-pdf-extended' ) );
 


### PR DESCRIPTION
## Description
Quick update on custom size data type.
<!-- Describe what you have changed or added. -->
Replace (int) with (float) on Helper_PDF.php and Model_Form_Settings.
<!-- Link to the support ticket(s) where appropriate. -->
Issue  : #1203 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->

1. Add a new PDF to a Form
2. Go to Appearance tab
3. Set the Paper Size to Custom and then the Custom value to 11.25 x 5.52 inches.
4. Save the PDF
5. View a generated PDF from an entry and check the paper size

<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->
FLOAT
![image](https://user-images.githubusercontent.com/434866/110056777-45468700-7d14-11eb-9adb-cb462511121a.png)

INT
![image](https://user-images.githubusercontent.com/434866/110056743-3233b700-7d14-11eb-940f-e2e71814c618.png)

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
