### PR TITLE
Enable Conditional Logic settings by default.

### DIFF
--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -567,6 +567,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 				'name' => esc_html__( 'Show Form Title', 'gravity-forms-pdf-extended' ),
 				'desc' => esc_html__( 'Display the form title at the beginning of the PDF.', 'gravity-forms-pdf-extended' ),
 				'type' => 'toggle',
+				'std'  => 'Yes',
 			]
 		);
 	}

--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -643,6 +643,7 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 				'name' => esc_html__( 'Enable Conditional Logic', 'gravity-forms-pdf-extended' ),
 				'desc' => esc_html__( 'When enabled the PDF will adhere to the form field conditional logic and show/hide fields.', 'gravity-forms-pdf-extended' ),
 				'type' => 'toggle',
+				'std'  => 'Yes',
 			]
 		);
 	}


### PR DESCRIPTION
## Description
Since the introduction of toggle which replace the radio type. I noticed that we forgot to set the default value for Enable Logic.

<!-- Describe what you have changed or added. -->
Add default value for this field / std => 'Yes',  based on the field settings in v5.
<!-- Link to the support ticket(s) where appropriate. -->
#1255 
## Testing instructions
<!-- Add instructions to help the reviewer test your code. -->
<!-- Include sample forms, add-ons or snippets where appropriate. -->

## Screenshots <!-- if applicable -->

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->

## Additional Comments <!-- if applicable -->
