### PR TITLE
System Status : Add for core template version check.

### DIFF
--- a/src/View/View_System_Report.php
+++ b/src/View/View_System_Report.php
@@ -113,4 +113,34 @@ class View_System_Report extends Helper_Abstract_View {
 
 		return $output;
 	}
+
+	/**
+	 * Prepare message for outdated template file(s)
+	 *
+	 * @param string $path The path to the outdated PDF template file
+	 * @param string $template_version The current version of the outdated PDF template file
+	 * @param string $core_version The latest Core template version
+	 *
+	 * @since 6.0
+	 */
+	public function get_template_check_message( string $path, string $template_version, string $core_version ): array {
+		$message = sprintf( esc_html__( '%1$s version %2$s is out of date. The core version is %3$s', 'gravity-forms-pdf-extended' ), $path, '<span style="color: #ff0000;font-weight:bold">' . $template_version . '</span>', $core_version );
+
+		return [
+			'value'        => $message . $this->get_icon( false ) . '<hr>',
+			'value_export' => wp_strip_all_tags( $message ) . "   &#10008;\n",
+		];
+	}
+
+	/**
+	 * Prepare message on how to update outdated template file(s)
+	 *
+	 * @since 6.0
+	 */
+	public function get_template_upgrade_message(): string {
+		$learn_more_url = 'https://docs.gravitypdf.com/@TODO';
+
+		return $this->markup_warning . ' <a href="' . $learn_more_url . '">' . esc_html__( 'Learn how to update', 'gravity-forms-pdf-extended' ) . '</a>';
+	}
+
 }

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_System_Report.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_System_Report.php
@@ -55,4 +55,22 @@ class Test_Controller_System_Report extends WP_UnitTestCase {
 			[ 3, 'logged_out_timeout' ],
 		];
 	}
+
+	public function test_system_report_outdated_template() {
+		/* verify no outdated template info */
+		$system_report = apply_filters( 'gform_system_report', [] );
+		$this->assertArrayNotHasKey( 'outdated_templates', $system_report[0]['tables'][1]['items'] );
+
+		/* copy core template to override location and adjust version number, then verify outdated message is included */
+		$data          = \GPDFAPI::get_data_class();
+		$override_path = $data->template_location . 'zadani.php';
+
+		$template = file_get_contents( PDF_PLUGIN_DIR . 'src/templates/zadani.php' );
+		file_put_contents( $override_path, preg_replace( '/Version: (.+?)/', 'Version: 1.5.2', $template ) );
+
+		$system_report = apply_filters( 'gform_system_report', [] );
+		$this->assertArrayHasKey( 'outdated_templates', $system_report[0]['tables'][1]['items'] );
+
+		@unlink( $override_path );
+	}
 }


### PR DESCRIPTION
## Description
Create a method that checks for core template version number and compare it with the latest one (2.0.0), make sure that the export function still works as intended.

<!-- Describe what you have changed or added. -->
Added Model_System_Report.get_template_status(), utilize Helper_Templates ability to check for core template's header. I have able to compare the current version using php's version_compare method.
I have updated the View_System_Report as well, as I need to access the warning icon. Created a method for that and update a line which was that property is used.

Added html entities for cross icon on export.

<!-- Link to the support ticket(s) where appropriate. -->
#1221 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
I still need the  correct instruction link for the core template update.