### PR TITLE
Prevent 6.0 update if dependancies not met, and show any v5 updates

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://gravitypdf.com/donate-to-plugin/
 Tags: gravity, forms, pdf, automation, attachment, email
 Requires at least: 4.8
 Tested up to: 5.7
-Stable tag: 5.3.4
+Stable tag: 5.4.0
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl.txt
@@ -89,6 +89,10 @@ Also, if you enjoy using the software [we'd love it if you could give us a revie
 18. Blank Slate provides a print-friendly template focusing solely on the user-submitted data.
 
 == Changelog ==
+
+= 5.4.0=
+* Feature: Prevent update to 6.0 if minimum requirements are not met (including when automatic updates enabled)
+* Feature: Show/allow any new updates for 5.x if minimum requirements are not met for 6.0
 
 = 5.3.4 =
 * Security: Resolve XSS issue on PDF List page

--- a/pdf.php
+++ b/pdf.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Gravity PDF
-Version: 5.3.4
+Version: 5.4.0
 Description: Automatically generate highly-customisable PDF documents using Gravity Forms.
 Author: Gravity PDF
 Author URI: https://gravitypdf.com
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /*
  * Set base constants we'll use throughout the plugin
  */
-define( 'PDF_EXTENDED_VERSION', '5.3.4' ); /* the current plugin version */
+define( 'PDF_EXTENDED_VERSION', '5.4.0' ); /* the current plugin version */
 define( 'PDF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); /* plugin directory path */
 define( 'PDF_PLUGIN_URL', plugin_dir_url( __FILE__ ) ); /* plugin directory url */
 define( 'PDF_PLUGIN_BASENAME', plugin_basename( __FILE__ ) ); /* the plugin basename */

--- a/src/Controller/Controller_Update_Dependency_Manager.php
+++ b/src/Controller/Controller_Update_Dependency_Manager.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use GFPDF\Helper\Helper_Abstract_Controller;
+use GFPDF\View\View_Update_Dependency_Manager;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2021, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Controller_Update_Dependency_Manager
+ *
+ * @package GFPDF\Controller
+ */
+class Controller_Update_Dependency_Manager extends Helper_Abstract_Controller {
+
+	/**
+	 * @var View_Update_Dependency_Manager
+	 * @since 5.4
+	 */
+	public $view;
+
+	/**
+	 * @var string Current WordPress version
+	 * @since 5.4
+	 */
+	protected $wp_version;
+
+	/**
+	 * @var string Current PHP version
+	 * @since 5.4
+	 */
+	protected $php_version;
+
+	/**
+	 * @var string Current Gravity Forms version
+	 * @since 5.4
+	 */
+	protected $gf_version;
+
+	/**
+	 * @var string Current plugin version
+	 * @since 5.4
+	 */
+	protected $plugin_version;
+
+	public function __construct( View_Update_Dependency_Manager $view, $php_version, $wp_version, $gf_version, $plugin_version ) {
+		$this->view           = $view;
+		$this->wp_version     = $wp_version;
+		$this->php_version    = $php_version;
+		$this->gf_version     = $gf_version;
+		$this->plugin_version = $plugin_version;
+	}
+
+	/**
+	 * @since 5.4
+	 */
+	public function init() {
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'pre_set_site_transient' ] );
+		add_filter( 'after_plugin_row_' . PDF_PLUGIN_BASENAME, [ $this, 'after_plugin_row' ], 10, 2 );
+	}
+
+	/**
+	 * Prevents major version update if not currently compatible, while still allowing current major version updates
+	 *
+	 * @param array $value
+	 *
+	 * @return array
+	 *
+	 * @since 5.4
+	 */
+	public function pre_set_site_transient( $value ) {
+
+		/* don't do anything if Gravity PDF update not available */
+		if ( ! isset( $value->response[ PDF_PLUGIN_BASENAME ] ) && ! isset( $value->no_update[ PDF_PLUGIN_BASENAME ] ) ) {
+			return $value;
+		}
+
+		$plugin = isset( $value->response[ PDF_PLUGIN_BASENAME ] ) ? $value->response[ PDF_PLUGIN_BASENAME ] : $value->no_update[ PDF_PLUGIN_BASENAME ];
+
+		/* Do nothing if update for v5 */
+		if ( version_compare( $plugin->new_version, '6.0.0', '<' ) ) {
+			return $value;
+		}
+
+		/*
+		 * Move the plugin to the `no_update` list if the current Gravity Forms version isn't compatible with v6
+		 *
+		 * We check if the PHP version is valid because WordPress will already stop updates and show an error message if it is not.
+		 * We don't check for the WP version because it'll already be in the `no_update` list if it isn't compatible.
+		 */
+		if (
+			! isset( $value->no_update[ PDF_PLUGIN_BASENAME ] ) &&
+			version_compare( $plugin->new_version, '7.0.0', '<' ) &&
+			$this->is_php_compatible( '7.3.0' ) &&
+			! $this->is_gf_compatible( '2.5' )
+		) {
+			/* Not compatible, so move to the no_update list */
+			$value->no_update[ PDF_PLUGIN_BASENAME ] = $plugin;
+			unset( $value->response[ PDF_PLUGIN_BASENAME ] );
+		}
+
+		/*
+		 * If there's an update for the plugin, but we don't meet the minimum requirements, check if there's one available
+		 * for the current major version (5.x.x) that the user could update to instead.
+		 *
+		 * This allows us to support two major versions at the same time
+		 */
+		$update = isset( $value->no_update[ PDF_PLUGIN_BASENAME ] ) ? $this->has_update_for_current_major_version( $value->no_update[ PDF_PLUGIN_BASENAME ]->new_version ) : false;
+
+		if ( is_array( $update ) ) {
+			$plugin              = $value->no_update[ PDF_PLUGIN_BASENAME ];
+			$plugin->new_version = $update[0];
+			$plugin->package     = $update[1];
+			unset( $plugin->requires_php );
+			unset( $plugin->upgrade_notice );
+
+			$value->response[ PDF_PLUGIN_BASENAME ] = $plugin;
+			unset( $value->no_update[ PDF_PLUGIN_BASENAME ] );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Show error message on plugin list page if minimum requirements a new major version have not been met
+	 *
+	 * @param string $file
+	 * @param array  $plugin
+	 *
+	 * @since 5.4
+	 */
+	public function after_plugin_row( $file, $plugin ) {
+		/* Do nothing if update for v5 or lower */
+		if ( version_compare( $plugin['new_version'], '6.0.0', '<' ) ) {
+			return;
+		}
+
+		/* Handle v6 minimum requirement checks */
+		if ( version_compare( $plugin['new_version'], '7.0.0', '<' ) ) {
+			/* If current PHP isn't compatible let WordPress handle the error message */
+			if ( ! $this->is_php_compatible( '7.3.0' ) ) {
+				return;
+			}
+
+			$error_message = esc_html__( 'There is a new version of %1$s available, but it doesn&#8217;t work with your version of %2$s.', 'gravity-forms-pdf-extended' );
+
+			/* Display error if current Gravity Forms isn't compatible */
+			if ( ! $this->is_gf_compatible( '2.5.0' ) ) {
+				$this->view->plugin_list_error(
+					[
+						'message' => sprintf( $error_message, $plugin['Name'], 'Gravity Forms' ),
+						'plugin'  => $plugin,
+					]
+				);
+
+				return;
+			}
+
+			/* Display error if current WordPress isn't compatible */
+			if ( ! $this->is_wp_compatible( '5.3' ) ) {
+				$this->view->plugin_list_error(
+					[
+						'message' => sprintf( $error_message, $plugin['Name'], 'WordPress' ),
+						'plugin'  => $plugin,
+					]
+				);
+
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Check if there's a new update available on the current major version, provided the user is on an older major version
+	 *
+	 * @param string $new_available_version Latest version of the plugin, as retrieved by WP.org
+	 *
+	 * @return array|false
+	 *
+	 * @since 5.4
+	 */
+	protected function has_update_for_current_major_version( $new_available_version ) {
+
+		$current_version_array       = explode( '.', $this->plugin_version );
+		$new_available_version_array = explode( '.', $new_available_version );
+
+		/* If the major version is the same for the current version and new available version, don't check for an update */
+		if ( $current_version_array[0] === $new_available_version_array[0] ) {
+			return false;
+		}
+
+		$slug     = dirname( PDF_PLUGIN_BASENAME );
+		$response = wp_remote_get( 'https://api.wordpress.org/plugins/info/1.0/' . $slug . '.json' );
+		if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
+			return false;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( empty( $body['versions'] ) || ! is_array( $body['versions'] ) ) {
+			return false;
+		}
+
+		/* Get the first matching tag for the current major release and url (the latest) */
+		foreach ( array_reverse( $body['versions'] ) as $update_version => $download_url ) {
+			$update_version_array = explode( '.', $update_version );
+			if ( $update_version_array[0] === $current_version_array[0] ) {
+				break;
+			}
+		}
+
+		if ( version_compare( $update_version, $this->plugin_version, '>' ) ) {
+			return [ $update_version, $download_url ];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the current WP version exceeds $version
+	 *
+	 * @param string $version
+	 *
+	 * @return bool
+	 *
+	 * @since 5.4
+	 */
+	protected function is_wp_compatible( $version ) {
+		return version_compare( $this->wp_version, $version, '>=' );
+	}
+
+	/**
+	 * Check if the current GF version exceeds $version
+	 *
+	 * @param string $version
+	 *
+	 * @return bool
+	 *
+	 * @since 5.4
+	 */
+	protected function is_gf_compatible( $version ) {
+		return version_compare( $this->gf_version, $version, '>=' );
+	}
+
+	/**
+	 * Check if the current PHP version exceeds $version
+	 *
+	 * @param string $version
+	 *
+	 * @return bool
+	 *
+	 * @since 5.4
+	 */
+	protected function is_php_compatible( $version ) {
+		return version_compare( $this->php_version, $version, '>=' );
+	}
+}

--- a/src/View/View_Update_Dependency_Manager.php
+++ b/src/View/View_Update_Dependency_Manager.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace GFPDF\View;
+
+use GFPDF\Helper\Helper_Abstract_View;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2021, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class View_Update_Dependency_Manager
+ *
+ * @package GFPDF\View
+ */
+class View_Update_Dependency_Manager extends Helper_Abstract_View {
+
+	/**
+	 * Set the view's name
+	 *
+	 * @var string
+	 *
+	 * @since 5.4
+	 */
+	protected $view_type = 'UpdateDependencyManager';
+}

--- a/src/View/html/UpdateDependencyManager/plugin_list_error.php
+++ b/src/View/html/UpdateDependencyManager/plugin_list_error.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Plugin List Error Message
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2021, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       5.4
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** @var $args array */
+
+$message = $args['message'];
+$plugin  = $args['plugin'];
+
+$details_url = self_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $plugin['slug'] . '&section=changelog&TB_iframe=true&width=600&height=800' );
+
+?>
+
+<tr class="plugin-update-tr active" id="<?= esc_attr( $plugin['slug'] ) ?>-update" data-slug="<?= esc_attr( $plugin['slug'] ) ?>" data-plugin="<?= esc_attr( $plugin['plugin'] ) ?>">
+	<td colspan="4" class="plugin-update colspanchange">
+		<div class="update-message notice inline notice-error notice-alt">
+			<p>
+				<?= $message ?>
+
+				<a href="<?= esc_url( $details_url ) ?>"
+				   class="thickbox open-plugin-details-modal"
+				   aria-label="<?= esc_attr( sprintf( __( 'View %1$s version %2$s details', 'default' ), $plugin['Name'], $plugin['new_version'] ) ) ?>">
+					<?= sprintf( esc_html__( 'View version %s details', 'default' ), $plugin['new_version'] ) ?>
+				</a>
+			</p>
+		</div>
+	</td>
+</tr>

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -215,6 +215,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$this->load_core_font_handler();
 		$this->load_debug();
 		$this->check_system_status();
+		$this->update_dependency_manager();
 
 		/* Add localisation support */
 		$this->add_localization_support();
@@ -888,6 +889,19 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 		$class = new Controller\Controller_System_Report( $this->data->allow_url_fopen );
 		$class->init();
 
+		$this->singleton->add_class( $class );
+	}
+
+	/**
+	 * @since 5.4
+	 *
+	 * @return void
+	 */
+	public function update_dependency_manager() {
+		$view  = new View\View_Update_Dependency_Manager( [] );
+		$class = new Controller\Controller_Update_Dependency_Manager( $view, PHP_VERSION, $GLOBALS['wp_version'], \GFForms::$version, PDF_EXTENDED_VERSION );
+
+		$class->init();
 		$this->singleton->add_class( $class );
 	}
 

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Update_Dependency_Manager.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Update_Dependency_Manager.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace GFPDF\Controller;
+
+use GFPDF\View\View_Update_Dependency_Manager;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2021, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Class Test_Controller_Update_Dependency_Manager
+ *
+ * @package GFPDF\Controller
+ *
+ * @group   update-dependency-manager
+ */
+class Test_Controller_Update_Dependency_Manager extends WP_UnitTestCase {
+
+	/**
+	 * @var View_Update_Dependency_Manager
+	 */
+	protected $view;
+
+	protected $site_transient_value_update;
+	protected $site_transient_value_no_update;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->view = new View_Update_Dependency_Manager( [] );
+
+		$plugin                 = new \stdClass();
+		$plugin->new_version    = '6.0.0';
+		$plugin->package        = '6.0.0.zip';
+		$plugin->requires_php   = '7.4';
+		$plugin->upgrade_notice = 'This is a major release.';
+
+		$site_transient_value            = new \stdClass();
+		$site_transient_value->response  = [];
+		$site_transient_value->no_update = [];
+
+		$this->site_transient_value_update    = clone $site_transient_value;
+		$this->site_transient_value_no_update = clone $site_transient_value;
+
+		$this->site_transient_value_update->response[ PDF_PLUGIN_BASENAME ]     = $plugin;
+		$this->site_transient_value_no_update->no_update[ PDF_PLUGIN_BASENAME ] = $plugin;
+	}
+
+	public function tearDown() {
+		remove_all_filters( 'pre_http_request' );
+
+		parent::tearDown();
+	}
+
+	protected function deepClone( $object ) {
+		return unserialize( serialize( $object ) );
+	}
+
+	public function test_pre_set_site_transient() {
+		add_filter( 'pre_http_request', '__return_true' );
+		$controller = new Controller_Update_Dependency_Manager( $this->view, '7.4', '5.7', '2.5', '5.4' );
+
+		/* Test we exit very early if no update available */
+		$this->assertNull( $controller->pre_set_site_transient( null ) );
+
+		/* Test we exit early if the update is for v5 */
+		$transient = $this->deepClone( $this->site_transient_value_update );
+		$transient->response[ PDF_PLUGIN_BASENAME ]->new_version = '5.4.0';
+
+		$this->assertSame( $transient, $controller->pre_set_site_transient( $transient ) );
+
+		/* Test we don't make any changes if the update is compatible */
+		$this->assertEquals( $this->site_transient_value_update, $controller->pre_set_site_transient( $this->site_transient_value_update ) );
+
+		/* Test we move the plugin to the no_update list when not compatible (GF) */
+		$controller = new Controller_Update_Dependency_Manager( $this->view, '7.4', '5.7', '2.4', '5.4' );
+		$this->assertEquals( $this->site_transient_value_no_update, $controller->pre_set_site_transient( $this->site_transient_value_update ) );
+
+		/* Test we move the plugin to the no_update list when not compatible (WP) */
+		$controller = new Controller_Update_Dependency_Manager( $this->view, '7.4', '5.0', '2.5', '5.8' );
+		$this->assertEquals( $this->site_transient_value_no_update, $controller->pre_set_site_transient( $this->site_transient_value_update ) );
+
+		/* Test we move the plugin to the update list if new minor or patch available when major update not compatible */
+		remove_filter( 'pre_http_request', '__return_true' );
+		add_filter(
+			'pre_http_request',
+			function( $pre, $parsed_args, $url ) {
+				return [
+					'response' => [
+						'code' => 200,
+					],
+
+					'body'     => json_encode(
+						[
+							'versions' => [
+								'5.5' => 'current-major-download.zip',
+							],
+						]
+					),
+				];
+			},
+			10,
+			3
+		);
+
+		$controller = new Controller_Update_Dependency_Manager( $this->view, '7.4', '5.0', '2.5', '5.2' );
+		$output     = $controller->pre_set_site_transient( $this->site_transient_value_no_update );
+
+		$this->assertSame( '5.5', $output->response[ PDF_PLUGIN_BASENAME ]->new_version );
+		$this->assertSame( 'current-major-download.zip', $output->response[ PDF_PLUGIN_BASENAME ]->package );
+	}
+
+	public function test_after_plugin_row() {
+		/* Test for no output when version 5 update */
+		$controller = new Controller_Update_Dependency_Manager( $this->view, '7.2', '5.0', '2.5', '5.2' );
+		$this->assertNull( $controller->after_plugin_row( '', [ 'new_version' => '5.0.0' ] ) );
+
+		/* Test for no output when PHP not compatible (handled by WP) */
+		$controller = new Controller_Update_Dependency_Manager( $this->view, '7.2', '5.0', '2.5', '5.2' );
+		$this->assertNull( $controller->after_plugin_row( '', [ 'new_version' => '6.0.0' ] ) );
+
+		/* Test for output when WP not compatible */
+		$controller = new Controller_Update_Dependency_Manager( $this->view, '7.4', '5.0', '2.5', '5.2' );
+		ob_start();
+		$controller->after_plugin_row(
+			'',
+			[
+				'plugin'      => '',
+				'Name'        => '',
+				'slug'        => '',
+				'new_version' => '6.0.0',
+			]
+		);
+
+		$this->assertNotFalse( strpos( ob_get_clean(), 'There is a new version' ) );
+
+		/* Test for output when GF not compatible */
+		$controller = new Controller_Update_Dependency_Manager( $this->view, '7.4', '5.7', '2.4', '5.2' );
+		ob_start();
+		$controller->after_plugin_row(
+			'',
+			[
+				'plugin'      => '',
+				'Name'        => '',
+				'slug'        => '',
+				'new_version' => '6.0.0',
+			]
+		);
+
+		$this->assertNotFalse( strpos( ob_get_clean(), 'There is a new version' ) );
+	}
+}


### PR DESCRIPTION
## Description

This update will help alleviate problems with the 6.0 rollout by preventing sites being updated if they don't meet the minimum requirements. 

## Testing instructions
1. Install GF2.4
2. Go to Dashboard -> Updates and force an update check
3. Go to Plugins -> Installed Plugins page
4. See a notice about the 6.0 release being available, but requirements not me
5. Downgrade PHP or WordPress will do a similar thing

## Checklist:
- [X] I've tested the code.
- [X] My code is easy to read, follow, and understand
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation / docblocks. <!-- Guidelines: http://docs.phpdoc.org/references/phpdoc/basic-syntax.html -->