### PR TITLE
Legend Styles on PDF pages don't match Gravity Forms styles

### DIFF
--- a/src/assets/scss/Component/_gf-settings-containers.scss
+++ b/src/assets/scss/Component/_gf-settings-containers.scss
@@ -33,6 +33,10 @@
       font-size: .875rem;
       margin-bottom: 0.25rem;
     }
+
+    .gform-settings-panel__header legend {
+      margin-bottom: 0;
+    }
   }
 
   .gform-settings-panel--collapsible {

--- a/src/assets/scss/Component/_gf-settings-containers.scss
+++ b/src/assets/scss/Component/_gf-settings-containers.scss
@@ -25,10 +25,8 @@
     }
 
     .gform-settings-panel__title {
-      font-weight: bold;
-      color: #23282D;
+      font-size: .875rem;
       margin-bottom: 0.25rem;
-      font-size: 0.8125rem;
     }
   }
 

--- a/src/assets/scss/Component/_gf-settings-containers.scss
+++ b/src/assets/scss/Component/_gf-settings-containers.scss
@@ -22,9 +22,14 @@
 
     .gfpdf-settings-field-wrapper {
       margin-bottom: 1.25rem;
+
+      .gform-settings-panel__title {
+        color: #23282d;
+        font-size: .8125rem;
+      }
     }
 
-    .gform-settings-panel__title {
+    legend {
       font-size: .875rem;
       margin-bottom: 0.25rem;
     }


### PR DESCRIPTION
## Description

Issues: #1189 #1190 

- Match GF style for legend
- Match GF page style for bold/label

## Testing instructions

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
