### PR TITLE
Fix font manager 2 columns overlap issue

### DIFF
--- a/src/assets/js/react/components/FontManager/TemplateTooltip.js
+++ b/src/assets/js/react/components/FontManager/TemplateTooltip.js
@@ -2,6 +2,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { sprintf } from 'sprintf-js'
+/* Utilities */
+import { adjustFontListHeight } from '../../utilities/FontManager/adjustFontListHeight'
 
 /**
  * @package     Gravity PDF
@@ -38,6 +40,8 @@ export class TemplateTooltip extends React.Component {
    */
   handleDisplayInfo = () => {
     this.setState({ tooltip: !this.state.tooltip })
+
+    setTimeout(() => adjustFontListHeight(), 100)
   }
 
   /**


### PR DESCRIPTION
## Description
Issue: With the new tooltip under font manager, font list column height needs to be automatically adjusted to avoid overlapping issue with update font column. (Screenshot attached)

<!-- Describe what you have changed or added. -->
<!-- Link to the support ticket(s) where appropriate. -->

## Testing instructions
**Step To Reproduce**
Steps to reproduce the behavior:
1. Go to Font Manager
2. Click/Open a font
3. Expand tooltip by clicking 'View template usage'
4. Click 'Cancel' button

<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->
![1](https://user-images.githubusercontent.com/10412650/111938239-84424e00-8b04-11eb-8b87-d07e50d3d157.png)
![2](https://user-images.githubusercontent.com/10412650/111938242-85737b00-8b04-11eb-8de6-2f7c347f262c.png)


## Checklist:
- [x] I've tested the code.
- [ ] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
