### PR TITLE
Adjust uninstall Gravity PDF E2E check

### DIFF
--- a/tests/e2e/tabs/tools/uninstall-gravity-pdf-field.test.js
+++ b/tests/e2e/tabs/tools/uninstall-gravity-pdf-field.test.js
@@ -1,4 +1,3 @@
-import { fieldHeaderTitle, fieldDescription } from '../../utilities/page-model/helpers/field'
 import Tools from '../../utilities/page-model/tabs/tools'
 
 const run = new Tools()
@@ -7,12 +6,11 @@ fixture`Tools tab - Uninstall Gravity PDF field test`
 
 test('should display \'Uninstall Gravity PDF\' field', async t => {
   // Actions
-  await run.navigateSettingsTab('gf_settings&subview=PDF&tab=tools#')
-  await t.click(run.uninstallGravityPdfCollapsiblePanel)
+  await run.navigateSettingsTab('gf_settings&subview=uninstall')
 
   // Assertions
   await t
-    .expect(fieldHeaderTitle('Uninstall Gravity PDF').exists).ok()
-    .expect(fieldDescription('This operation deletes ALL Gravity PDF settings and deactivates the plugin. If you continue, all settings, configuration, custom templates and fonts will be removed.', 'p').exists).ok()
+    .expect(run.uninstallPanelTitle.exists).ok()
+    .expect(run.uninstallPanelDescription.exists).ok()
     .expect(run.uninstallGravityPdfButton.exists).ok()
 })

--- a/tests/e2e/utilities/page-model/tabs/tools.js
+++ b/tests/e2e/utilities/page-model/tabs/tools.js
@@ -3,9 +3,6 @@ import { admin, baseURL } from '../../../auth'
 
 class Tools {
   constructor () {
-    // Fieldset collapsible link
-    this.uninstallGravityPdfCollapsiblePanel = Selector('#gfpdf-fieldset-uninstaller').find('[id="gform_settings_section_collapsed_uninstaller"]')
-
     // Install Core Fonts field
     this.downloadCoreFontsButton = Selector('#gfpdf-fieldset-install_core_fonts').find('button').withText('Download Core Fonts')
     this.pendingResult = Selector('.gfpdf-core-font-status-pending')
@@ -15,7 +12,9 @@ class Tools {
     this.retryDownload = Selector('a').withText('Retry Failed Downloads?')
 
     // Uninstall Gravity PDF field
-    this.uninstallGravityPdfButton = Selector('#gfpdf-fieldset-uninstaller').find('button').withText('Uninstall Gravity PDF')
+    this.uninstallPanelTitle = Selector('.addon-uninstall-text').find('h4').withText('Gravity PDF')
+    this.uninstallPanelDescription = Selector('.addon-uninstall-text').find('div').withText('This operation deletes ALL Gravity PDF settings.')
+    this.uninstallGravityPdfButton = Selector('.addon-uninstall-button').find('button').withText('Uninstall')
   }
 
   async navigateSettingsTab (address) {


### PR DESCRIPTION
## Description
Issue: Fix E2E test check for Gravity PDF uninstall option.

<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->

## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
