### PR TITLE
Detect and warn about deprecated v3 functionality ahead of 7.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -49,8 +49,11 @@ yarn test:e2e:debug      # Open Playwright UI for interactive debugging
 ```
 
 E2E tests live in `tests/playwright/` and run against a single wp-env instance on port 8702. Permalink mode is flipped per Playwright project group via `tools/playwright/global-setup.ts` (which shells out to `wp-env run cli wp option update permalink_structure`):
-- `core` project — runs `core/*` and `permalinks/*` tests under plain permalinks.
-- `core-with-permalinks` project — re-runs `permalinks/*` tests under `/%postname%/` permalinks. Depends on `core` so it runs serially after the plain-permalink pass completes.
+- `core` project — runs `core/*` and `permalinks/*` tests under plain permalinks, less whatever `core-isolated` claims.
+- `core-isolated` project — specs whose fixtures change site-wide state the rest of the suite can observe (currently `core/system-status/*`, which raises an admin notice on every page the other snapshots are taken on). Depends on `core`, so nothing else is in flight while their state is live. `test.describe.configure({ mode: 'serial' })` only orders a single file and is not enough on its own.
+- `core-with-permalinks` project — re-runs `permalinks/*` tests under `/%postname%/` permalinks. Depends on `core-isolated` so it runs serially after the plain-permalink pass completes.
+
+Filters only narrow the projects you name: a project pulled in as a `dependency` runs in full regardless of `--grep` or a file filter. So a bare `yarn test:e2e -- <filter>` still runs everything, while `npx playwright test --config=tools/playwright/config.ts --project=core <filter>` runs just that slice plus `setup-core`. `--no-deps` isolates a project completely, but skipping `setup-core` leaves no storage state, so anything using `requestUtils` fails on auth.
 
 In CI, Playwright is sharded 4-ways via `--shard=N/4` (see `.github/workflows/playwright-e2e.yml`); each shard runs all setup projects against its own wp-env instance and executes its slice of the consumer projects' tests.
 

--- a/pdf.php
+++ b/pdf.php
@@ -500,7 +500,9 @@ if ( ! class_exists( 'GFPDF_Major_Compatibility_Checks' ) ) {
 		 * @since 6.12
 		 * @deprecated
 		 */
-		public function maybe_display_canonical_plugin_notice() {}
+		public function maybe_display_canonical_plugin_notice() {
+			_deprecated_function( __METHOD__, '6.12' );
+		}
 
 		/**
 		 * Notify administrator they are not using the canonical version of Gravity PDF
@@ -510,7 +512,9 @@ if ( ! class_exists( 'GFPDF_Major_Compatibility_Checks' ) ) {
 		 * @since 6.12
 		 * @deprecated
 		 */
-		public function maybe_display_canonical_plugin_notice_below_plugin( $plugin_file, $plugin_data ) {}
+		public function maybe_display_canonical_plugin_notice_below_plugin( $plugin_file, $plugin_data ) {
+			_deprecated_function( __METHOD__, '6.12' );
+		}
 	}
 }
 

--- a/src/Controller/Controller_Actions.php
+++ b/src/Controller/Controller_Actions.php
@@ -10,6 +10,7 @@ use GFPDF\Helper\Helper_Form;
 use GFPDF\Helper\Helper_Interface_Actions;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Model\Model_Actions;
+use GFPDF\Statics\Deprecation;
 use GFPDF\View\View_Actions;
 use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
@@ -119,6 +120,10 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 * condition: The function or method to call to determine if a notice should be displayed (Boolean)
 	 * process: The function to handle a successful action. On success the disable_route() method should be called
 	 * view: The function used to display the notice content
+	 * view_class: Optional classes for the notice box, including a `notice-*` state like `notice-warning`
+	 * dismiss: Optional function to call when the notice is dismissed, instead of dismissing the route's own
+	 *          action ID. A route that supplies one records the dismissal wherever it likes, so it also owns
+	 *          suppressing itself afterwards through `condition`
 	 *
 	 * @return array
 	 *
@@ -126,20 +131,55 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 */
 	public function get_routes() {
 
-		$routes = [
+		$routes = array_merge(
 			[
-				'action'      => 'install_core_fonts',
-				'action_text' => esc_html__( 'Install Core Fonts', 'gravity-pdf' ),
-				'condition'   => [ $this->model, 'core_font_condition' ],
-				'process'     => [ $this->model, 'core_font_redirect' ],
-				'view'        => [ $this->view, 'core_font' ],
-				'capability'  => 'gravityforms_edit_settings',
+				[
+					'action'      => 'install_core_fonts',
+					'action_text' => esc_html__( 'Install Core Fonts', 'gravity-pdf' ),
+					'condition'   => [ $this->model, 'core_font_condition' ],
+					'process'     => [ $this->model, 'core_font_redirect' ],
+					'view'        => [ $this->view, 'core_font' ],
+					'capability'  => 'gravityforms_edit_settings',
+				],
 			],
-		];
+			$this->get_deprecated_feature_routes()
+		);
 
 		/* See https://docs.gravitypdf.com/developers/filters/gfpdf_one_time_action_routes for more details about this filter */
 
 		return apply_filters( 'gfpdf_one_time_action_routes', $routes );
+	}
+
+	/**
+	 * Build the one notice route covering every deprecated feature in use
+	 *
+	 * One notice rather than one per feature: five separate warnings on the same admin screen is noise a reader
+	 * learns to scroll past. Dismissing it records each feature it listed, so silencing today's list says nothing
+	 * about the next round of removals — that arrives undismissed and raises the notice again. Site Health keeps
+	 * the whole picture either way, so nothing here is the last word on a feature.
+	 *
+	 * The condition reads what was recorded the last time deprecated functionality was detected, rather than
+	 * detecting for itself — see Deprecation::get_detected_features().
+	 *
+	 * @return array
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_feature_routes(): array {
+		return [
+			[
+				'action'      => 'deprecated_features',
+				'action_text' => esc_html__( 'View the system report', 'gravity-pdf' ),
+				'condition'   => [ $this->model, 'has_deprecated_features' ],
+				'process'     => [ $this->model, 'system_report_redirect' ],
+				/* One notice covers them all, so dismissing it dismisses each feature it was listing */
+				'dismiss'     => [ $this->model, 'dismiss_deprecated_features' ],
+				'view'        => function ( $action, $button_text ) {
+					return $this->view->deprecated_features( $this->model->get_undismissed_deprecated_features(), $action, $button_text );
+				},
+				'view_class'  => $this->model->has_unsupported_deprecated_feature() ? 'notice-error' : 'notice-warning',
+				'capability'  => 'gravityforms_view_settings',
+			],
+		];
 	}
 
 	/**
@@ -158,6 +198,11 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 			return null;
 		}
 
+		/* Don't run the route conditions, which query the database, on pages that discard the notice anyway */
+		if ( ! $this->notices->can_display_notice_on_this_page() ) {
+			return null;
+		}
+
 		foreach ( $this->get_routes() as $route ) {
 
 			/* Before displaying check the user has the correct capabilities, the notice isn't already been dismissed and the route condition has been met */
@@ -173,8 +218,10 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 					]
 				);
 
-				$class = ( isset( $route['view_class'] ) ) ? $route['view_class'] : '';
-				$this->notices->add_notice( call_user_func( $route['view'], $route['action'], $route['action_text'] ), $class );
+				$this->notices->add_notice(
+					call_user_func( $route['view'], $route['action'], $route['action_text'] ),
+					$route['view_class'] ?? ''
+				);
 			}
 		}
 	}
@@ -187,6 +234,11 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 * @since 4.0
 	 */
 	public function route() {
+
+		/* Runs on every admin_init, including ajax, and the route table costs more to build than this check */
+		if ( rgpost( 'gfpdf_action' ) === '' ) {
+			return;
+		}
 
 		foreach ( $this->get_routes() as $route ) {
 
@@ -225,7 +277,11 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 						]
 					);
 
-					$this->model->dismiss_notice( $route['action'] );
+					if ( isset( $route['dismiss'] ) ) {
+						call_user_func( $route['dismiss'] );
+					} else {
+						$this->model->dismiss_notice( $route['action'] );
+					}
 				} else {
 					$this->log->notice(
 						'Trigger Action Process.',

--- a/src/Controller/Controller_Install.php
+++ b/src/Controller/Controller_Install.php
@@ -206,6 +206,6 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 	 * @deprecated 6.0
 	 */
 	public function maybe_uninstall() {
-		_doing_it_wrong( __METHOD__, 'This method has been moved to Controller_Uninstall::uninstall_addon()', '6.0' );
+		_deprecated_function( __METHOD__, '6.0', 'Controller_Uninstall::uninstall_addon()' );
 	}
 }

--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -11,6 +11,7 @@ use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_PDF;
 use GFPDF\Model\Model_PDF;
 use GFPDF\Statics\Debug;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF\View\View_PDF;
 use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
@@ -204,7 +205,7 @@ class Controller_PDF extends Helper_Abstract_Controller {
 		add_filter( 'gfpdf_pdf_html_output', $add_view_html_debugger, 9999, 5 );
 
 		/* Backwards compatibility for our Tier 2 plugin */
-		add_filter( 'gfpdfe_pre_load_template', [ 'PDFRender', 'prepare_ids' ], 1, 8 );
+		add_filter( 'gfpdfe_pre_load_template', Deprecation_V3::INTERNAL_FILTER_CALLBACK, 1, 8 );
 
 		/* Pre-process our template arguments and automatically render them in PDF */
 		add_filter( 'gfpdf_template_args', [ $this->model, 'preprocess_template_arguments' ] );
@@ -240,7 +241,7 @@ class Controller_PDF extends Helper_Abstract_Controller {
 	 * add print dialog -> https://example.com/pdf/66307560bcdf4/2403/?print=1
 	 *
 	 * Recommend you generate the URL with a shortcode or merge tag
-	 * See https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags
+	 * See https://docs.gravitypdf.com/upgrade/legacy-download-urls/
 	 *
 	 * This method runs just before the main WP_Query class is executed
 	 *
@@ -292,7 +293,7 @@ class Controller_PDF extends Helper_Abstract_Controller {
 			return null;
 		}
 
-		_doing_it_wrong( __METHOD__, 'Legacy PDF URLs are deprecated. Replace with the [gravitypdf] shortcode or PDF merge tags. See https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags for usage instructions.', '4.0' );
+		_deprecated_function( __METHOD__, '4.0', 'the [gravitypdf] shortcode or PDF merge tags, https://docs.gravitypdf.com/upgrade/legacy-download-urls/' );
 
 		$config = [
 			'lid'      => (int) explode( ',', $_GET['lid'] )[0],
@@ -310,6 +311,9 @@ class Controller_PDF extends Helper_Abstract_Controller {
 			$this->pdf_error( $pid );
 		}
 
+		/* Report the form from now on, whether or not the URL itself lives anywhere the form scan can find it */
+		Deprecation_V3::record_legacy_endpoint_usage( $config['fid'] );
+
 		/* Store our ids in the WP query_vars object */
 		$GLOBALS['wp']->query_vars['gpdf'] = 1;
 		$GLOBALS['wp']->query_vars['pid']  = $pid;
@@ -323,7 +327,7 @@ class Controller_PDF extends Helper_Abstract_Controller {
 			]
 		);
 
-		$this->log->warning( 'Legacy PDF URLs are deprecated. Replace with the [gravitypdf] shortcode or PDF merge tags. See https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags for usage instructions.' );
+		$this->log->warning( sprintf( 'Legacy download URLs are removed in Gravity PDF %s. Replace with the [gravitypdf] shortcode or PDF merge tags. See https://docs.gravitypdf.com/upgrade/legacy-download-urls/ for upgrade instructions.', Deprecation_V3::REMOVED_IN ) );
 
 		/* Send to our model to handle validation / authentication */
 		do_action( 'gfpdf_legacy_pre_view_or_download_pdf', $config['lid'], $pid, $config['action'] );
@@ -399,7 +403,7 @@ class Controller_PDF extends Helper_Abstract_Controller {
 	 * @deprecated 6.12 All buffers are auto-closed before a PDF is sent to the browser
 	 */
 	public function sgoptimizer_html_minification_fix() {
-		_doing_it_wrong( __METHOD__, 'This method has been removed and no alternative is available.', '6.12' );
+		_deprecated_function( __METHOD__, '6.12' );
 	}
 
 	/**

--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -241,7 +241,7 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 */
 	public function queue_dispatch_resend_notification_tasks( $form = null, $entry = null ) {
 		if ( ! is_null( $entry ) ) {
-			_doing_it_wrong( __METHOD__, '$entry argument ignored and now set in self::should_send_async_notification()', '6.13.5' );
+			_deprecated_argument( __METHOD__, '6.13.5', 'The $entry argument is ignored and now set in self::should_send_async_notification()' );
 		}
 
 		/* loop over all form/entries */
@@ -305,7 +305,7 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 * @deprecated 6.12.0 Caching layer + auto-purge added
 	 */
 	public function queue_cleanup_task( $form, $entry ) {
-		_doing_it_wrong( __METHOD__, 'This method is deprecated and no alternative is available. The temporary cache is automatically cleaned every hour using the WP Cron.', '6.12' );
+		_deprecated_function( __METHOD__, '6.12' );
 	}
 
 	/**
@@ -516,6 +516,6 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 * @deprecated 6.11
 	 */
 	public function queue_async_resend_notification_tasks( $notification, $form, $entry ) {
-		_doing_it_wrong( esc_html( 'queue_async_resend_notification_tasks() was removed in Gravity PDF 6.11' ) );
+		_deprecated_function( __METHOD__, '6.11' );
 	}
 }

--- a/src/Controller/Controller_System_Report.php
+++ b/src/Controller/Controller_System_Report.php
@@ -3,10 +3,12 @@
 namespace GFPDF\Controller;
 
 use GFPDF\Helper\Helper_Abstract_Controller;
+use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Abstract_Model;
 use GFPDF\Helper\Helper_Abstract_View;
 use GFPDF\Model\Model_System_Report;
 use GFPDF\View\View_System_Report;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -38,12 +40,23 @@ class Controller_System_Report extends Helper_Abstract_Controller {
 	 */
 	public $view;
 
-	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view ) {
+	/**
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
+	 *
+	 * @var Helper_Abstract_Form
+	 *
+	 * @since 6.17.0
+	 */
+	protected $gform;
+
+	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view, Helper_Abstract_Form $gform ) {
 		$this->model = $model;
 		$this->model->setController( $this );
 
 		$this->view = $view;
 		$this->view->setController( $this );
+
+		$this->gform = $gform;
 	}
 
 	/**
@@ -62,6 +75,61 @@ class Controller_System_Report extends Helper_Abstract_Controller {
 	 */
 	public function add_filters() {
 		add_filter( 'gform_system_report', [ $this, 'system_report' ] );
+		add_filter( 'site_status_tests', [ $this, 'site_status_tests' ] );
+		add_filter( 'debug_information', [ $this, 'debug_information' ] );
+	}
+
+	/**
+	 * Register a Site Health test for any deprecated functionality in use on this site
+	 *
+	 * The admin notice can be dismissed for good, and the Gravity Forms system report has to be sought out. This
+	 * puts the same detections where WordPress reports the rest of a site's problems, and keeps them there until
+	 * they're fixed.
+	 *
+	 * @param array $tests
+	 *
+	 * @return array
+	 * @since 6.17.0
+	 */
+	public function site_status_tests( $tests ) {
+		if ( ! is_array( $tests ) || ! $this->gform->has_capability( 'gravityforms_view_settings' ) ) {
+			return $tests;
+		}
+
+		$tests['direct']['gravity_pdf_deprecated_features'] = [
+			'label' => esc_html__( 'Deprecated Gravity PDF functionality', 'gravity-pdf' ),
+			'test'  => [ $this, 'deprecated_features_test' ],
+		];
+
+		return $tests;
+	}
+
+	/**
+	 * Run the deprecated functionality Site Health test
+	 *
+	 * @return array
+	 * @since 6.17.0
+	 */
+	public function deprecated_features_test() {
+		return $this->view->get_deprecated_features_test( Deprecation::refresh_signals() );
+	}
+
+	/**
+	 * Add the deprecated functionality to the Site Health Info tab
+	 *
+	 * The Info tab is what users copy into a support ticket, so the detections travel with it.
+	 *
+	 * @param array $info
+	 *
+	 * @return array
+	 * @since 6.17.0
+	 */
+	public function debug_information( $info ) {
+		if ( ! is_array( $info ) || ! $this->gform->has_capability( 'gravityforms_view_settings' ) ) {
+			return $info;
+		}
+
+		return array_merge( $info, $this->view->get_deprecated_debug_information( Deprecation::refresh_signals() ) );
 	}
 
 	/**

--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -5,6 +5,7 @@ namespace GFPDF\Controller;
 use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Data;
 use GFPDF\Model\Model_Custom_Fonts;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -44,6 +45,7 @@ class Controller_Upgrade_Routines {
 	 */
 	public function init(): void {
 		add_action( 'gfpdf_version_changed', [ $this, 'maybe_run_upgrade' ], 10, 2 );
+		add_action( 'gfpdf_plugin_installed', [ $this, 'record_deprecated_functionality' ] );
 	}
 
 	/**
@@ -68,6 +70,23 @@ class Controller_Upgrade_Routines {
 			$this->remove_legacy_update_cache();
 			$this->remove_legacy_license_check_cron();
 		}
+
+		/* Deliberately ungated: every release is a chance for a new round of removals to arrive. Runs last, so it
+		   reflects the routines above */
+		$this->record_deprecated_functionality();
+	}
+
+	/**
+	 * Record the deprecated functionality this site uses, for the admin notices to read
+	 *
+	 * Taken at install and on every version change, since the notices would otherwise have to detect it on each of
+	 * the admin pages they can appear on. The system report and Site Health screens keep the record current in
+	 * between, detecting live as they do.
+	 *
+	 * @since 6.17.0
+	 */
+	public function record_deprecated_functionality(): void {
+		Deprecation::refresh_signals();
 	}
 
 	/**

--- a/src/Helper/Fields/Field_Signature.php
+++ b/src/Helper/Fields/Field_Signature.php
@@ -4,6 +4,7 @@ namespace GFPDF\Helper\Fields;
 
 use GFFormsModel;
 use GFPDF\Helper\Helper_Abstract_Fields;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -132,7 +133,7 @@ class Field_Signature extends Helper_Abstract_Fields {
 			 * @param integer The original image width
 			 */
 			if ( $signature_details !== false ) {
-				$optimised_width = apply_filters( 'gfpdfe_signature_width', $signature_details[0] / 3, $signature_details[0] ); /* backwards compat */
+				$optimised_width = Deprecation::apply_filters( 'gfpdfe_signature_width', [ $signature_details[0] / 3, $signature_details[0] ] );
 
 				/* See https://docs.gravitypdf.com/developers/filters/gfpdf_signature_width/ for more details about this filter */
 				$optimised_width = apply_filters( 'gfpdf_signature_width', $optimised_width, $signature_details[0] );

--- a/src/Helper/Helper_Abstract_View.php
+++ b/src/Helper/Helper_Abstract_View.php
@@ -108,6 +108,10 @@ abstract class Helper_Abstract_View extends Helper_Abstract_Model {
 
 		$args = array_merge( $this->data_cache, $args );
 
+		if ( isset( $args['content'] ) ) {
+			_deprecated_argument( esc_html( $this->view_type . '/' . $filename . '.php' ), '6.4.0', "Use \$args['callback'] instead" );
+		}
+
 		if ( is_readable( $path ) ) {
 
 			if ( $output ) {

--- a/src/Helper/Helper_Interface_Deprecated_Features.php
+++ b/src/Helper/Helper_Interface_Deprecated_Features.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Describes a set of Gravity PDF functionality being removed, for Deprecation to detect and report on
+ *
+ * @since 6.17.0
+ */
+interface Helper_Interface_Deprecated_Features {
+
+	/**
+	 * The features this class contributes to the deprecation registry
+	 *
+	 * Each entry is keyed by the ID it is detected and reported under, and holds:
+	 *
+	 * - `label`      (string)   The name the feature is known by to the user
+	 * - `group`      (string)   Deprecation::GROUP_UNSUPPORTED or Deprecation::GROUP_DEPRECATED
+	 * - `removed_in` (string)   The Gravity PDF version the feature is, or will be, removed in
+	 * - `url`        (string)   Where the upgrade instructions live
+	 * - `detect`     (callable) Returns what was found on this site, and an empty array when the feature is unused
+	 *
+	 * A feature the default sentence describes badly declares one more:
+	 *
+	 * - `notice`     (string)   What becomes of the feature, taking the removal version as `%s`. Read by every
+	 *                           surface, so it has to make sense with nothing else around it
+	 *
+	 * A feature made up of hooks declares two more, so Deprecation::apply_filters() can warn the listeners by name:
+	 *
+	 * - `hooks`         (array<string, string>) Each deprecated hook mapped to its replacement, '' when none exists
+	 * - `deprecated_in` (string)                The Gravity PDF version the hooks were deprecated in
+	 * - `hook_prefix`   (string)                Optional. Claims any hook starting with it as well, which is how
+	 *                                           the dynamic hooks are matched
+	 *
+	 * @return array<string, array>
+	 * @since 6.17.0
+	 */
+	public static function get_features(): array;
+
+	/**
+	 * The WordPress options this class stores its own detection data in, for the uninstaller to remove
+	 *
+	 * @return string[] Option names, empty when the class stores nothing of its own
+	 * @since 6.17.0
+	 */
+	public static function get_stored_options(): array;
+}

--- a/src/Helper/Helper_Misc.php
+++ b/src/Helper/Helper_Misc.php
@@ -788,7 +788,7 @@ class Helper_Misc {
 	 * @deprecated 6.12 compatibility code no longer required
 	 */
 	public function maybe_add_multicurrency_support() {
-		_doing_it_wrong( __METHOD__, 'This method has been removed and no alternative is available.', '6.12' );
+		_deprecated_function( __METHOD__, '6.12' );
 	}
 
 	/**

--- a/src/Helper/Helper_Notices.php
+++ b/src/Helper/Helper_Notices.php
@@ -61,7 +61,9 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @since 6.5
 	 * @deprecated 6.11 No longer required. Running all notices through standard WP hooks, but have included `gf-notice` class so GF does not remove it
 	 */
-	public function maybe_remove_non_pdf_messages(): void {}
+	public function maybe_remove_non_pdf_messages(): void {
+		_deprecated_function( __METHOD__, '6.11' );
+	}
 
 	/**
 	 * Determine which notice should be triggered
@@ -80,32 +82,32 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * Public endpoint for adding a new notice
 	 *
 	 * @param string $notice    The message to be queued
-	 * @param string $css_class The class that should be included with the notice box
+	 * @param string $css_class The class that should be included with the notice box. Pass a WordPress `notice-*`
+	 *                          state class, like `notice-warning`, to override the default success styling.
 	 *
 	 * @since 4.0
 	 */
 	public function add_notice( $notice, $css_class = '' ): void {
-		if ( empty( $css_class ) ) {
-			$this->notices[] = $notice;
-		} else {
-			$this->notices[ $css_class ] = $notice;
-		}
+		$this->notices[] = [
+			'message' => $notice,
+			'class'   => $css_class,
+		];
 	}
 
 	/**
 	 * Public endpoint for adding a new notice
 	 *
 	 * @param string $error     The error message that should be added
-	 * @param string $css_class Any class names that should apply to the error
+	 * @param string $css_class Any class names that should apply to the error, including a WordPress `notice-*`
+	 *                          state class to override the default error styling
 	 *
 	 * @since    4.0
 	 */
 	public function add_error( $error, $css_class = '' ) {
-		if ( empty( $css_class ) ) {
-			$this->errors[] = $error;
-		} else {
-			$this->errors[ $css_class ] = $error;
-		}
+		$this->errors[] = [
+			'message' => $error,
+			'class'   => $css_class,
+		];
 	}
 
 	/**
@@ -154,26 +156,26 @@ class Helper_Notices implements Helper_Interface_Actions {
 			return;
 		}
 
-		foreach ( $this->notices as $css_class => $notice ) {
-			$include_class = ( ! is_int( $css_class ) ) ? $css_class : '';
-			$this->html( $notice, 'updated ' . $include_class );
+		foreach ( $this->notices as $notice ) {
+			$this->html( $notice['message'], $notice['class'], 'updated' );
 		}
 
-		foreach ( $this->errors as $css_class => $error ) {
-			$include_class = ( ! is_int( $css_class ) ) ? $css_class : '';
-			$this->html( $error, 'error ' . $include_class );
+		foreach ( $this->errors as $error ) {
+			$this->html( $error['message'], $error['class'], 'error' );
 		}
 	}
 
 	/**
 	 * Generate the HTML used to display the notice / error
 	 *
-	 * @param string $text      The message to be displayed
-	 * @param string $css_class The class name (updated / error)
+	 * @param string $text          The message to be displayed
+	 * @param string $css_class     Any classes the caller asked for
+	 * @param string $default_state The state class used when the caller hasn't chosen one (updated / error)
 	 *
 	 * @since 4.0
+	 * @since 6.17.0 Added $default_state
 	 */
-	protected function html( string $text, string $css_class = 'updated' ): void {
+	protected function html( string $text, string $css_class = '', string $default_state = 'updated' ): void {
 		$allow_form_elements = static function ( $tags ) {
 			$tags['input'] = [
 				'type'  => true,
@@ -187,12 +189,16 @@ class Helper_Notices implements Helper_Interface_Actions {
 
 		add_filter( 'wp_kses_allowed_html', $allow_form_elements );
 
+		/* `div.updated` out-specifies `.notice-warning`, so a caller-supplied state replaces ours instead of joining it */
+		$state   = strpos( $css_class, 'notice-' ) === false ? $default_state : '';
+		$classes = trim( $state . ' ' . $css_class );
+
 		/* Add specific classes on Gravity Forms page so the notice displays correctly */
 		if ( class_exists( 'GFForms' ) && \GFForms::is_gravity_page() ) {
-			$classes  = 'notice gf-notice gform-settings__wrapper ' . $css_class;
-			$classes .= strpos( $css_class, 'updated' ) !== false ? ' notice-success' : '';
+			$classes  = 'notice gf-notice gform-settings__wrapper ' . $classes;
+			$classes .= $state === 'updated' ? ' notice-success' : '';
 		} else {
-			$classes = 'notice ' . $css_class;
+			$classes = 'notice ' . $classes;
 		}
 
 		?>
@@ -214,8 +220,9 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @return bool
 	 *
 	 * @since 6.11
+	 * @since 6.17.0 Made public so callers can skip building a notice that would be discarded
 	 */
-	protected function can_display_notice_on_this_page() {
+	public function can_display_notice_on_this_page() {
 		global $pagenow;
 
 		$misc = \GPDFAPI::get_misc_class();
@@ -251,6 +258,8 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @deprecated 6.11 No longer required. Running all notices through standard WP hooks, but have included `gf-notice` class so GF does not remove it
 	 */
 	public function reset_gravityforms_messages( $messages ) {
+		_deprecated_function( __METHOD__, '6.11' );
+
 		return $messages;
 	}
 
@@ -265,6 +274,8 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @deprecated 6.11 No longer required. Running all notices through standard WP hooks, but have included `gf-notice` class so GF does not remove it
 	 */
 	public function set_gravitypdf_notices( $messages ) {
+		_deprecated_function( __METHOD__, '6.11' );
+
 		return $messages;
 	}
 
@@ -279,6 +290,8 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @deprecated 6.11 No longer required. Running all notices through standard WP hooks, but have included `gf-notice` class so GF does not remove it
 	 */
 	public function set_gravitypdf_errors( $errors ) {
+		_deprecated_function( __METHOD__, '6.11' );
+
 		return $errors;
 	}
 }

--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -2,6 +2,7 @@
 
 namespace GFPDF\Helper;
 
+use GFPDF\Statics\Deprecation_V3;
 use WP_Error;
 
 /**
@@ -693,11 +694,11 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 	 */
 	public function get_advanced_template_field( $settings ) {
 
-		if ( ! class_exists( 'gfpdfe_business_plus' ) ) {
+		if ( ! Deprecation_V3::has_tier_2_addon() ) {
 			return $settings;
 		}
 
-		_doing_it_wrong( __METHOD__, 'Legacy templates are deprecated and no longer supported. Contact GravityPDF.com to discuss upgrade options.', '6.12' );
+		_deprecated_function( __METHOD__, '6.12', 'a Gravity PDF 6 template, https://docs.gravitypdf.com/upgrade/legacy-templates/' );
 
 		$settings['advanced_template'] = [
 			'id'   => 'advanced_template',

--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -5,8 +5,10 @@ namespace GFPDF\Helper;
 use Exception;
 use GFPDF\Helper\Mpdf\Request;
 use GFPDF\Statics\Cache;
+use GFPDF\Statics\Deprecation;
 use GFPDF_Vendor\Mpdf\Config\FontVariables;
 use GFPDF\Helper\Mpdf\Mpdf;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF_Vendor\Mpdf\MpdfException;
 use GFPDF_Vendor\Mpdf\Utils\UtfString;
 use GFPDF_Vendor\Mpdf\Container\SimpleContainer;
@@ -266,8 +268,8 @@ class Helper_PDF {
 		}
 
 		/* Apply our filters */
-		$html = apply_filters( 'gfpdfe_pdf_template', $html, $form['id'], $this->entry['id'], $args['settings'] ); /* Backwards compat */
-		$html = apply_filters( 'gfpdfe_pdf_template_' . $form['id'], $html, $this->entry['id'], $args['settings'] ); /* Backwards compat */
+		$html = Deprecation::apply_filters( 'gfpdfe_pdf_template', [ $html, $form['id'], $this->entry['id'], $args['settings'] ] );
+		$html = Deprecation::apply_filters( 'gfpdfe_pdf_template_' . $form['id'], [ $html, $this->entry['id'], $args['settings'] ], 'gfpdf_pdf_html_output_' . $form['id'] );
 
 		/* See https://docs.gravitypdf.com/developers/filters/gfpdf_pdf_html_output/ for more details about these filters */
 		$html = apply_filters( 'gfpdf_pdf_html_output', $html, $form, $this->entry, $args['settings'], $this );
@@ -302,9 +304,11 @@ class Helper_PDF {
 		$this->mpdf = apply_filters( 'gfpdf_mpdf_class', $this->mpdf, $form, $this->entry, $this->settings, $this );
 
 		/* deprecated backwards compatibility filters */
-		$this->mpdf = apply_filters( 'gfpdfe_mpdf_class_pre_render', $this->mpdf, $this->entry['form_id'], $this->entry['id'], $this->settings, '', $this->get_filename() );
-		$this->mpdf = apply_filters( 'gfpdfe_pre_render_pdf', $this->mpdf, $this->entry['form_id'], $this->entry['id'], $this->settings, '', $this->get_filename() );
-		$this->mpdf = apply_filters( 'gfpdfe_mpdf_class', $this->mpdf, $this->entry['form_id'], $this->entry['id'], $this->settings, '', $this->get_filename() );
+		$legacy_args = [ $this->entry['form_id'], $this->entry['id'], $this->settings, '', $this->get_filename() ];
+
+		foreach ( [ 'gfpdfe_mpdf_class_pre_render', 'gfpdfe_pre_render_pdf', 'gfpdfe_mpdf_class' ] as $legacy_hook ) {
+			$this->mpdf = Deprecation::apply_filters( $legacy_hook, array_merge( [ $this->mpdf ], $legacy_args ) );
+		}
 
 		do_action( 'gfpdf_pre_pdf_generation_output', $this->mpdf, $form, $this->entry, $this->settings, $this );
 
@@ -387,6 +391,11 @@ class Helper_PDF {
 
 		/* Check if there are version requirements */
 		$template_info = $this->templates->get_template_info_by_path( $this->template_path );
+
+		if ( $this->templates->is_legacy_template( $template_info ) ) {
+			Deprecation_V3::restore_v3_form_class();
+		}
+
 		if ( ! $this->templates->is_template_compatible( $template_info['required_pdf_version'] ) ) {
 			/* translators: 1: PDF template name wrapped in <em> tags, 2: Required Gravity PDF version wrapped in <em> tags */
 			throw new Exception( sprintf( esc_html__( 'The PDF Template %1$s requires Gravity PDF version %2$s. Upgrade to the latest version.', 'gravity-pdf' ), '<em>' . esc_html( $template ) . '</em>', '<em>' . esc_html( $template_info['required_pdf_version'] ) . '</em>' ) );

--- a/src/Helper/Helper_Templates.php
+++ b/src/Helper/Helper_Templates.php
@@ -3,6 +3,7 @@
 namespace GFPDF\Helper;
 
 use Exception;
+use GFPDF\Statics\Deprecation;
 use GPDFAPI;
 use GFPDF_Vendor\Psr\Log\LoggerInterface;
 use stdClass;
@@ -271,6 +272,19 @@ class Helper_Templates {
 			},
 			$this->get_all_templates()
 		);
+	}
+
+	/**
+	 * Check if the template info describes a legacy (v3) template
+	 *
+	 * A v3 template has no `Group` header, so self::get_template_info_by_path() falls back to the Legacy group.
+	 *
+	 * @param array $info The template header info
+	 *
+	 * @since 6.17.0
+	 */
+	public function is_legacy_template( array $info ): bool {
+		return ( $info['group'] ?? '' ) === esc_html__( 'Legacy', 'gravity-pdf' );
 	}
 
 	/**
@@ -766,7 +780,7 @@ class Helper_Templates {
 
 				'form_id'   => $form['id'], /* backwards compat */
 				'lead_ids'  => $legacy_ids, /* backwards compat */
-				'lead_id'   => apply_filters( 'gfpdfe_lead_id', $entry['id'], $form, $entry, $gfpdf ), /* backwards compat */
+				'lead_id'   => Deprecation::apply_filters( 'gfpdfe_lead_id', [ $entry['id'], $form, $entry, $gfpdf ] ), /* backwards compat */
 
 				'form'      => $form,
 				'entry'     => $entry,

--- a/src/Model/Model_Actions.php
+++ b/src/Model/Model_Actions.php
@@ -7,6 +7,7 @@ use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Options_Fields;
+use GFPDF\Statics\Deprecation;
 use GPDFAPI;
 
 /**
@@ -28,6 +29,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0
  */
 class Model_Actions extends Helper_Abstract_Model {
+
+	/**
+	 * The prefix each deprecated feature's dismissal is recorded under in `action_dismissal`
+	 *
+	 * @since 6.17.0
+	 */
+	const DEPRECATED_FEATURE_DISMISSAL = 'deprecated_feature_';
 
 	/**
 	 * Holds our Helper_Data object
@@ -106,9 +114,29 @@ class Model_Actions extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function dismiss_notice( $type ) {
+		$this->dismiss_notices( [ $type ] );
+	}
 
-		$dismissed_notices          = $this->options->get_option( 'action_dismissal', [] );
-		$dismissed_notices[ $type ] = $type;
+	/**
+	 * Mark several notices as dismissed at once
+	 *
+	 * Written in one go, since each update_option() rewrites the whole autoloaded settings blob.
+	 *
+	 * @param string[] $types The notice IDs
+	 *
+	 * @since 6.17.0
+	 */
+	public function dismiss_notices( array $types ): void {
+		if ( $types === [] ) {
+			return;
+		}
+
+		$dismissed_notices = $this->options->get_option( 'action_dismissal', [] );
+
+		foreach ( $types as $type ) {
+			$dismissed_notices[ $type ] = $type;
+		}
+
 		$this->options->update_option( 'action_dismissal', $dismissed_notices );
 	}
 
@@ -138,6 +166,83 @@ class Model_Actions extends Helper_Abstract_Model {
 	 */
 	public function core_font_redirect() {
 		wp_safe_redirect( admin_url( 'admin.php?page=gf_settings&subview=PDF&tab=tools#/downloadCoreFonts' ) );
+		exit;
+	}
+
+	/**
+	 * The deprecated features in use that the user hasn't dismissed a notice for
+	 *
+	 * The recorded detections are read rather than detected here, because this runs on every admin page a notice
+	 * can appear on. Deprecation records a fresh set on every version change — which is when a new round of
+	 * removals arrives — and again whenever the system report or Site Health screens detect for themselves.
+	 *
+	 * @return string[] The feature IDs the notice should list
+	 * @since 6.17.0
+	 */
+	public function get_undismissed_deprecated_features(): array {
+		$features = Deprecation::get_features();
+
+		return array_values(
+			array_filter(
+				Deprecation::get_detected_features(),
+				function ( $key ) use ( $features ) {
+					/* A record taken before a provider was removed can name a feature nothing declares any more */
+					return isset( $features[ $key ] ) && ! $this->is_notice_already_dismissed( static::DEPRECATED_FEATURE_DISMISSAL . $key );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Whether anything in use is worth raising the deprecation notice for
+	 *
+	 * @since 6.17.0
+	 */
+	public function has_deprecated_features(): bool {
+		return $this->get_undismissed_deprecated_features() !== [];
+	}
+
+	/**
+	 * Whether anything the notice lists has already been removed, which reads as an error rather than a warning
+	 *
+	 * @since 6.17.0
+	 */
+	public function has_unsupported_deprecated_feature(): bool {
+		foreach ( $this->get_undismissed_deprecated_features() as $key ) {
+			if ( ( Deprecation::get_feature( $key )['group'] ?? '' ) === Deprecation::GROUP_UNSUPPORTED ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Dismiss every feature the notice was listing when the user dismissed it
+	 *
+	 * Recorded per feature rather than against the notice itself, so a round of removals arriving later raises the
+	 * notice again instead of being silenced by a dismissal that predates it.
+	 *
+	 * @since 6.17.0
+	 */
+	public function dismiss_deprecated_features(): void {
+		$this->dismiss_notices(
+			array_map(
+				function ( $key ) {
+					return static::DEPRECATED_FEATURE_DISMISSAL . $key;
+				},
+				$this->get_undismissed_deprecated_features()
+			)
+		);
+	}
+
+	/**
+	 * Send the user to the system report, which lists every detection behind the notice
+	 *
+	 * @since 6.17.0
+	 */
+	public function system_report_redirect() {
+		wp_safe_redirect( admin_url( 'admin.php?page=gf_system_status' ) );
 		exit;
 	}
 }

--- a/src/Model/Model_Install.php
+++ b/src/Model/Model_Install.php
@@ -10,6 +10,7 @@ use GFPDF\Helper\Helper_Form;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Pdf_Queue;
+use GFPDF\Statics\Deprecation;
 use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
@@ -182,8 +183,8 @@ class Model_Install extends Helper_Abstract_Model {
 		$upload_dir_url = $this->data->upload_dir_url;
 
 		/* Legacy Filters */
-		$this->data->template_location     = trailingslashit( apply_filters( 'gfpdfe_template_location', $template_dir, $working_folder, $upload_dir ) );
-		$this->data->template_location_url = trailingslashit( apply_filters( 'gfpdfe_template_location_uri', $template_url, $working_folder, $upload_dir_url ) );
+		$this->data->template_location     = trailingslashit( Deprecation::apply_filters( 'gfpdfe_template_location', [ $template_dir, $working_folder, $upload_dir ] ) );
+		$this->data->template_location_url = trailingslashit( Deprecation::apply_filters( 'gfpdfe_template_location_uri', [ $template_url, $working_folder, $upload_dir_url ] ) );
 
 		/* Allow user to change directory location(s) */
 
@@ -398,6 +399,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function uninstall_plugin() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::uninstall_plugin()' );
+
 		$this->uninstall->uninstall_plugin();
 	}
 
@@ -409,6 +412,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function remove_plugin_options() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::remove_plugin_options()' );
+
 		$this->uninstall->remove_plugin_options();
 	}
 
@@ -421,6 +426,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function remove_plugin_form_settings() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::remove_plugin_form_settings()' );
+
 		$this->uninstall->remove_plugin_form_settings();
 	}
 
@@ -432,6 +439,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function remove_folder_structure() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::remove_folder_structure()' );
+
 		$this->uninstall->remove_folder_structure();
 	}
 
@@ -443,6 +452,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function deactivate_plugin() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::deactivate_plugin()' );
+
 		$this->uninstall->deactivate_plugin();
 	}
 

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -23,6 +23,8 @@ use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Options_Fields;
 use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Templates;
+use GFPDF\Statics\Deprecation;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF_Vendor\Mpdf\Mpdf;
 use GFPDF_Vendor\Spatie\UrlSigner\Exceptions\InvalidSignatureKey;
 use GFQuiz;
@@ -246,7 +248,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		 * To prevent cache misses we need to ensure we don't unnecessarily modify the settings array
 		 */
 		unset( $settings['pdf_action'] );
-		$action = apply_filters( 'gfpdfe_pdf_output_type', $action ); /* Backwards compat */
+		$action = Deprecation::apply_filters( 'gfpdfe_pdf_output_type', [ $action ] );
 		$action = in_array( $action, [ 'view', 'download' ], true ) ? $action : 'view';
 
 		/* Get the PDF document for the request */
@@ -290,31 +292,31 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
-		$settings['filename'] = $this->misc->remove_extension_from_string( apply_filters( 'gfpdfe_pdf_name', $settings['filename'], $form, $entry ) );
-		$settings['template'] = $this->misc->remove_extension_from_string( apply_filters( 'gfpdfe_template', $settings['template'], $form, $entry ), '.php' );
+		$settings['filename'] = $this->misc->remove_extension_from_string( Deprecation::apply_filters( 'gfpdfe_pdf_name', [ $settings['filename'], $form, $entry ] ) );
+		$settings['template'] = $this->misc->remove_extension_from_string( Deprecation::apply_filters( 'gfpdfe_template', [ $settings['template'], $form, $entry ] ), '.php' );
 
 		if ( isset( $settings['orientation'] ) ) {
-			$settings['orientation'] = apply_filters( 'gfpdf_orientation', $settings['orientation'], $form, $entry );
+			$settings['orientation'] = Deprecation::apply_filters( 'gfpdf_orientation', [ $settings['orientation'], $form, $entry ] );
 		}
 
 		if ( isset( $settings['security'] ) ) {
-			$settings['security'] = $this->misc->update_deprecated_config( apply_filters( 'gfpdf_security', $settings['security'], $form, $entry ) );
+			$settings['security'] = $this->misc->update_deprecated_config( Deprecation::apply_filters( 'gfpdf_security', [ $settings['security'], $form, $entry ] ) );
 		}
 
 		if ( isset( $settings['privileges'] ) ) {
-			$settings['privileges'] = apply_filters( 'gfpdf_privilages', $settings['privileges'], $form, $entry );
+			$settings['privileges'] = Deprecation::apply_filters( 'gfpdf_privilages', [ $settings['privileges'], $form, $entry ] );
 		}
 
 		if ( isset( $settings['password'] ) ) {
-			$settings['password'] = apply_filters( 'gfpdf_password', $settings['password'], $form, $entry );
+			$settings['password'] = Deprecation::apply_filters( 'gfpdf_password', [ $settings['password'], $form, $entry ] );
 		}
 
 		if ( isset( $settings['master_password'] ) ) {
-			$settings['master_password'] = apply_filters( 'gfpdf_master_password', $settings['master_password'], $form, $entry );
+			$settings['master_password'] = Deprecation::apply_filters( 'gfpdf_master_password', [ $settings['master_password'], $form, $entry ] );
 		}
 
 		if ( isset( $settings['rtl'] ) ) {
-			$settings['rtl'] = $this->misc->update_deprecated_config( apply_filters( 'gfpdf_rtl', $settings['rtl'], $form, $entry ) );
+			$settings['rtl'] = $this->misc->update_deprecated_config( Deprecation::apply_filters( 'gfpdf_rtl', [ $settings['rtl'], $form, $entry ] ) );
 		}
 
 		return $settings;
@@ -865,7 +867,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		$name = apply_filters( 'gfpdf_pdf_filename', $name, $form, $entry, $settings );
 
 		/* Backwards compatible filter */
-		$name = apply_filters( 'gfpdfe_pdf_filename', $name, $form, $entry, $settings );
+		$name = Deprecation::apply_filters( 'gfpdfe_pdf_filename', [ $name, $form, $entry, $settings ] );
 
 		/* Remove any characters that cannot be present in a filename */
 		$name = $this->misc->strip_invalid_characters( $name );
@@ -890,7 +892,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		global $wp_rewrite;
 
 		if ( $esc !== true ) {
-			_doing_it_wrong( __METHOD__, '$esc has been deprecated. Late-escape the returned value where appropriate.', '6.4.0' );
+			_deprecated_argument( __METHOD__, '6.4.0', 'The $esc argument is ignored. Late-escape the returned value where appropriate.' );
 		}
 
 		/*
@@ -1266,7 +1268,7 @@ class Model_PDF extends Helper_Abstract_Model {
 			$pdf_generator->set_output_type( 'save' );
 
 			/* Add Backwards compatibility support for our v3 Tier 2 Add-on */
-			if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) === 'yes' ) {
+			if ( Deprecation_V3::is_advanced_template_pdf( $settings ) ) {
 
 				/* Check if we should process this document using our legacy system */
 				if ( $this->handle_legacy_tier_2_processing( $pdf_generator, $entry, $settings, $args ) ) {
@@ -1455,17 +1457,24 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
-		$prevent_main_pdf_loader = apply_filters(
+		$this->log->warning( sprintf( 'Advanced Templating (Tier 2) processing is removed in Gravity PDF %s. Contact GravityPDF.com to discuss upgrade options.', Deprecation_V3::REMOVED_IN ) );
+
+		/* The add-on runs the template file itself, so Helper_PDF::set_template() never sees it */
+		Deprecation_V3::restore_v3_form_class();
+
+		$prevent_main_pdf_loader = Deprecation::apply_filters(
 			'gfpdfe_pre_load_template',
-			$form['id'],
-			$entry['id'],
-			basename( $pdf_generator->get_template_path() ),
-			$form['id'] . $entry['id'],
-			$this->misc->backwards_compat_output( $pdf_generator->get_output_type() ),
-			$pdf_generator->get_filename(),
-			$this->misc->backwards_compat_conversion( $settings, $form, $entry ),
-			$args
-		); /* Backwards Compatibility */
+			[
+				$form['id'],
+				$entry['id'],
+				basename( $pdf_generator->get_template_path() ),
+				$form['id'] . $entry['id'],
+				$this->misc->backwards_compat_output( $pdf_generator->get_output_type() ),
+				$pdf_generator->get_filename(),
+				$this->misc->backwards_compat_conversion( $settings, $form, $entry ),
+				$args,
+			]
+		);
 
 		return $prevent_main_pdf_loader === true;
 	}
@@ -2045,7 +2054,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @deprecated 6.12 Caching layer + auto-purge added
 	 */
 	public function cleanup_pdf_after_submission( $form, $entry_id ) {
-		_doing_it_wrong( __METHOD__, 'This method is deprecated and no alternative is available. The temporary cache is automatically cleaned every hour using the WP Cron.', '6.12' );
+		_deprecated_function( __METHOD__, '6.12' );
 
 		/* Exit if background processing is enabled */
 		if ( $this->options->get_option( 'background_processing', 'No' ) === 'Yes' ) {
@@ -2076,7 +2085,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @deprecated 6.12 Caching layer + auto-purge added
 	 */
 	public function cleanup_pdf( $entry, $form ) {
-		_doing_it_wrong( __METHOD__, 'This method is deprecated and no alternative is available. The temporary cache is automatically cleaned every hour using the WP Cron.', '6.12' );
+		_deprecated_function( __METHOD__, '6.12' );
 
 		$pdfs = $this->get_active_pdfs( $form['gfpdf_form_settings'] ?? [], $entry );
 
@@ -2112,7 +2121,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @deprecated 6.12 Caching layer + auto-purge added
 	 */
 	public function resend_notification_pdf_cleanup( $form, $entries ) {
-		_doing_it_wrong( __METHOD__, 'This method is deprecated and no alternative is available. The temporary cache is automatically cleaned every hour using the WP Cron.', '6.12' );
+		_deprecated_function( __METHOD__, '6.12' );
 
 		foreach ( $entries as $entry_id ) {
 			$entry = $this->gform->get_entry( $entry_id );
@@ -2227,7 +2236,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @deprecated 4.0 Added for backwards compatibility, but ideally should not be used
 	 */
 	public function get_legacy_config( $config ) {
-		_doing_it_wrong( __METHOD__, 'Legacy PDF URLs are deprecated. Replace with the [gravitypdf] shortcode or PDF merge tags. See https://docs.gravitypdf.com/v6/users/shortcodes-and-mergetags for usage instructions.', '4.0' );
+		_deprecated_function( __METHOD__, '4.0', 'the [gravitypdf] shortcode or PDF merge tags, https://docs.gravitypdf.com/upgrade/legacy-download-urls/' );
 
 		/* Get the form settings */
 		$pdfs = $this->options->get_form_pdfs( $config['fid'] );

--- a/src/Model/Model_Settings.php
+++ b/src/Model/Model_Settings.php
@@ -720,7 +720,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Removed in 6.0. Use GPDFAPI::delete_pdf_font()
 	 */
-	public function remove_font_file( $fonts ) {}
+	public function remove_font_file( $fonts ) {
+		_deprecated_function( __METHOD__, '6.0', 'GPDFAPI::delete_pdf_font()' );
+	}
 
 	/**
 	 * Check that the font name passed conforms to our expected naming convention
@@ -731,7 +733,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Moved in 6.0. Use Model_Custom_Fonts::check_font_name_valid()
 	 */
-	public function is_font_name_valid( $name ) {}
+	public function is_font_name_valid( $name ) {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Custom_Fonts::check_font_name_valid()' );
+	}
 
 	/**
 	 * Query our custom fonts options table and check if the font name already exists
@@ -743,7 +747,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Removed in 6.0. Font names no longer need to be unique
 	 */
-	public function is_font_name_unique( $name, $id = '' ) {}
+	public function is_font_name_unique( $name, $id = '' ) {
+		_deprecated_function( __METHOD__, '6.0' );
+	}
 
 	/**
 	 * Handles the database updates required to save a new font
@@ -754,7 +760,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Moved in 6.0 to Model_Custom_Fonts::add_font()
 	 */
-	public function install_fonts( $fonts ) {}
+	public function install_fonts( $fonts ) {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Custom_Fonts::add_font()' );
+	}
 
 	/**
 	 * AJAX Endpoint for saving the custom font
@@ -763,7 +771,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Moved in 6.0. Use GPDFAPI::add_pdf_font()
 	 */
-	public function save_font() {}
+	public function save_font() {
+		_deprecated_function( __METHOD__, '6.0', 'GPDFAPI::add_pdf_font()' );
+	}
 
 	/**
 	 * AJAX Endpoint for deleting a custom font
@@ -772,7 +782,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Moved in 6.0. Use GPDFAPI::delete_pdf_font()
 	 */
-	public function delete_font() {}
+	public function delete_font() {
+		_deprecated_function( __METHOD__, '6.0', 'GPDFAPI::delete_pdf_font()' );
+	}
 
 	/**
 	 * Validate user input and save as new font
@@ -783,7 +795,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Removed in 6.0. Use GPDFAPI::add_pdf_font()
 	 */
-	public function process_font( $font ) {}
+	public function process_font( $font ) {
+		_deprecated_function( __METHOD__, '6.0', 'GPDFAPI::add_pdf_font()' );
+	}
 
 	/**
 	 * Find the font unique ID from the font name
@@ -794,7 +808,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Removed in 6.0. Font names no longer linked to IDs.
 	 */
-	public function get_font_id_by_name( $font_name ) {}
+	public function get_font_id_by_name( $font_name ) {
+		_deprecated_function( __METHOD__, '6.0' );
+	}
 
 	/**
 	 * Create a file in our tmp directory and check if it is publicly accessible (i.e no .htaccess protection)
@@ -803,7 +819,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Functionality removed in 6.0
 	 */
-	public function check_tmp_pdf_security() {}
+	public function check_tmp_pdf_security() {
+		_deprecated_function( __METHOD__, '6.0' );
+	}
 
 	/**
 	 * Create a file in our tmp directory and verify if it's protected from the public
@@ -815,6 +833,8 @@ class Model_Settings extends Helper_Abstract_Model {
 	 * @deprecated Moved in 6.0. Use Model_System_Report::test_public_tmp_directory_access()
 	 */
 	public function test_public_tmp_directory_access() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_System_Report::test_public_tmp_directory_access()' );
+
 		/** @var Model_System_Report $model_system_report */
 		$model_system_report = \GPDFAPI::get_mvc_class( 'Model_System_Report' );
 

--- a/src/Model/Model_Shortcodes.php
+++ b/src/Model/Model_Shortcodes.php
@@ -47,7 +47,7 @@ class Model_Shortcodes extends Helper_Abstract_Pdf_Shortcode {
 	 * @internal Deprecated in 5.2. Use Model_Shortcodes::process()
 	 */
 	public function gravitypdf( $attributes ) {
-		_doing_it_wrong( __METHOD__, 'This method has been replaced by Model_Shortcodes::process()', '5.2' );
+		_deprecated_function( __METHOD__, '5.2', 'Model_Shortcodes::process()' );
 
 		return $this->process( $attributes );
 	}

--- a/src/Model/Model_System_Report.php
+++ b/src/Model/Model_System_Report.php
@@ -9,6 +9,8 @@ use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Templates;
+use GFPDF\Statics\Deprecation;
+use GFPDF\View\View_System_Report;
 use GFPDF_Major_Compatibility_Checks;
 use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
@@ -90,11 +92,19 @@ class Model_System_Report extends Helper_Abstract_Model {
 	 */
 	public function build_gravitypdf_report(): array {
 		$structure = $this->get_report_structure();
-		foreach ( $this->get_report_items() as $index => $report ) {
-			foreach ( $report as $id => $info ) {
-				$structure[0]['tables'][ $index ]['items'][ $id ] = $info;
-			}
+		$items     = $this->get_report_items();
+
+		foreach ( $structure[0]['tables'] as $index => $table ) {
+			$structure[0]['tables'][ $index ]['items'] = $items[ $table['id'] ] ?? [];
 		}
+
+		/* Drop any section with nothing to show, which is how the Deprecated section stays hidden on a clean site */
+		$structure[0]['tables'] = array_filter(
+			$structure[0]['tables'],
+			static function ( $table ) {
+				return ! empty( $table['items'] );
+			}
+		);
 
 		return $structure;
 	}
@@ -106,35 +116,49 @@ class Model_System_Report extends Helper_Abstract_Model {
 	 */
 	public function get_report_structure(): array {
 		$title_export_prefix = 'Gravity PDF - ';
+		$deprecated_tables   = [];
+
+		/* Deprecation decides which groups there are and in what order; the view names them, once, for all three surfaces */
+		foreach ( View_System_Report::get_deprecated_groups() as $group => $names ) {
+			$deprecated_tables[] = [
+				'id'           => $group,
+				'title'        => esc_html( $names['label'] ),
+				'title_export' => $title_export_prefix . $names['label'],
+			];
+		}
+
 		return [
 			[
 				'title'        => esc_html__( 'Gravity PDF Environment', 'gravity-pdf' ),
 				'title_export' => 'Gravity PDF Environment',
-				'tables'       => [
+				'tables'       => array_merge(
+					$deprecated_tables,
 					[
-						'title'        => esc_html__( 'PHP', 'gravity-pdf' ),
-						'title_export' => $title_export_prefix . 'PHP',
-						'items'        => [],
-					],
+						[
+							'id'           => 'php',
+							'title'        => esc_html__( 'PHP', 'gravity-pdf' ),
+							'title_export' => $title_export_prefix . 'PHP',
+						],
 
-					[
-						'title'        => esc_html__( 'Directories and Permissions', 'gravity-pdf' ),
-						'title_export' => $title_export_prefix . 'Directories and Permissions',
-						'items'        => [],
-					],
+						[
+							'id'           => 'directories',
+							'title'        => esc_html__( 'Directories and Permissions', 'gravity-pdf' ),
+							'title_export' => $title_export_prefix . 'Directories and Permissions',
+						],
 
-					[
-						'title'        => esc_html__( 'Global Settings', 'gravity-pdf' ),
-						'title_export' => $title_export_prefix . 'Global Settings',
-						'items'        => [],
-					],
+						[
+							'id'           => 'global',
+							'title'        => esc_html__( 'Global Settings', 'gravity-pdf' ),
+							'title_export' => $title_export_prefix . 'Global Settings',
+						],
 
-					[
-						'title'        => esc_html__( 'Security Settings', 'gravity-pdf' ),
-						'title_export' => $title_export_prefix . 'Security Settings',
-						'items'        => [],
-					],
-				],
+						[
+							'id'           => 'security',
+							'title'        => esc_html__( 'Security Settings', 'gravity-pdf' ),
+							'title_export' => $title_export_prefix . 'Security Settings',
+						],
+					]
+				),
 			],
 		];
 	}
@@ -171,8 +195,13 @@ class Model_System_Report extends Helper_Abstract_Model {
 		$temp_folder_protected  = $this->check_temp_folder_permission();
 		$temp_folder_permission = $this->is_temporary_folder_writable();
 
+		/* Keyed by group, which is what the matching report sections are named after */
+		foreach ( Deprecation::group_signals( Deprecation::refresh_signals() ) as $group => $signals ) {
+			$items[ $group ] = $this->get_deprecated_feature_items( $signals );
+		}
+
 		/* PHP */
-		$items[0] = [
+		$items['php'] = [
 			'memory'            => [
 				'label'        => esc_html__( 'WP Memory', 'gravity-pdf' ),
 				'label_export' => 'WP Memory',
@@ -200,7 +229,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 		];
 
 		/* Directory and Permissions */
-		$items[1] = [
+		$items['directories'] = [
 			'pdf_working_directory'     => [
 				'label'        => esc_html__( 'PDF Working Directory', 'gravity-pdf' ),
 				'label_export' => 'PDF Working Directory',
@@ -246,10 +275,10 @@ class Model_System_Report extends Helper_Abstract_Model {
 			],
 		];
 
-		/* Check if outdated core template overrides and display warning */
+		/* Check for outdated core template overrides and display a warning */
 		$template_status = $this->check_core_template_override_versions();
 		if ( ! empty( $template_status ) ) {
-			$items[1]['outdated_templates'] = [
+			$items['directories']['outdated_templates'] = [
 				'label'        => esc_html__( 'Outdated Templates', 'gravity-pdf' ),
 				'label_export' => 'Outdated Templates',
 				'value'        => $template_status['value'],
@@ -269,7 +298,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 			[ 'a' => [ 'href' => true ] ]
 		);
 
-		$items[2] = [
+		$items['global'] = [
 			'canonical_release'             => [
 				'label'        => esc_html__( 'Canonical Release', 'gravity-pdf' ),
 				'label_export' => 'Canonical Release',
@@ -300,7 +329,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 		];
 
 		/* Security Settings */
-		$items[3] = [
+		$items['security'] = [
 			'user_restrictions'  => [
 				'label'        => esc_html__( 'User Restrictions', 'gravity-pdf' ),
 				'label_export' => 'User Restrictions',
@@ -316,6 +345,27 @@ class Model_System_Report extends Helper_Abstract_Model {
 		];
 
 		return apply_filters( 'gfpdf_system_status_report_items', $items );
+	}
+
+	/**
+	 * Build the rows for one of the deprecation sections
+	 *
+	 * Each row is only included when that feature is actually in use on this site, and the section itself is
+	 * discarded by build_gravitypdf_report() when nothing is detected.
+	 *
+	 * @param array $signals The signals belonging to that section
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_feature_items( array $signals ): array {
+		$view = $this->getController()->view;
+
+		$items = [];
+		foreach ( $signals as $key => $signal ) {
+			$items[ $key ] = $view->get_deprecated_feature_report_item( $key, $signal );
+		}
+
+		return $items;
 	}
 
 	/**
@@ -446,7 +496,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 		foreach ( $templates as $path => $core_version ) {
 			$template = $this->templates->get_template_info_by_id( basename( $path, '.php' ) );
 			if ( version_compare( $core_version, $template['version'], '>' ) ) {
-				$relative_template_path = str_replace( ABSPATH, '/', $template['path'] );
+				$relative_template_path = $this->misc->relative_path( $template['path'], '/' );
 				$message                = $this->getController()->view->get_template_check_message( $relative_template_path, $template['version'], $core_version );
 
 				$value        .= $message['value'];

--- a/src/Model/Model_Templates.php
+++ b/src/Model/Model_Templates.php
@@ -391,7 +391,7 @@ class Model_Templates extends Helper_Abstract_Model {
 			/* Check if we have a valid v4 template header in the file */
 			$info = $this->templates->get_template_info_by_path( $file );
 
-			if ( $info['group'] === esc_html__( 'Legacy', 'gravity-pdf' ) ) {
+			if ( $this->templates->is_legacy_template( $info ) ) {
 				/* Check if it's a v3 template */
 				$fp        = fopen( $file, 'rb' );
 				$file_data = fread( $fp, 8192 );

--- a/src/Model/Model_Uninstall.php
+++ b/src/Model/Model_Uninstall.php
@@ -10,6 +10,7 @@ use GFPDF\Helper\Helper_Interface_Extension_Uninstaller;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Pdf_Queue;
+use GFPDF\Statics\Deprecation;
 use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
 /**
@@ -163,6 +164,7 @@ class Model_Uninstall extends Helper_Abstract_Model {
 		delete_option( 'gfpdf_is_installed' );
 		delete_option( 'gfpdf_current_version' );
 		delete_option( 'gfpdf_settings' );
+		Deprecation::delete_stored_data();
 
 		/* Remove license API data. Deleting one by one, not with a raw DELETE, lets WordPress drop its cached copies */
 		global $wpdb;

--- a/src/Statics/Deprecation.php
+++ b/src/Statics/Deprecation.php
@@ -1,0 +1,419 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Detects and reports the deprecated Gravity PDF functionality a site still relies on
+ *
+ * The functionality itself is described by the providers in self::get_providers(), so each new round of removals is
+ * registered rather than wired in. This class only knows how to detect, group and warn about whatever they declare.
+ *
+ * @since 6.17.0
+ */
+class Deprecation {
+
+	/**
+	 * Functionality that has been removed from Gravity PDF
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const GROUP_UNSUPPORTED = 'unsupported';
+
+	/**
+	 * Functionality that still works, but is scheduled for removal
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const GROUP_DEPRECATED = 'deprecated';
+
+	/**
+	 * The classes describing the functionality Gravity PDF is removing
+	 *
+	 * Add a class here to have its features detected and reported everywhere the existing ones are.
+	 *
+	 * @return string[] Helper_Interface_Deprecated_Features implementations
+	 * @since 6.17.0
+	 */
+	protected static function get_providers(): array {
+		return [
+			Deprecation_V3::class,
+		];
+	}
+
+	/**
+	 * Every feature the providers declare, keyed by the ID it is detected and reported under
+	 *
+	 * @return array<string, array> See Helper_Interface_Deprecated_Features::get_features() for the shape of an entry
+	 * @since 6.17.0
+	 */
+	public static function get_features(): array {
+		static $features = [];
+
+		/* Keyed by the registry, since a subclass can declare a different one */
+		$key = static::class;
+
+		if ( ! isset( $features[ $key ] ) ) {
+			$registered = [];
+
+			foreach ( static::get_providers() as $provider ) {
+				$registered += $provider::get_features();
+			}
+
+			$features[ $key ] = $registered;
+		}
+
+		return $features[ $key ];
+	}
+
+	/**
+	 * Get a single feature, or an empty array when nothing is registered under that ID
+	 *
+	 * @param string $key The feature ID
+	 *
+	 * @since 6.17.0
+	 */
+	public static function get_feature( string $key ): array {
+		return static::get_features()[ $key ] ?? [];
+	}
+
+	/**
+	 * Get every signal that deprecated functionality is in use on this site
+	 *
+	 * Features with nothing to report are omitted, so the return value doubles as the list of features in use.
+	 *
+	 * @return array<string, array> Feature ID mapped to what its detector found
+	 * @since 6.17.0
+	 */
+	public static function get_signals(): array {
+		$signals = [];
+
+		foreach ( static::get_features() as $key => $feature ) {
+			$signals[ $key ] = call_user_func( $feature['detect'] );
+		}
+
+		return array_filter( $signals );
+	}
+
+	/**
+	 * The features this site was last found to be using
+	 *
+	 * The admin notices read this rather than detecting for themselves: detection walks the database and the
+	 * template directory, which is far too much to repeat on every admin page a notice can appear on. The record is
+	 * rewritten whenever detection genuinely runs — see self::store_detected_features().
+	 *
+	 * @return array A list of feature IDs
+	 * @since 6.17.0
+	 */
+	public static function get_detected_features(): array {
+		return (array) \GPDFAPI::get_options_class()->get_option( 'deprecated_features', [] );
+	}
+
+	/**
+	 * Record what a run of self::get_signals() found
+	 *
+	 * Called on every version change, which is when a new round of removals arrives, and again by the report and
+	 * Site Health screens, which detect live — so a site that has fixed everything stops being told about it
+	 * without waiting for the next release.
+	 *
+	 * @param array $signals The signals from self::get_signals()
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function store_detected_features( array $signals ): void {
+		$detected = array_keys( $signals );
+
+		if ( $detected !== static::get_detected_features() ) {
+			\GPDFAPI::get_options_class()->update_option( 'deprecated_features', $detected );
+		}
+	}
+
+	/**
+	 * Add a single feature to the record, when something detects it outside of a full detection run
+	 *
+	 * @param string $key The feature ID
+	 *
+	 * @since 6.17.0
+	 */
+	public static function mark_feature_detected( string $key ): void {
+		$detected = static::get_detected_features();
+
+		if ( in_array( $key, $detected, true ) ) {
+			return;
+		}
+
+		$detected[] = $key;
+
+		\GPDFAPI::get_options_class()->update_option( 'deprecated_features', $detected );
+	}
+
+	/**
+	 * Delete everything the providers have stored, so a new provider doesn't have to be added to the uninstaller
+	 *
+	 * The engine's own record needs no handling here: it lives in `gfpdf_settings`, which is deleted wholesale.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function delete_stored_data(): void {
+		foreach ( static::get_providers() as $provider ) {
+			foreach ( $provider::get_stored_options() as $option ) {
+				delete_option( $option );
+			}
+		}
+	}
+
+	/**
+	 * Detect what this site is using, and record it for the admin notices to read
+	 *
+	 * The notices read the record rather than detecting for themselves, so every surface that detects live
+	 * refreshes it as it goes and a site that has fixed everything stops being told about it.
+	 *
+	 * @return array<string, array> See self::get_signals()
+	 * @since 6.17.0
+	 */
+	public static function refresh_signals(): array {
+		$signals = static::get_signals();
+
+		static::store_detected_features( $signals );
+
+		return $signals;
+	}
+
+	/**
+	 * State what becomes of a feature, which is all its group and removal version have to say
+	 *
+	 * Read by every surface that reports the feature, so it says the same thing wherever it is named. The fallback
+	 * names the feature and the release, which suits most of them; one that reads badly out of the context its
+	 * report row gives it declares a `notice` of its own instead.
+	 *
+	 * @param array $feature The feature's registration
+	 *
+	 * @since 6.17.0
+	 */
+	public static function get_feature_notice( array $feature ): string {
+		/* A feature saying it better than the fallback can declares its own sentence */
+		if ( isset( $feature['notice'] ) ) {
+			return sprintf( $feature['notice'], $feature['removed_in'] );
+		}
+
+		if ( $feature['group'] === static::GROUP_UNSUPPORTED ) {
+			/* translators: %s: The name of the deprecated feature */
+			return sprintf( __( '%s is no longer supported.', 'gravity-pdf' ), $feature['label'] );
+		}
+
+		/* translators: 1: The name of the deprecated feature, 2: The Gravity PDF version it is removed in */
+		return sprintf( __( 'Support for %1$s will be removed in Gravity PDF %2$s.', 'gravity-pdf' ), $feature['label'], $feature['removed_in'] );
+	}
+
+	/**
+	 * The groups a registered feature belongs to, in the order they are reported
+	 *
+	 * A group nothing declares is left out, so no surface carries an empty section around until a later round of
+	 * removals has something to put in it.
+	 *
+	 * @return string[]
+	 * @since 6.17.0
+	 */
+	public static function get_groups(): array {
+		$declared = array_column( static::get_features(), 'group' );
+
+		return array_values(
+			array_filter(
+				[ static::GROUP_UNSUPPORTED, static::GROUP_DEPRECATED ],
+				static function ( $group ) use ( $declared ) {
+					return in_array( $group, $declared, true );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Split the detected signals by the group their feature belongs to
+	 *
+	 * @param array $signals The signals from self::get_signals()
+	 *
+	 * @return array<string, array> Group mapped to its signals, with empty groups omitted
+	 * @since 6.17.0
+	 */
+	public static function group_signals( array $signals ): array {
+		$features = static::get_features();
+		$groups   = array_fill_keys( static::get_groups(), [] );
+
+		foreach ( $signals as $key => $signal ) {
+			$groups[ $features[ $key ]['group'] ][ $key ] = $signal;
+		}
+
+		return array_filter( $groups );
+	}
+
+	/**
+	 * Fire one of the deprecated hooks, warning any third party still listening to it
+	 *
+	 * The version and replacement come from whichever registered feature owns the hook, so the notice names the
+	 * release it disappears in. It is only emitted when a listener is actually attached, so sites that have already
+	 * moved on stay quiet.
+	 *
+	 * @param string $hook_name   The deprecated filter to fire
+	 * @param array  $args        The arguments to pass to the filter, the first of which is returned
+	 * @param string $replacement Override the mapped replacement, for dynamic hooks
+	 *
+	 * @return mixed
+	 * @since 6.17.0
+	 */
+	public static function apply_filters( string $hook_name, array $args, string $replacement = '' ) {
+		/* Sidestep building the deprecation message on the vast majority of sites, which have no listener */
+		if ( ! has_filter( $hook_name ) ) {
+			return $args[0];
+		}
+
+		$feature    = static::get_feature_by_hook( $hook_name );
+		$removed_in = $feature['removed_in'] ?? '';
+
+		if ( $replacement === '' ) {
+			$replacement = $feature['hooks'][ $hook_name ] ?? '';
+		}
+
+		static::log_deprecated_filter( $hook_name, $replacement, $removed_in );
+
+		return apply_filters_deprecated(
+			$hook_name,
+			$args,
+			$feature['deprecated_in'] ?? '',
+			$replacement,
+			$removed_in === '' ? '' : sprintf(
+				/* translators: %s: The Gravity PDF version the filter is removed in */
+				esc_html__( 'This filter is removed in Gravity PDF %s.', 'gravity-pdf' ),
+				$removed_in
+			)
+		);
+	}
+
+	/**
+	 * Find the registered feature a deprecated hook belongs to
+	 *
+	 * @param string $hook_name The deprecated hook
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function get_feature_by_hook( string $hook_name ): array {
+		foreach ( static::get_features() as $feature ) {
+			$prefix = $feature['hook_prefix'] ?? '';
+
+			if ( isset( $feature['hooks'][ $hook_name ] ) || ( $prefix !== '' && strpos( $hook_name, $prefix ) === 0 ) ) {
+				return $feature;
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * Record a deprecated hook with a third-party listener in the Gravity PDF log
+	 *
+	 * Written once per hook per request so a PDF that fires the same filter for every field doesn't flood the log.
+	 *
+	 * @param string $hook_name   The deprecated filter being fired
+	 * @param string $replacement The filter to use instead, if one exists
+	 * @param string $removed_in  The Gravity PDF version it is removed in, if it is known
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function log_deprecated_filter( string $hook_name, string $replacement, string $removed_in ): void {
+		static $logged = [];
+
+		if ( isset( $logged[ $hook_name ] ) ) {
+			return;
+		}
+
+		/* Some deprecated hooks fire while the container is still being built, so the logger may not exist yet */
+		$log = \GPDFAPI::get_log_class();
+		if ( $log === null ) {
+			return;
+		}
+
+		$logged[ $hook_name ] = true;
+
+		$log->warning(
+			sprintf(
+				'The %1$s filter has a third-party listener attached%2$s.%3$s',
+				$hook_name,
+				$removed_in !== '' ? sprintf( ' and is removed in Gravity PDF %s', $removed_in ) : '',
+				$replacement !== '' ? sprintf( ' Use the %s filter instead.', $replacement ) : ''
+			)
+		);
+	}
+
+	/**
+	 * Get the deprecated hooks that currently have a third-party listener attached
+	 *
+	 * Walks every registered hook so dynamic ones, like `gfpdfe_pdf_template_{form_id}`, are included too. Only the
+	 * System Report and Site Health screens ask for this, so the walk stays off the paths that matter.
+	 *
+	 * @param array  $hooks            The known hooks, mapped to their replacement
+	 * @param string $prefix           Also match any hook starting with this
+	 * @param array  $ignore_callbacks The callbacks Gravity PDF registers itself, which aren't third party
+	 *
+	 * @return array<string, int> Hook name mapped to the number of listeners
+	 * @since 6.17.0
+	 */
+	public static function get_hooks_with_listeners( array $hooks, string $prefix = '', array $ignore_callbacks = [] ): array {
+		global $wp_filter;
+
+		$active = [];
+
+		foreach ( (array) $wp_filter as $name => $hook ) {
+			$name = (string) $name;
+
+			if ( ! isset( $hooks[ $name ] ) && ( $prefix === '' || strpos( $name, $prefix ) !== 0 ) ) {
+				continue;
+			}
+
+			$count = static::count_third_party_callbacks( $hook, $ignore_callbacks );
+			if ( $count > 0 ) {
+				$active[ $name ] = $count;
+			}
+		}
+
+		ksort( $active );
+
+		return $active;
+	}
+
+	/**
+	 * Count the callbacks on a hook, ignoring the ones Gravity PDF registers itself
+	 *
+	 * @param \WP_Hook $hook
+	 * @param array    $ignore_callbacks
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function count_third_party_callbacks( $hook, array $ignore_callbacks ): int {
+		$count = 0;
+
+		foreach ( $hook->callbacks ?? [] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( in_array( $callback['function'] ?? null, $ignore_callbacks, true ) ) {
+					continue;
+				}
+
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+}

--- a/src/Statics/Deprecation_V3.php
+++ b/src/Statics/Deprecation_V3.php
@@ -1,0 +1,552 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+use GFPDF\Helper\Helper_Interface_Deprecated_Features;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The v3 backwards compatibility layer, which Gravity PDF 7.0 removes
+ *
+ * @since 6.17.0
+ */
+class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
+
+	/**
+	 * The release the v3 backwards compatibility layer is removed in
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const REMOVED_IN = '7.0';
+
+	/**
+	 * The release the v3 backwards compatibility layer was deprecated in
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const DEPRECATED_IN = '4.0';
+
+	/**
+	 * The feature ID legacy download URLs are detected and reported under
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const FEATURE_LEGACY_ENDPOINT = 'legacy_endpoint';
+
+	/**
+	 * The query argument every legacy `?gf_pdf=1` download URL carries
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const LEGACY_URL_MARKER = 'gf_pdf=1';
+
+	/**
+	 * The option the forms that have served a legacy download URL are recorded in
+	 *
+	 * Kept out of `gfpdf_settings` and out of the autoloaded set: it is written from the front end, and only the
+	 * report, Site Health and uninstall paths ever read it.
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const LEGACY_ENDPOINT_OPTION = 'gfpdf_legacy_endpoint_usage';
+
+	/**
+	 * How long a form stays recorded after the last legacy download URL was served for it
+	 *
+	 * @var int
+	 * @since 6.17.0
+	 */
+	const LEGACY_ENDPOINT_TTL = 30 * DAY_IN_SECONDS;
+
+	/**
+	 * How often a form already on the record is written again
+	 *
+	 * @var int
+	 * @since 6.17.0
+	 */
+	const LEGACY_ENDPOINT_REFRESH = DAY_IN_SECONDS;
+
+	/**
+	 * The prefix every v3 hook carries, including the dynamic ones the map below can't name
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const HOOK_PREFIX = 'gfpdfe_';
+
+	/**
+	 * The call every Business Plus (Tier 2) template makes, and no plain v3 template does
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const BUSINESS_PLUS_MARKER = '$mpdf->';
+
+	/**
+	 * The class the v3 "Advanced Templating" (Tier 2) add-on declares
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const TIER_2_ADDON_CLASS = 'gfpdfe_business_plus';
+
+	/**
+	 * The `gfpdfe_pre_load_template` callback core registers itself, which the listener scan must ignore
+	 *
+	 * @var array
+	 * @since 6.17.0
+	 */
+	const INTERNAL_FILTER_CALLBACK = [ 'PDFRender', 'prepare_ids' ];
+
+	/**
+	 * What the legacy template scan found this request, keyed on the installed template list it read
+	 *
+	 * @var array<string, array<string, array<string, int[]>>>
+	 * @since 6.17.0
+	 */
+	protected static $legacy_templates = [];
+
+	/**
+	 * @inheritDoc
+	 * @since 6.17.0
+	 */
+	public static function get_features(): array {
+		return [
+			'legacy_templates'              => [
+				'label'      => __( 'Legacy Templates', 'gravity-pdf' ),
+				'group'      => Deprecation::GROUP_DEPRECATED,
+				'removed_in' => static::REMOVED_IN,
+				'url'        => 'https://docs.gravitypdf.com/upgrade/legacy-templates/',
+				'detect'     => [ static::class, 'get_legacy_templates' ],
+			],
+
+			'business_plus_templates'       => [
+				'label'      => __( 'Business Plus Templates', 'gravity-pdf' ),
+				'group'      => Deprecation::GROUP_DEPRECATED,
+				'removed_in' => static::REMOVED_IN,
+				'url'        => 'https://docs.gravitypdf.com/upgrade/legacy-templates/#business-plus--tier-2-template-upgrade-guide',
+				'detect'     => [ static::class, 'get_business_plus_templates' ],
+			],
+
+			static::FEATURE_LEGACY_ENDPOINT => [
+				'label'      => __( 'Legacy Download URLs', 'gravity-pdf' ),
+				'group'      => Deprecation::GROUP_DEPRECATED,
+				'removed_in' => static::REMOVED_IN,
+				'url'        => 'https://docs.gravitypdf.com/upgrade/legacy-download-urls/',
+				'detect'     => [ static::class, 'get_legacy_download_urls' ],
+				/* translators: %s: The Gravity PDF version the feature is removed in */
+				'notice'     => __( 'Support for legacy download URLs will be removed in Gravity PDF %s.', 'gravity-pdf' ),
+			],
+
+			'deprecated_filters'            => [
+				'label'         => __( 'Actions and Filters', 'gravity-pdf' ),
+				'group'         => Deprecation::GROUP_DEPRECATED,
+				'removed_in'    => static::REMOVED_IN,
+				'url'           => 'https://docs.gravitypdf.com/upgrade/deprecated-filters/',
+				'detect'        => [ static::class, 'get_active_deprecated_filters' ],
+				/* The label is a category, so out of its report row the fallback would read as the whole hook API */
+				/* translators: %s: The Gravity PDF version the hooks are removed in */
+				'notice'        => __( 'Code on this site uses Gravity PDF hooks that are removed in version %s.', 'gravity-pdf' ),
+				'hooks'         => static::get_deprecated_filters(),
+				'deprecated_in' => static::DEPRECATED_IN,
+				'hook_prefix'   => static::HOOK_PREFIX,
+			],
+		];
+	}
+
+	/**
+	 * The deprecated v3 filters still fired by core, mapped to their v4+ replacement
+	 *
+	 * An empty replacement means no equivalent exists.
+	 *
+	 * @return array<string, string>
+	 * @since 6.17.0
+	 */
+	protected static function get_deprecated_filters(): array {
+		return [
+			'gfpdfe_template_location'              => 'gfpdf_template_location',
+			'gfpdfe_template_location_uri'          => 'gfpdf_template_location_uri',
+			'gfpdfe_pdf_output_type'                => '',
+			'gfpdfe_pdf_name'                       => 'gfpdf_pdf_config',
+			'gfpdfe_template'                       => 'gfpdf_pdf_config',
+			'gfpdfe_pdf_filename'                   => 'gfpdf_pdf_filename',
+			'gfpdfe_pdf_template'                   => 'gfpdf_pdf_html_output',
+			'gfpdfe_mpdf_class_pre_render'          => 'gfpdf_mpdf_class',
+			'gfpdfe_pre_render_pdf'                 => 'gfpdf_mpdf_class',
+			'gfpdfe_mpdf_class'                     => 'gfpdf_mpdf_class',
+			'gfpdfe_lead_id'                        => 'gfpdf_template_args',
+			'gfpdfe_signature_width'                => 'gfpdf_signature_width',
+			'gfpdfe_pre_load_template'              => '',
+			'gfpdf_orientation'                     => 'gfpdf_pdf_config',
+			'gfpdf_security'                        => 'gfpdf_pdf_config',
+			'gfpdf_privilages'                      => 'gfpdf_pdf_config',
+			'gfpdf_password'                        => 'gfpdf_pdf_config',
+			'gfpdf_master_password'                 => 'gfpdf_pdf_config',
+			'gfpdf_rtl'                             => 'gfpdf_pdf_config',
+
+			/* Fired by the v3 endpoint and template layers, and removed along with them */
+			'gfpdf_legacy_save_path'                => '',
+			'gfpdf_legacy_templates'                => '',
+			'gfpdf_legacy_pre_view_or_download_pdf' => '',
+		];
+	}
+
+	/**
+	 * Get the deprecated v3 filters that currently have a third-party listener attached
+	 *
+	 * @return array<string, int> Hook name mapped to the number of listeners
+	 * @since 6.17.0
+	 */
+	public static function get_active_deprecated_filters(): array {
+		return Deprecation::get_hooks_with_listeners(
+			static::get_deprecated_filters(),
+			static::HOOK_PREFIX,
+			[ static::INTERNAL_FILTER_CALLBACK ]
+		);
+	}
+
+	/**
+	 * Restore the `RGForms` class the v3 template boilerplate guards on
+	 *
+	 * Gravity Forms declared `RGForms` as an empty subclass of `GFForms`, deprecated it in 2.10.5 and removed it in
+	 * 3.0. Every v3 template opens by checking for it and returning when it's missing, so the PDF renders with no
+	 * content at all — no fatal, and nothing in the log to explain the blank page. Aliasing the class it extended
+	 * puts the check back in the only place it still matters, until 7.0 removes these templates along with it.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function restore_v3_form_class(): void {
+		if ( class_exists( 'RGForms' ) || ! class_exists( 'GFForms' ) ) {
+			return;
+		}
+
+		class_alias( 'GFForms', 'RGForms' );
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 6.17.0
+	 */
+	public static function get_stored_options(): array {
+		return [ static::LEGACY_ENDPOINT_OPTION ];
+	}
+
+	/**
+	 * Get the forms still tied to a legacy `?gf_pdf=1` download URL
+	 *
+	 * Two sources are combined: the forms whose stored settings, confirmations or notifications hand one of these
+	 * URLs out, and the forms one has actually been served for — see self::record_legacy_endpoint_usage(). The scan
+	 * finds a URL nobody has followed yet; the record finds one living somewhere the scan can't see, like a page or
+	 * an email that has already gone out.
+	 *
+	 * @return array List of form IDs, ascending
+	 * @since 6.17.0
+	 */
+	public static function get_legacy_download_urls(): array {
+		global $wpdb;
+
+		$marker = '%' . $wpdb->esc_like( static::LEGACY_URL_MARKER ) . '%';
+
+		/* Recorded IDs are cast on the way in and out, so they're safe to interpolate */
+		$recorded        = static::get_recorded_legacy_endpoint_usage();
+		$recorded_clause = $recorded === [] ? '' : sprintf( 'meta.form_id IN ( %s ) OR', implode( ',', $recorded ) );
+
+		$forms = static::scan_forms(
+			'meta.form_id',
+			"{$recorded_clause} meta.display_meta LIKE %s OR meta.confirmations LIKE %s OR meta.notifications LIKE %s",
+			[ $marker, $marker, $marker ]
+		);
+
+		return array_map( 'intval', array_column( $forms, 'form_id' ) );
+	}
+
+	/**
+	 * Scan the stored forms for one of the signals this class detects
+	 *
+	 * Trashed forms are left out of every scan: the user can't see them in their form list, so there's nothing for
+	 * them to act on.
+	 *
+	 * @param string $columns  The columns to select, from the `meta` and `form` tables the query names below
+	 * @param string $criteria What a form has to match, carrying one `%s` placeholder per entry in $values
+	 * @param array  $values   One value per placeholder in $criteria
+	 *
+	 * @return array<int, array<string, string>> One row per matching form, by form ID ascending
+	 * @since 6.17.0
+	 */
+	protected static function scan_forms( string $columns, string $criteria, array $values ): array {
+		global $wpdb;
+
+		$meta_table = \GFFormsModel::get_meta_table_name();
+		$form_table = \GFFormsModel::get_form_table_name();
+
+		/* The table names come from Gravity Forms, and every caller value travels as a placeholder in $values */
+		//phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders
+		return (array) $wpdb->get_results( //phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT {$columns} FROM {$meta_table} meta
+				INNER JOIN {$form_table} form ON form.id = meta.form_id
+				WHERE form.is_trash = 0 AND ( {$criteria} )
+				ORDER BY meta.form_id",
+				$values
+			),
+			ARRAY_A
+		);
+		//phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders
+	}
+
+	/**
+	 * The forms a legacy `?gf_pdf=1` download URL has actually been served for
+	 *
+	 * A record older than self::LEGACY_ENDPOINT_TTL is dropped as it's read, so a form stops being reported once
+	 * the links pointing at it have gone quiet. Gravity PDF can't tell whether a URL it served last year still
+	 * exists, and without an expiry the form would be reported forever.
+	 *
+	 * @return array List of form IDs, ascending
+	 * @since 6.17.0
+	 */
+	public static function get_recorded_legacy_endpoint_usage(): array {
+		$recorded = array_map( 'intval', static::get_legacy_endpoint_records() );
+		$cutoff   = time() - static::LEGACY_ENDPOINT_TTL;
+
+		ksort( $recorded );
+
+		$current = array_filter(
+			$recorded,
+			function ( $last_served ) use ( $cutoff ) {
+				return $last_served >= $cutoff;
+			}
+		);
+
+		if ( $current !== $recorded ) {
+			update_option( static::LEGACY_ENDPOINT_OPTION, $current, false );
+		}
+
+		return array_map( 'intval', array_keys( $current ) );
+	}
+
+	/**
+	 * The raw record, mapping each form to when a legacy download URL was last served for it
+	 *
+	 * Left in the order it was stored: the front end reads this on every legacy download to check one timestamp,
+	 * and only self::get_recorded_legacy_endpoint_usage() promises an order.
+	 *
+	 * @return array<int, int> Form ID mapped to a Unix timestamp
+	 * @since 6.17.0
+	 */
+	protected static function get_legacy_endpoint_records(): array {
+		return (array) get_option( static::LEGACY_ENDPOINT_OPTION, [] );
+	}
+
+	/**
+	 * Record that a legacy `?gf_pdf=1` download URL has been served for a form
+	 *
+	 * Called by the endpoint itself, once it has resolved the request to a real PDF, so a URL that lives outside the
+	 * form's own settings is still reported. The timestamp is what self::get_recorded_legacy_endpoint_usage() expires
+	 * the form on, so it's refreshed while the links are still being followed — at most once a day, since this runs
+	 * on the front end.
+	 *
+	 * @param int $form_id The form the PDF was served from
+	 *
+	 * @since 6.17.0
+	 */
+	public static function record_legacy_endpoint_usage( int $form_id ): void {
+		$recorded = static::get_legacy_endpoint_records();
+		$now      = time();
+
+		if ( ( $recorded[ $form_id ] ?? 0 ) > $now - static::LEGACY_ENDPOINT_REFRESH ) {
+			return;
+		}
+
+		$recorded[ $form_id ] = $now;
+
+		update_option( static::LEGACY_ENDPOINT_OPTION, $recorded, false );
+
+		/* The notices read a record taken at install and on each version change, which a URL followed since then
+		   won't be in yet */
+		Deprecation::mark_feature_detected( static::FEATURE_LEGACY_ENDPOINT );
+	}
+
+	/**
+	 * Check if the v3 "Advanced Templating" (Tier 2) add-on is installed
+	 *
+	 * @since 6.17.0
+	 */
+	public static function has_tier_2_addon(): bool {
+		return class_exists( static::TIER_2_ADDON_CLASS );
+	}
+
+	/**
+	 * Check if a PDF is configured to use the v3 Advanced Templating mode
+	 *
+	 * Compared case-insensitively, which is how the render path has always read the setting.
+	 *
+	 * @param array $settings The PDF settings
+	 *
+	 * @since 6.17.0
+	 */
+	public static function is_advanced_template_pdf( array $settings ): bool {
+		return strtolower( (string) ( $settings['advanced_template'] ?? '' ) ) === 'yes';
+	}
+
+	/**
+	 * Get the installed legacy (v3) PDF templates written as plain HTML and CSS
+	 *
+	 * @return array<string, int[]> Absolute template path mapped to the forms it is configured on
+	 * @since 6.17.0
+	 */
+	public static function get_legacy_templates(): array {
+		return static::get_legacy_templates_by_kind()['standard'];
+	}
+
+	/**
+	 * Get the installed legacy (v3) PDF templates that drive the PDF engine themselves
+	 *
+	 * These were built by our own team and sold as Business Plus, or Tier 2, alongside the plugin now reported as
+	 * the Advanced Templating add-on. They upgrade differently to a plain v3 template, so they're reported apart.
+	 *
+	 * @return array<string, int[]> Absolute template path mapped to the forms it is configured on
+	 * @since 6.17.0
+	 */
+	public static function get_business_plus_templates(): array {
+		return static::get_legacy_templates_by_kind()['business_plus'];
+	}
+
+	/**
+	 * Get every installed legacy (v3) PDF template, split by the kind of template it is
+	 *
+	 * A template is classified as legacy when it has no `Group` header, which is how Helper_Templates groups
+	 * v3-era templates that predate the v4 header format. What the file does with the PDF engine then says which
+	 * of the two kinds it is — the PDF's own settings aren't consulted, so a template is reported for what it is
+	 * rather than for how one PDF happens to be configured. Which forms select it is then carried alongside, so a
+	 * report says what actually breaks when the file stops rendering.
+	 *
+	 * @return array<string, array<string, int[]>> The `standard` and `business_plus` templates, each mapped to the
+	 *                                            forms it is configured on
+	 * @since 6.17.0
+	 */
+	protected static function get_legacy_templates_by_kind(): array {
+		$templates = \GPDFAPI::get_templates_class();
+
+		/* Both detectors ask, so the walk, the file reads and the form scan happen once rather than once per
+		   detector. Keyed on the installed template list, which a template being added or removed changes; the
+		   form usage carried alongside it is held for the request, and dropped by self::flush_cache() */
+		$key = implode( '|', $templates->get_all_templates() );
+
+		if ( ! isset( static::$legacy_templates[ $key ] ) ) {
+			$legacy = array_filter( $templates->get_all_template_info(), [ $templates, 'is_legacy_template' ] );
+			$usage  = static::get_forms_using_templates( array_column( $legacy, 'id' ) );
+
+			$kinds = [
+				'standard'      => [],
+				'business_plus' => [],
+			];
+
+			foreach ( $legacy as $template ) {
+				$kind = static::is_business_plus_template( $template['path'] ) ? 'business_plus' : 'standard';
+
+				$kinds[ $kind ][ $template['path'] ] = $usage[ $template['id'] ];
+			}
+
+			static::$legacy_templates[ $key ] = $kinds;
+		}
+
+		return static::$legacy_templates[ $key ];
+	}
+
+	/**
+	 * Forget what the legacy template scan found this request
+	 *
+	 * The scan reads the template directory and the stored forms, and nothing changes either between the two
+	 * detectors asking, so what it finds is held for the request. Anything that does change them while a request
+	 * is still running has to say so here.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function flush_cache(): void {
+		static::$legacy_templates = [];
+	}
+
+	/**
+	 * Get the forms each of the given templates is selected on
+	 *
+	 * Trashed forms are skipped, as they are everywhere else here: the user can't see them in their form list, so
+	 * there's nothing to act on. A PDF is counted whether or not it's active, since a disabled one still has to be
+	 * moved off the template before it can be turned back on.
+	 *
+	 * @param string[] $template_ids Template IDs, as Helper_Templates writes them into a PDF's settings
+	 *
+	 * @return array<string, int[]> Template ID mapped to the forms configured with it, ascending
+	 * @since 6.17.0
+	 */
+	protected static function get_forms_using_templates( array $template_ids ): array {
+		global $wpdb;
+
+		if ( $template_ids === [] ) {
+			return [];
+		}
+
+		$usage = array_fill_keys( $template_ids, [] );
+
+		/* A form configured with a template carries its ID somewhere in the stored form, so a LIKE per template
+		   narrows the scan to the rows worth reading — the whole form travels back, and on a site of any size
+		   that is most of what the query costs. Which template each PDF actually selects is a JSON value, so the
+		   decode below is what settles it */
+		$criteria = implode( ' OR ', array_fill( 0, count( $usage ), 'meta.display_meta LIKE %s' ) );
+		$values   = array_map(
+			static function ( $id ) use ( $wpdb ) {
+				return '%' . $wpdb->esc_like( $id ) . '%';
+			},
+			array_keys( $usage )
+		);
+
+		foreach ( static::scan_forms( 'meta.form_id, meta.display_meta', $criteria, $values ) as $form ) {
+			$meta    = json_decode( (string) $form['display_meta'], true );
+			$form_id = (int) $form['form_id'];
+
+			foreach ( (array) ( $meta['gfpdf_form_settings'] ?? [] ) as $pdf ) {
+				$template = (string) ( $pdf['template'] ?? '' );
+
+				/* A form with several PDFs on the one template is still the one form to fix */
+				if ( isset( $usage[ $template ] ) && ! in_array( $form_id, $usage[ $template ], true ) ) {
+					$usage[ $template ][] = $form_id;
+				}
+			}
+		}
+
+		return $usage;
+	}
+
+	/**
+	 * Check whether a legacy template drives the PDF engine itself
+	 *
+	 * Direct access to the engine is the one thing the Advanced Templating add-on gave a template and a plain v3
+	 * template never had, so the call is what tells the two apart.
+	 *
+	 * @param string $path The absolute path to the template file
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function is_business_plus_template( string $path ): bool {
+		//phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$contents = is_readable( $path ) ? (string) file_get_contents( $path ) : '';
+
+		return strpos( $contents, static::BUSINESS_PLUS_MARKER ) !== false;
+	}
+}

--- a/src/Statics/Queue_Callbacks.php
+++ b/src/Statics/Queue_Callbacks.php
@@ -127,7 +127,7 @@ class Queue_Callbacks {
 	 * @deprecated 6.12 Caching layer + auto-purge added
 	 */
 	public static function cleanup_pdfs( $form_id, $entry_id ) {
-		_doing_it_wrong( __METHOD__, 'This method is deprecated and no alternative is available. The temporary cache is automatically cleaned every hour using the WP Cron.', '6.12' );
+		_deprecated_function( __METHOD__, '6.12' );
 
 		$gform = GPDFAPI::get_form_class();
 		$log   = GPDFAPI::get_log_class();

--- a/src/View/View_Actions.php
+++ b/src/View/View_Actions.php
@@ -3,6 +3,7 @@
 namespace GFPDF\View;
 
 use GFPDF\Helper\Helper_Abstract_View;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -68,6 +69,40 @@ class View_Actions extends Helper_Abstract_View {
 
 		$html  = $this->load( 'core_font', [], false );
 		$html .= $this->get_action_buttons( $type, $button_text, 'disabled' );
+
+		return $html;
+	}
+
+	/**
+	 * Load the notice for the deprecated functionality the site still uses
+	 *
+	 * One notice lists them all, each named the same way so the list scans. That is deliberately the registration's
+	 * own sentence rather than the tailored copy the report writes per feature: "These hooks will be removed"
+	 * makes sense under a row titled Actions and Filters, and not in a list where nothing else names it. The
+	 * detections are left to the report the button links to, since a notice is read at a glance and the template
+	 * files or form IDs behind a feature can run long.
+	 *
+	 * @param string[] $keys        The feature IDs from Deprecation::get_features()
+	 * @param string   $type        The action ID
+	 * @param string   $button_text The primary button text
+	 *
+	 * @return string The notice HTML
+	 * @since 6.17.0
+	 */
+	public function deprecated_features( array $keys, string $type, string $button_text ): string {
+		$features = [];
+
+		foreach ( $keys as $key ) {
+			$feature = Deprecation::get_feature( $key );
+
+			$features[] = [
+				'notice' => Deprecation::get_feature_notice( $feature ),
+				'url'    => $feature['url'],
+			];
+		}
+
+		$html  = $this->load( 'deprecated_features', [ 'features' => $features ], false );
+		$html .= $this->get_action_buttons( $type, $button_text );
 
 		return $html;
 	}

--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -20,6 +20,8 @@ use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Templates;
 use GFPDF\Statics\Debug;
+use GFPDF\Statics\Deprecation;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF\Statics\Kses;
 use GFPDFEntryDetail;
 use GFPDF_Vendor\Psr\Log\LoggerInterface;
@@ -151,7 +153,7 @@ class View_PDF extends Helper_Abstract_View {
 	 * @deprecated 6.12.0 Use \GPDFAPI::create_pdf() to generate PDFs
 	 */
 	public function generate_pdf( $entry, $settings ) {
-		_doing_it_wrong( __METHOD__, 'Use \GPDFAPI::create_pdf() to generate PDFs', '6.12' );
+		_deprecated_function( __METHOD__, '6.12', '\GPDFAPI::create_pdf()' );
 
 		$controller = $this->getController();
 		$model      = $controller->model;
@@ -159,7 +161,7 @@ class View_PDF extends Helper_Abstract_View {
 
 		do_action( 'gfpdf_view_or_download_pdf', $form, $entry, $settings );
 
-		$settings['pdf_action'] = apply_filters( 'gfpdfe_pdf_output_type', $settings['pdf_action'] ?? 'download' ); /* Backwards compat */
+		$settings['pdf_action'] = Deprecation::apply_filters( 'gfpdfe_pdf_output_type', [ $settings['pdf_action'] ?? 'download' ] );
 
 		/* Setup the PDF that will be generated */
 		$pdf_generator = new Helper_PDF( $entry, $settings, $this->gform, $this->data, $this->misc, $this->templates, $this->log );
@@ -200,7 +202,7 @@ class View_PDF extends Helper_Abstract_View {
 			}
 
 			/* Add Backwards compatibility support for our v3 Tier 2 Add-on */
-			if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) === 'yes' ) {
+			if ( Deprecation_V3::is_advanced_template_pdf( $settings ) ) {
 
 				/* Check if we should process this document using our legacy system */
 				if ( $model->handle_legacy_tier_2_processing( $pdf_generator, $entry, $settings, $args ) ) {
@@ -256,7 +258,7 @@ class View_PDF extends Helper_Abstract_View {
 	 * @deprecated 4.1
 	 */
 	public function get_template_filename( $name ) {
-		_doing_it_wrong( __METHOD__, 'This method has been replaced by Helper_Misc::get_file_with_extension().', '4.1' );
+		_deprecated_function( __METHOD__, '4.1', 'Helper_Misc::get_file_with_extension()' );
 
 		return $this->misc->get_file_with_extension( $name, '.php' );
 	}
@@ -496,6 +498,7 @@ class View_PDF extends Helper_Abstract_View {
 	 * @deprecated 6.10.1 Page fields are handled like all other fields, with markup generated using a dedicated Field_Page class
 	 */
 	public function display_page_name( $page, $form, Helper_Field_Container $container ) {
+		_deprecated_function( __METHOD__, '6.10.1', 'GFPDF\Helper\Fields\Field_Page' );
 
 		/* Only display the current page name if it exists */
 		if ( isset( $form['pagination']['pages'][ $page ] ) && strlen( trim( $form['pagination']['pages'][ $page ] ) ) > 0 ) {
@@ -540,16 +543,14 @@ class View_PDF extends Helper_Abstract_View {
 	 * @since 4.0
 	 */
 	public function autoprocess_core_template_options( $html, $form, $entry, $settings ) {
-		/* Prevent core styles loading if a v3 template or using our legacy Tier 2 add-on */
 		$template_info = $this->templates->get_template_info_by_id( $settings['template'] );
-		if (
-			( esc_html__( 'Legacy', 'gravity-pdf' ) !== $template_info['group'] ) &&
-			( empty( $settings['advanced_template'] ) || 'Yes' !== $settings['advanced_template'] )
-		) {
-			$html = $this->get_core_template_styles( $settings, $entry ) . $html;
+
+		/* A v3 template brings its own styles, and the Tier 2 add-on renders the document itself */
+		if ( $this->templates->is_legacy_template( $template_info ) || Deprecation_V3::is_advanced_template_pdf( $settings ) ) {
+			return $html;
 		}
 
-		return $html;
+		return $this->get_core_template_styles( $settings, $entry ) . $html;
 	}
 
 	/**

--- a/src/View/View_Settings.php
+++ b/src/View/View_Settings.php
@@ -137,6 +137,8 @@ class View_Settings extends Helper_Abstract_View {
 	 * @deprecated 6.4
 	 */
 	public function tabs() {
+		_deprecated_function( __METHOD__, '6.4', 'View_Settings::sub_menu()' );
+
 		ob_start();
 		$this->sub_menu();
 

--- a/src/View/View_System_Report.php
+++ b/src/View/View_System_Report.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace GFPDF\View;
 
 use GFPDF\Helper\Helper_Abstract_View;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -146,6 +147,366 @@ class View_System_Report extends Helper_Abstract_View {
 	public function get_template_upgrade_message(): string {
 		$learn_more_url = 'https://docs.gravitypdf.com/developers/template-hierarchy';
 
-		return $this->markup_warning . ' <a href="' . $learn_more_url . '">' . esc_html__( 'Learn how to update', 'gravity-pdf' ) . '</a>';
+		return $this->markup_warning . ' <a href="' . esc_url( $learn_more_url ) . '">' . esc_html__( 'Learn how to update', 'gravity-pdf' ) . '</a>';
+	}
+
+	/**
+	 * Describe one of the deprecated features detected on this site
+	 *
+	 * Shared by the Gravity Forms system report and the Site Health test, which present the same detections
+	 * differently.
+	 *
+	 * @param string $key    The signal key from Deprecation::get_signals()
+	 * @param array  $signal The detections recorded for that signal
+	 *
+	 * @return array The `label` this feature is known by, one `lines` entry per detection, plus the `notice` its
+	 *               registration states and the `url` explaining it. A feature may also carry `html`, escaped
+	 *               markup the display surfaces show in place of `lines`. Every other value is unescaped, as one
+	 *               of the three consumers is the Site Health Info tab, which escapes what it's given.
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_feature( string $key, array $signal ): array {
+		$feature      = Deprecation::get_feature( $key );
+		$descriptions = $this->get_deprecated_feature_descriptions();
+
+		$description = isset( $descriptions[ $key ] )
+			? call_user_func( $descriptions[ $key ], $signal, $feature )
+			: $this->get_default_feature_description( $signal );
+
+		/* Whatever the description leaves out, the feature's own registration answers */
+		return $description + [
+			'label'  => $feature['label'],
+			'notice' => Deprecation::get_feature_notice( $feature ),
+			'url'    => $feature['url'],
+		];
+	}
+
+	/**
+	 * The method that describes each feature's detections, keyed by the feature it describes
+	 *
+	 * A feature with no entry here is described generically, so a newly registered one reports something usable
+	 * before it has copy of its own.
+	 *
+	 * @return array<string, callable>
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_feature_descriptions(): array {
+		return [
+			'legacy_templates'        => [ $this, 'get_legacy_templates_feature' ],
+			'business_plus_templates' => [ $this, 'get_legacy_templates_feature' ],
+			'legacy_endpoint'         => [ $this, 'get_legacy_endpoint_feature' ],
+			'deprecated_filters'      => [ $this, 'get_deprecated_filter_feature' ],
+		];
+	}
+
+	/**
+	 * Describe a feature's detections when it carries no copy of its own
+	 *
+	 * @param array $signal The detections recorded for the feature
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_default_feature_description( array $signal ): array {
+		$lines = [];
+
+		/* A detection is named by its key where it has one, as the hooks and the templates are, or is the value
+		   itself. A keyed detection's value is the feature's own business, so it is left to describe it */
+		foreach ( $signal as $key => $detection ) {
+			$lines[] = is_string( $key ) ? $key : (string) $detection;
+		}
+
+		return [ 'lines' => $lines ];
+	}
+
+	/**
+	 * Describe any installed legacy (v3) template file(s), and the forms each is configured on
+	 *
+	 * A template no form selects is named as such rather than left bare, so the reader isn't left deciding whether
+	 * the forms were checked or simply not listed.
+	 *
+	 * @param array $templates Absolute template path mapped to the forms it is configured on
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_legacy_templates_feature( array $templates ): array {
+		$lines = [];
+		$html  = [];
+
+		foreach ( $templates as $path => $form_ids ) {
+			/* Templates live in one directory the report states of its own, so the file name is enough to find them */
+			$name = basename( $path );
+
+			if ( $form_ids === [] ) {
+				/* translators: %1$s: The template file name */
+				$format = __( '%1$s (not configured on a form)', 'gravity-pdf' );
+			} else {
+				/* translators: 1: The template file name, 2: Comma separated list of form IDs */
+				$format = _n( '%1$s (form ID %2$s)', '%1$s (form IDs %2$s)', count( $form_ids ), 'gravity-pdf' );
+			}
+
+			/* One format, applied twice: the surfaces taking the plain text get the IDs, the ones taking markup
+			   get them linked. The unused sentence names no forms and ignores the second argument */
+			$lines[] = sprintf( $format, $name, implode( ', ', $form_ids ) );
+			$html[]  = sprintf( esc_html( $format ), esc_html( $name ), implode( ', ', $this->get_form_settings_links( $form_ids ) ) );
+		}
+
+		return [
+			'lines' => $lines,
+			/* Every display surface links to the PDF settings of each form, which is where the template is changed */
+			'html'  => implode( ', ', $html ),
+		];
+	}
+
+	/**
+	 * Describe the forms that still hand out a legacy `?gf_pdf=1` download URL
+	 *
+	 * @param array $form_ids The forms the URLs were found on
+	 * @param array $feature  The feature's registration
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_legacy_endpoint_feature( array $form_ids, array $feature ): array {
+		/* translators: %s: Comma separated list of form IDs */
+		$in_use = __( 'In use on form ID %s', 'gravity-pdf' );
+
+		return [
+			'lines' => [ sprintf( $in_use, implode( ', ', $form_ids ) ) ],
+			/* Every display surface links to the PDF settings of each form, which is where the URLs are replaced */
+			'html'  => sprintf( esc_html( $in_use ), implode( ', ', $this->get_form_settings_links( $form_ids ) ) ),
+		];
+	}
+
+	/**
+	 * Link each form to its Gravity PDF settings, which is where what was detected on it is changed
+	 *
+	 * @param array $form_ids The forms to link
+	 *
+	 * @return string[] One escaped link per form, in the order given
+	 * @since 6.17.0
+	 */
+	protected function get_form_settings_links( array $form_ids ): array {
+		return array_map(
+			static function ( $form_id ) {
+				$url = admin_url( sprintf( 'admin.php?page=gf_edit_forms&view=settings&subview=PDF&id=%d', $form_id ) );
+
+				return '<a href="' . esc_url( $url ) . '">' . (int) $form_id . '</a>';
+			},
+			$form_ids
+		);
+	}
+
+	/**
+	 * Describe the deprecated v3 filters that have a third-party listener attached
+	 *
+	 * @param array $filters Hook name mapped to the number of listeners
+	 * @param array $feature The feature's registration
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_filter_feature( array $filters, array $feature ): array {
+		$lines = [];
+
+		foreach ( $filters as $name => $count ) {
+			$lines[] = sprintf(
+				/* translators: 1: Filter name, 2: Number of callbacks attached to it */
+				_n( '%1$s has %2$d listener', '%1$s has %2$d listeners', $count, 'gravity-pdf' ),
+				$name,
+				$count
+			);
+		}
+
+		return [ 'lines' => $lines ];
+	}
+
+	/**
+	 * Assemble the Gravity Forms system report row for a detected feature
+	 *
+	 * The report keeps a row to a single line, so a feature offering a terser set of detections is listed by that
+	 * instead of the whole story the Site Health screens tell.
+	 *
+	 * @param string $key    The signal key from Deprecation::get_signals()
+	 * @param array  $signal The detections recorded for that signal
+	 *
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_feature_report_item( string $key, array $signal ): array {
+		$feature = $this->get_deprecated_feature( $key, $signal );
+
+		/* Every row is handed over as a failure, so Gravity Forms draws the cross and the red message itself */
+		return [ 'is_valid' => false ] + $this->get_deprecated_feature_values( $feature, $feature['lines'] );
+	}
+
+	/**
+	 * Assemble the Site Health account of a detected feature
+	 *
+	 * Both Site Health screens have room for every detection, so they list them in full: the test takes the escaped
+	 * values and the Info tab the `_export` ones.
+	 *
+	 * @param string $key    The signal key from Deprecation::get_signals()
+	 * @param array  $signal The detections recorded for that signal
+	 *
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_feature_detail( string $key, array $signal ): array {
+		$feature = $this->get_deprecated_feature( $key, $signal );
+
+		return $this->get_deprecated_feature_values( $feature, $feature['lines'] );
+	}
+
+	/**
+	 * Assemble the display and export values a surface shows for a detected feature
+	 *
+	 * @param array $feature The feature, from self::get_deprecated_feature()
+	 * @param array $lines   The detections the surface has room to list
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_feature_values( array $feature, array $lines ): array {
+		$value = implode( ', ', $lines );
+
+		return [
+			'label'                     => esc_html( $feature['label'] ),
+			'label_export'              => $feature['label'],
+			'value'                     => $feature['html'] ?? esc_html( $value ),
+			'value_export'              => $value,
+			'validation_message'        => $this->get_removal_message( $feature['notice'], $feature['url'] ),
+			'validation_message_export' => $feature['notice'] . ' ' . $feature['url'],
+		];
+	}
+
+	/**
+	 * The name each group is known by, and what belonging to it means
+	 *
+	 * Both Site Health screens show the description; the system report has no room for it and titles its sections
+	 * with the name alone. Deprecation::get_groups() decides which of them a surface sees.
+	 *
+	 * @return array<string, array<string, string>>
+	 * @since 6.17.0
+	 */
+	public static function get_deprecated_groups(): array {
+		$names = [
+			Deprecation::GROUP_UNSUPPORTED => [
+				'label'       => __( 'Unsupported', 'gravity-pdf' ),
+				'description' => __( 'These features have been removed and any Gravity PDF document that relied on them will stop working.', 'gravity-pdf' ),
+			],
+
+			Deprecation::GROUP_DEPRECATED  => [
+				'label'       => __( 'Deprecated', 'gravity-pdf' ),
+				'description' => __( "Legacy functionality that will be removed in an upcoming release. It's important to fix each item to keep your PDFs working correctly.", 'gravity-pdf' ),
+			],
+		];
+
+		return array_intersect_key( $names, array_flip( Deprecation::get_groups() ) );
+	}
+
+	/**
+	 * Build the Site Health test result for the deprecated features detected on this site
+	 *
+	 * Unlike the one-time admin notice, this surface can't be dismissed: it clears itself once the site stops
+	 * using the deprecated functionality, and returns if it starts again.
+	 *
+	 * @param array $signals The signals from Deprecation::get_signals()
+	 *
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_features_test( array $signals ): array {
+		/* One result covers every round of removals at once, so it names no version: each item below names its own */
+		$result = [
+			'label'       => esc_html__( 'Your PDFs are ready for the next Gravity PDF release', 'gravity-pdf' ),
+			'status'      => 'good',
+			'badge'       => [
+				'label' => esc_html__( 'Gravity PDF', 'gravity-pdf' ),
+				'color' => 'blue',
+			],
+			'description' => '<p>' . esc_html__( 'Nothing on this site relies on Gravity PDF functionality that is scheduled for removal, so there is nothing to do.', 'gravity-pdf' ) . '</p>',
+			'actions'     => '',
+			'test'        => 'gravity_pdf_deprecated_features',
+		];
+
+		if ( $signals === [] ) {
+			return $result;
+		}
+
+		$result['status'] = 'recommended';
+		$result['label']  = esc_html__( 'Your site uses Gravity PDF functionality that is scheduled for removal', 'gravity-pdf' );
+
+		$result['description'] = '<p>' . esc_html__( 'Update each item below before the release that removes it, so the PDFs that rely on it will continue working. Each one links to instructions to upgrade.', 'gravity-pdf' ) . '</p>';
+
+		$groups = static::get_deprecated_groups();
+		foreach ( Deprecation::group_signals( $signals ) as $group => $group_signals ) {
+			$result['description'] .= '<h4>' . esc_html( $groups[ $group ]['label'] ) . '</h4>';
+			$result['description'] .= '<p>' . esc_html( $groups[ $group ]['description'] ) . '</p>';
+
+			foreach ( $group_signals as $key => $signal ) {
+				$message = $this->get_deprecated_feature_detail( $key, $signal );
+
+				$result['description'] .= '<p><strong>' . $message['label'] . '</strong><br>' .
+					$message['value'] . '. ' . $message['validation_message'] . '</p>';
+			}
+		}
+
+		$result['actions'] = '<p><a href="' . esc_url( admin_url( 'admin.php?page=gf_system_status' ) ) . '">' . esc_html__( 'View the Gravity Forms system report', 'gravity-pdf' ) . '</a></p>';
+
+		return $result;
+	}
+
+	/**
+	 * Prepare the advice Gravity Forms shows after a deprecated feature's detections
+	 *
+	 * @param string $notice What happens to the feature
+	 * @param string $url    Where to read more about that action
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_removal_message( string $notice, string $url ): string {
+		return esc_html( $notice ) . ' <a href="' . esc_url( $url ) . '">' . esc_html__( 'Learn how to upgrade', 'gravity-pdf' ) . '</a>';
+	}
+
+	/**
+	 * Build the Site Health Info tab sections for the features detected on this site
+	 *
+	 * This is the tab users copy into a support ticket, so a section is present whether or not its group has
+	 * anything to report: an empty one says so, rather than leaving the reader to guess whether the check ran.
+	 * They report what the system report exports, which keeps the two plain-text surfaces reading the same by
+	 * construction.
+	 *
+	 * @param array $signals The signals from Deprecation::get_signals()
+	 *
+	 * @return array One Site Health Info section per group, keyed by the ID it is registered under
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_debug_information( array $signals ): array {
+		$grouped  = Deprecation::group_signals( $signals );
+		$sections = [];
+
+		foreach ( static::get_deprecated_groups() as $group => $names ) {
+			$fields = [];
+
+			foreach ( $grouped[ $group ] ?? [] as $key => $signal ) {
+				$message = $this->get_deprecated_feature_detail( $key, $signal );
+
+				$fields[ $key ] = [
+					'label' => $message['label_export'],
+					'value' => $message['value_export'] . '. ' . $message['validation_message_export'],
+				];
+			}
+
+			if ( $fields === [] ) {
+				$fields[ $group ] = [
+					/* translators: %s: The group name, as get_deprecated_groups() gives it */
+					'label' => sprintf( __( '%s functionality', 'gravity-pdf' ), $names['label'] ),
+					'value' => __( 'None detected', 'gravity-pdf' ),
+				];
+			}
+
+			$sections[ 'gravity-pdf-' . $group ] = [
+				/* translators: %s: The group name, as get_deprecated_groups() gives it */
+				'label'       => sprintf( __( 'Gravity PDF - %s Functionality', 'gravity-pdf' ), $names['label'] ),
+				'description' => esc_html( $names['description'] ),
+				'fields'      => $fields,
+			];
+		}
+
+		return $sections;
 	}
 }

--- a/src/View/html/Actions/deprecated_features.php
+++ b/src/View/html/Actions/deprecated_features.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * The Deprecated Features Notice
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       6.17.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** @var $args array */
+
+?>
+
+<div style="font-size:15px; line-height: 25px" role="alert" aria-live="polite">
+
+	<strong>
+		<?php esc_html_e( 'This site uses deprecated Gravity PDF functionality:', 'gravity-pdf' ); ?>
+	</strong>
+
+	<ul style="list-style: disc; margin: 0.5em 0 0.5em 2em">
+		<?php foreach ( $args['features'] as $feature ) : ?>
+			<li>
+				<?php echo esc_html( $feature['notice'] ); ?>
+				<a href="<?php echo esc_url( $feature['url'] ); ?>"><?php esc_html_e( 'Learn how to upgrade', 'gravity-pdf' ); ?></a>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+
+	<?php esc_html_e( 'Dismissing this notice hides the items above. Anything found later is reported again.', 'gravity-pdf' ); ?>
+</div>

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -130,8 +130,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 * @since 4.0
 	 */
 	public function __call( $name, $arguments ) {
-		/* translators: %s: deprecated method name */
-		_doing_it_wrong( esc_html( $name ), esc_html( sprintf( __( '"%s" has been deprecated as of Gravity PDF 4.0', 'gravity-pdf' ), $name ) ), '4.0' );
+		_deprecated_function( esc_html( $name ), '4.0' );
 	}
 
 	/**
@@ -143,7 +142,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 * @since  4.0
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		_doing_it_wrong( esc_html( $name ), esc_html( sprintf( __( '"%s" has been deprecated as of Gravity PDF 4.0', 'gravity-pdf' ), $name ) ), '4.0' );
+		_deprecated_function( esc_html( $name ), '4.0' );
 	}
 
 	/**
@@ -920,7 +919,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	public function check_system_status() {
 		$view  = new View\View_System_Report();
 		$model = new Model\Model_System_Report( $this->options, $this->data, $this->log, $this->misc, new GFPDF_Major_Compatibility_Checks(), $this->templates );
-		$class = new Controller\Controller_System_Report( $model, $view );
+		$class = new Controller\Controller_System_Report( $model, $view, $this->gform );
 		$class->init();
 
 		$this->singleton->add_class( $class );

--- a/src/deprecated.php
+++ b/src/deprecated.php
@@ -42,7 +42,7 @@ abstract class GFPDF_Deprecated_Abstract {
 	 *
 	 */
 	public function __call( $name, $arguments ) {
-		_doing_it_wrong( esc_html( $name ), esc_html( sprintf( __( '"%s" has been deprecated as of Gravity PDF 4.0', 'gravity-pdf' ), $name ) ), '4.0' );
+		_deprecated_function( esc_html( static::class . '::' . $name ), '4.0' );
 	}
 
 	/**
@@ -55,7 +55,7 @@ abstract class GFPDF_Deprecated_Abstract {
 	 *
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		_doing_it_wrong( esc_html( $name ), esc_html( sprintf( __( '"%s" has been deprecated as of Gravity PDF 4.0', 'gravity-pdf' ), $name ) ), '4.0' );
+		_deprecated_function( esc_html( static::class . '::' . $name ), '4.0' );
 	}
 }
 
@@ -130,6 +130,7 @@ class PDFRender extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public function savePDF( $raw_pdf_string, $filename, $id ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::create_pdf()' );
 
 		/* create our path */
 		$path = apply_filters( 'gfpdf_legacy_save_path', PDF_SAVE_LOCATION . $id . '/', $filename, $id );
@@ -166,6 +167,7 @@ class PDFRender extends GFPDF_Deprecated_Abstract {
 	 *
 	 */
 	public static function prepare_ids( $form_id, $lead_id, $template, $id, $output, $filename, $arguments, $args ) {
+		/* No deprecation notice — core registers this callback itself on `gfpdfe_pre_load_template` */
 		global $lead_ids;
 		$lead_ids = $args['lead_ids'];
 
@@ -188,6 +190,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 4.0
 	 */
 	public static function get_ids() {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		global $form_id, $lead_id, $lead_ids;
 
 		$form_id  = ! empty( (int) $form_id ) ? (int) $form_id : (int) rgget( 'fid' );
@@ -209,6 +213,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function get_upload_dir() {
+		_deprecated_function( __METHOD__, '4.0', 'Helper_Misc::get_upload_details()' );
+
 		$misc = GPDFAPI::get_misc_class();
 
 		return $misc->get_upload_details();
@@ -226,6 +232,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function do_mergetags( $text, $form_id, $lead_id ) {
+		_deprecated_function( __METHOD__, '4.0', 'Helper_Form::process_tags()' );
+
 		$gform = GPDFAPI::get_form_class();
 
 		return $gform->process_tags( $text, $gform->get_form( $form_id ), $gform->get_entry( $lead_id ) );
@@ -239,6 +247,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 4.0
 	 */
 	public static function view_data( $form_data ) {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		$pdf_view = \GPDFAPI::get_pdf_class();
 		$pdf_view->maybe_view_form_data( $form_data );
 	}
@@ -253,6 +263,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function post( $name ) {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		/* phpcs:ignore WordPress.Security.NonceVerification.Missing */
 		if ( isset( $_POST[ $name ] ) ) {
 			/* phpcs:ignore WordPress.Security.NonceVerification.Missing */
@@ -272,6 +284,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function get( $name ) {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		/* phpcs:ignore WordPress.Security.NonceVerification.Recommended */
 		if ( isset( $_GET[ $name ] ) ) {
 			/* phpcs:ignore WordPress.Security.NonceVerification.Recommended */
@@ -292,6 +306,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function get_pdf_filename( $form_id, $lead_id ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::get_pdf_filename()' );
+
 		return "form-$form_id-entry-$lead_id.pdf";
 	}
 
@@ -305,6 +321,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 4.0
 	 */
 	public static function remove_invalid_characters( $name ) {
+		_deprecated_function( __METHOD__, '4.0', 'Helper_Misc::strip_invalid_characters()' );
+
 		$misc = GPDFAPI::get_misc_class();
 
 		return $misc->strip_invalid_characters( $name );
@@ -316,6 +334,7 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function setup_ids() {
+		_deprecated_function( __METHOD__, '4.0' );
 	}
 }
 
@@ -342,6 +361,8 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function lead_detail_grid( $form, $lead, $allow_display_empty_fields = false, $show_html = false, $show_page_name = false, $should_return = false ) {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		$config = [
 			'meta' => [
 				'empty_field' => $allow_display_empty_fields,
@@ -367,6 +388,7 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.7
 	 */
 	public static function do_lead_detail_grid( $form, $lead, $config = [] ) {
+		_deprecated_function( __METHOD__, '4.0' );
 
 		/* Convert old config values to our new ones */
 		if ( ! isset( $config['meta'] ) ) {
@@ -614,6 +636,8 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function lead_detail_grid_array( $form, $lead ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::get_form_data()' );
+
 		$model = GPDFAPI::get_pdf_class( 'model' );
 
 		return $model->get_form_data( $lead );
@@ -630,6 +654,8 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function product_table( $form, $lead ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::product_table()' );
+
 		GPDFAPI::product_table( $lead );
 	}
 
@@ -645,6 +671,8 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function get_likert( $form, $lead, $field_id ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::likert_table()' );
+
 		return GPDFAPI::likert_table( $lead, $field_id, true );
 	}
 }
@@ -680,6 +708,8 @@ class GFPDF_Core_Model extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function gfpdfe_save_pdf( $entry, $form ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::create_pdf()' );
+
 		$pdfs = GPDFAPI::get_entry_pdfs( $entry['id'] );
 
 		if ( ! is_wp_error( $pdfs ) ) {
@@ -734,6 +764,7 @@ if ( ! class_exists( 'mPDF' ) ) {
 		 * @since 5.0
 		 */
 		public function __construct( $mode = '', $format = 'A4', $default_font_size = 0, $default_font = '', $mgl = 15, $mgr = 15, $mgt = 16, $mgb = 16, $mgh = 9, $mgf = 9, $orientation = 'P' ) {
+			_deprecated_function( 'mPDF::__construct', '5.0', 'GFPDF\Helper\Mpdf\Mpdf' );
 
 			$data                = GPDFAPI::get_data_class();
 			$default_font_config = ( new FontVariables() )->getDefaults();

--- a/tests/phpunit/Concerns/CreatesLegacyDownloadUrls.php
+++ b/tests/phpunit/Concerns/CreatesLegacyDownloadUrls.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GFPDF\Tests\Concerns;
+
+/**
+ * Creates forms that still hand out a v3 `?gf_pdf=1` PDF download URL, which Deprecation detects.
+ * Requires UsesFactory for gf_factory().
+ */
+trait CreatesLegacyDownloadUrls {
+
+	/**
+	 * Create a form carrying a legacy download URL in `$location`
+	 *
+	 * Gravity Forms stores the form, its confirmations and its notifications in three separate columns, each of
+	 * which the detector has to search.
+	 *
+	 * @param string $location One of `form`, `confirmations` or `notifications`
+	 * @param string $marker   The query argument the URL carries, so a near miss can be set up too
+	 *
+	 * @return int The new form's ID
+	 */
+	protected function create_form_with_legacy_url( string $location = 'confirmations', string $marker = 'gf_pdf=1' ): int {
+		$form = \GFAPI::get_form( $this->gf_factory()->form->create() );
+		$link = sprintf( '<a href="/?%s&fid=%d&lid=1&template=zadani.php">Download</a>', $marker, $form['id'] );
+
+		switch ( $location ) {
+			case 'confirmations':
+				$form['confirmations'] = [
+					[
+						'id'      => 'abc123',
+						'name'    => 'Default Confirmation',
+						'type'    => 'message',
+						'message' => $link,
+					],
+				];
+				break;
+
+			case 'notifications':
+				$form['notifications'] = [
+					[
+						'id'      => 'def456',
+						'name'    => 'Admin Notification',
+						'to'      => 'admin@example.org',
+						'subject' => 'New submission',
+						'message' => $link,
+					],
+				];
+				break;
+
+			default:
+				$form['description'] = $link;
+		}
+
+		\GFAPI::update_form( $form );
+
+		return (int) $form['id'];
+	}
+}

--- a/tests/phpunit/Concerns/CreatesLegacyTemplates.php
+++ b/tests/phpunit/Concerns/CreatesLegacyTemplates.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GFPDF\Tests\Concerns;
+
+/**
+ * Installs v3 PDF templates in the working directory, which Deprecation detects.
+ */
+trait CreatesLegacyTemplates {
+
+	/**
+	 * Write a v3 template, which is one carrying no file headers, and return its path
+	 *
+	 * A body calling `$mpdf->` is what makes it a Business Plus (Tier 2) template rather than a plain one.
+	 *
+	 * @param string $name The file to write into the PDF working directory
+	 * @param string $body PHP appended after the v3 boilerplate
+	 *
+	 * @return string The new template's absolute path
+	 */
+	protected function create_legacy_template( string $name = 'my-legacy-template.php', string $body = '' ): string {
+		$path = \GPDFAPI::get_data_class()->template_location . $name;
+
+		file_put_contents( $path, '<?php if ( ! class_exists( "RGForms" ) ) { return; } ' . $body );
+
+		/* the template list is memoized per request by GFCache, and what Deprecation read off it by the detector */
+		\GFCache::flush();
+		\GFPDF\Statics\Deprecation_V3::flush_cache();
+
+		return $path;
+	}
+
+	/**
+	 * Create a form with one PDF set to render through the v3 Advanced Templating mode
+	 *
+	 * The setting is not a detection signal — the template file is — so this exists to prove it isn't one.
+	 *
+	 * @return int The new form's ID
+	 */
+	protected function create_form_with_advanced_templating(): int {
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'advanced_template' => 'Yes' ] );
+
+		return $form_id;
+	}
+
+	/**
+	 * Delete templates written by self::create_legacy_template(), so later tests don't read them
+	 *
+	 * @param string ...$paths
+	 */
+	protected function delete_legacy_templates( string ...$paths ): void {
+		foreach ( $paths as $path ) {
+			@unlink( $path );
+		}
+
+		\GFCache::flush();
+		\GFPDF\Statics\Deprecation_V3::flush_cache();
+	}
+}

--- a/tests/phpunit/Concerns/ResetsDetectedFeatures.php
+++ b/tests/phpunit/Concerns/ResetsDetectedFeatures.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GFPDF\Tests\Concerns;
+
+/**
+ * Clears the deprecation records a test writes, for the classes that write them.
+ */
+trait ResetsDetectedFeatures {
+
+	/**
+	 * Reset what Deprecation and the notices read
+	 *
+	 * Helper_Abstract_Options keeps `gfpdf_settings` in memory, and the WP test transaction rolls the database
+	 * back without touching that copy — so a record written by one test is still readable in the next.
+	 */
+	protected function reset_detected_features(): void {
+		$options = \GPDFAPI::get_options_class();
+
+		$options->update_option( 'deprecated_features', [] );
+		$options->update_option( 'action_dismissal', [] );
+	}
+}

--- a/tests/phpunit/integration/Controller/Test_Controller_Actions.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Actions.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 
 namespace GFPDF\Controller;
 
+use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
+use GFPDF\Tests\Concerns\ResetsDetectedFeatures;
 use GFPDF\Tests\Integration\TestCase;
 
 /**
@@ -13,6 +15,9 @@ use GFPDF\Tests\Integration\TestCase;
  * @group   actions
  */
 class Test_Controller_Actions extends TestCase {
+
+	use CreatesLegacyDownloadUrls;
+	use ResetsDetectedFeatures;
 
 	/**
 	 * @var Controller_Actions
@@ -25,6 +30,8 @@ class Test_Controller_Actions extends TestCase {
 		parent::set_up();
 
 		$this->controller = $gfpdf->singleton->get_class( 'Controller_Actions' );
+
+		$this->reset_detected_features();
 	}
 
 	public function tear_down(): void {
@@ -42,15 +49,176 @@ class Test_Controller_Actions extends TestCase {
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->controller, 'route_notices' ] ) );
 	}
 
-	public function test_get_routes_includes_default_core_fonts_route() {
+	public function test_get_routes_includes_default_routes() {
 		$routes = $this->controller->get_routes();
 
-		$this->assertCount( 1, $routes );
+		/* The core font install, plus the one notice covering every deprecated feature at once */
+		$this->assertCount( 2, $routes );
+
 		$this->assertSame( 'install_core_fonts', $routes[0]['action'] );
 		$this->assertSame( 'gravityforms_edit_settings', $routes[0]['capability'] );
 		$this->assertIsCallable( $routes[0]['condition'] );
 		$this->assertIsCallable( $routes[0]['process'] );
 		$this->assertIsCallable( $routes[0]['view'] );
+	}
+
+	public function test_every_deprecated_feature_shares_one_route() {
+		$route = array_column( $this->controller->get_routes(), null, 'action' )['deprecated_features'];
+
+		$this->assertSame( 'gravityforms_view_settings', $route['capability'] );
+		$this->assertIsCallable( $route['condition'] );
+		$this->assertIsCallable( $route['view'] );
+		$this->assertIsCallable( $route['dismiss'] );
+
+		/* Every v3 feature still works until 7.0, so the notice is a warning rather than an error */
+		$this->assertSame( 'notice-warning', $route['view_class'] );
+	}
+
+	/**
+	 * A record taken before a provider was removed can name a feature nothing declares any more
+	 */
+	public function test_an_unregistered_feature_is_never_listed() {
+		global $gfpdf;
+
+		$model = $gfpdf->singleton->get_class( 'Model_Actions' );
+
+		\GPDFAPI::get_options_class()->update_option( 'deprecated_features', [ 'legacy_templates', 'not-a-feature' ] );
+
+		$this->assertSame( [ 'legacy_templates' ], $model->get_undismissed_deprecated_features() );
+	}
+
+	/**
+	 * One notice covers every feature, and dismissing it records each one it listed — which is what keeps the
+	 * notices coming: the next round of removals arrives undismissed and raises it again
+	 */
+	public function test_dismissing_the_notice_clears_every_feature_it_listed() {
+		global $gfpdf, $pagenow;
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		set_current_screen( 'dashboard' );
+
+		$original = $pagenow;
+		$pagenow  = 'index.php';
+
+		$model   = $gfpdf->singleton->get_class( 'Model_Actions' );
+		$options = \GPDFAPI::get_options_class();
+
+		$options->update_option( 'deprecated_features', [ 'legacy_templates', 'legacy_endpoint' ] );
+
+		$this->assertTrue( $model->has_deprecated_features() );
+		$this->assertSame( [ 'legacy_templates', 'legacy_endpoint' ], $model->get_undismissed_deprecated_features() );
+
+		$html = $this->render_notices();
+		$this->assertStringContainsString( 'Support for Legacy Templates', $html );
+		$this->assertStringContainsString( 'Support for legacy download URLs', $html );
+
+		$model->dismiss_deprecated_features();
+
+		$this->assertSame( [], $model->get_undismissed_deprecated_features() );
+
+		/* Other routes can still have a notice of their own, so only this one has to be gone */
+		$html = $this->render_notices();
+		$this->assertStringNotContainsString( 'Support for Legacy Templates', $html );
+		$this->assertStringNotContainsString( 'Support for legacy download URLs', $html );
+
+		/* A feature detected after that dismissal was never listed, so the notice returns for it alone */
+		$options->update_option( 'deprecated_features', [ 'legacy_templates', 'legacy_endpoint', 'deprecated_filters' ] );
+
+		$this->assertTrue( $model->has_deprecated_features() );
+		$this->assertSame( [ 'deprecated_filters' ], $model->get_undismissed_deprecated_features() );
+
+		$html = $this->render_notices();
+		$this->assertStringContainsString( 'Code on this site uses Gravity PDF hooks', $html );
+		$this->assertStringNotContainsString( 'Support for Legacy Templates', $html );
+
+		$pagenow = $original;
+		$gfpdf->notices->clear();
+	}
+
+	public function test_route_notices_raises_a_notice_for_a_detected_feature() {
+		global $gfpdf, $pagenow;
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		set_current_screen( 'dashboard' );
+
+		$original = $pagenow;
+		$pagenow  = 'index.php';
+
+		$gfpdf->notices->clear();
+		$this->controller->route_notices();
+
+		$this->assertStringNotContainsString( 'legacy download URLs', $this->get_rendered_notices() );
+
+		$this->create_form_with_legacy_url();
+
+		/* The notice reads what the last detection recorded, and a release is when the site gets a fresh one */
+		do_action( 'gfpdf_version_changed', '6.16.0', '6.17.0' );
+
+		$gfpdf->notices->clear();
+		$this->controller->route_notices();
+
+		$html = $this->get_rendered_notices();
+
+		$this->assertStringContainsString( 'Support for legacy download URLs will be removed in Gravity PDF 7.0.', $html );
+		$this->assertStringContainsString( 'View the system report', $html );
+
+		/* Functionality still working, but not for much longer, reads as a warning rather than an error */
+		$this->assertStringContainsString( 'notice-warning', $html );
+
+		$pagenow = $original;
+		$gfpdf->notices->clear();
+	}
+
+	/**
+	 * Network admin reports the main site, which is the scope Gravity PDF's settings and detections live at: a
+	 * subsite's own admin raises its own notice. Aggregating the network is a 7.x question, not a 6.17 one
+	 */
+	public function test_route_notices_raises_the_notice_in_network_admin() {
+		global $gfpdf, $pagenow;
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$original = $pagenow;
+		$pagenow  = 'index.php';
+		set_current_screen( 'index.php-network' );
+
+		$this->create_form_with_legacy_url();
+		do_action( 'gfpdf_version_changed', '6.16.0', '6.17.0' );
+
+		$gfpdf->notices->clear();
+		$this->controller->route_notices();
+
+		$this->assertTrue( is_network_admin() );
+
+		/* Helper_Notices renders this on network_admin_notices rather than admin_notices */
+		$this->assertTrue( $gfpdf->notices->has_notice() );
+		$this->assertStringContainsString( 'Support for legacy download URLs', $this->get_rendered_notices() );
+
+		$pagenow = $original;
+		set_current_screen( 'dashboard' );
+		$gfpdf->notices->clear();
+	}
+
+	/**
+	 * Run the notice routes and render whatever they queue
+	 */
+	private function render_notices(): string {
+		global $gfpdf;
+
+		$gfpdf->notices->clear();
+		$this->controller->route_notices();
+
+		return $this->get_rendered_notices();
+	}
+
+	/**
+	 * Render whatever is queued, since the notices are only markup once WordPress asks for them
+	 */
+	private function get_rendered_notices(): string {
+		ob_start();
+		do_action( 'admin_notices' );
+
+		return (string) ob_get_clean();
 	}
 
 	public function test_get_routes_is_filterable() {
@@ -66,8 +234,7 @@ class Test_Controller_Actions extends TestCase {
 		$routes = $this->controller->get_routes();
 		remove_all_filters( 'gfpdf_one_time_action_routes' );
 
-		$this->assertCount( 2, $routes );
-		$this->assertSame( 'custom', $routes[1]['action'] );
+		$this->assertSame( 'custom', end( $routes )['action'] );
 	}
 
 	public function test_route_notices_short_circuits_on_getting_started_page() {
@@ -80,6 +247,49 @@ class Test_Controller_Actions extends TestCase {
 		$this->controller->route_notices();
 
 		$this->assertFalse( $gfpdf->notices->has_notice() );
+	}
+
+	public function test_route_notices_skips_pages_the_notice_cannot_display_on() {
+		global $gfpdf, $pagenow;
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		set_current_screen( 'dashboard' );
+
+		add_filter(
+			'gfpdf_one_time_action_routes',
+			static function () {
+				return [
+					[
+						'action'      => 'always_notify',
+						'action_text' => 'Do it',
+						'condition'   => '__return_true',
+						'process'     => '__return_true',
+						'view'        => static function () {
+							return 'A notice';
+						},
+						'capability'  => 'gravityforms_view_settings',
+					],
+				];
+			}
+		);
+
+		$original = $pagenow;
+		$pagenow  = 'upload.php';
+
+		$gfpdf->notices->clear();
+		$this->controller->route_notices();
+
+		$this->assertFalse( $gfpdf->notices->has_notice() );
+
+		$pagenow = 'index.php';
+
+		$this->controller->route_notices();
+
+		$this->assertTrue( $gfpdf->notices->has_notice() );
+
+		$pagenow = $original;
+		remove_all_filters( 'gfpdf_one_time_action_routes' );
+		$gfpdf->notices->clear();
 	}
 
 	public function test_route_dismisses_notice_when_dismiss_flag_set() {

--- a/tests/phpunit/integration/Controller/Test_Controller_Install.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Install.php
@@ -95,7 +95,7 @@ class Test_Controller_Install extends TestCase {
 	}
 
 	public function test_maybe_uninstall_emits_doing_it_wrong_notice() {
-		$this->setExpectedIncorrectUsage( 'GFPDF\Controller\Controller_Install::maybe_uninstall' );
+		$this->setExpectedDeprecated( 'GFPDF\Controller\Controller_Install::maybe_uninstall' );
 
 		$this->controller->maybe_uninstall();
 	}

--- a/tests/phpunit/integration/Controller/Test_Controller_PDF.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_PDF.php
@@ -7,6 +7,8 @@ namespace GFPDF\Controller;
 use Exception;
 use GFPDF\Helper\Helper_Url_Signer;
 use GFPDF\Model\Model_PDF;
+use GFPDF\Statics\Deprecation;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF\Tests\Integration\TestCase;
 use GFPDF\View\View_PDF;
 use ReflectionMethod;
@@ -126,7 +128,7 @@ class Test_Controller_PDF extends TestCase {
 	}
 
 	public function test_sgoptimizer_html_minification_fix_emits_doing_it_wrong() {
-		$this->setExpectedIncorrectUsage( 'GFPDF\Controller\Controller_PDF::sgoptimizer_html_minification_fix' );
+		$this->setExpectedDeprecated( 'GFPDF\Controller\Controller_PDF::sgoptimizer_html_minification_fix' );
 
 		$this->controller->sgoptimizer_html_minification_fix();
 	}
@@ -173,8 +175,8 @@ class Test_Controller_PDF extends TestCase {
 	 * @group slow
 	 */
 	public function test_process_legacy_pdf_endpoint() {
-		$this->setExpectedIncorrectUsage( 'GFPDF\Controller\Controller_PDF::process_legacy_pdf_endpoint' );
-		$this->setExpectedIncorrectUsage( 'GFPDF\Model\Model_PDF::get_legacy_config' );
+		$this->setExpectedDeprecated( 'GFPDF\Controller\Controller_PDF::process_legacy_pdf_endpoint' );
+		$this->setExpectedDeprecated( 'GFPDF\Model\Model_PDF::get_legacy_config' );
 
 		/* Test our endpoint is firing correctly */
 		$results = $this->form_and_entry();
@@ -209,6 +211,42 @@ class Test_Controller_PDF extends TestCase {
 
 			return;
 		}
+	}
+
+	/**
+	 * A legacy URL is often pasted somewhere the form scan can't see, so the endpoint records the form it served
+	 *
+	 * @group slow
+	 */
+	public function test_process_legacy_pdf_endpoint_records_the_form_it_served() {
+		$this->setExpectedDeprecated( 'GFPDF\Controller\Controller_PDF::process_legacy_pdf_endpoint' );
+		$this->setExpectedDeprecated( 'GFPDF\Model\Model_PDF::get_legacy_config' );
+
+		$results = $this->form_and_entry();
+		$form_id = (int) $results['form']['id'];
+
+		$_GET['gf_pdf']   = 1;
+		$_GET['fid']      = $form_id;
+		$_GET['lid']      = $results['entry']['id'];
+		$_GET['template'] = 'zadani.php';
+
+		$this->assertSame( [], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+
+		/* Recorded before the PDF is served, so a request the middleware turns away still counts as one made */
+		try {
+			wp_set_current_user( 0 );
+			$this->controller->process_legacy_pdf_endpoint();
+		} catch ( Exception $e ) {
+			$this->assertSame( 'Redirecting', $e->getMessage() );
+		}
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+
+		/* The form's own settings never mentioned the URL, so only the record can report it */
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_legacy_download_urls() );
+
+		/* The notices read a record taken at install and on each version change, which this happened after */
+		$this->assertContains( Deprecation_V3::FEATURE_LEGACY_ENDPOINT, Deprecation::get_detected_features() );
 	}
 
 	/**

--- a/tests/phpunit/integration/Controller/Test_Controller_Pdf_Queue.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Pdf_Queue.php
@@ -363,8 +363,8 @@ class Test_Controller_Pdf_Queue extends TestCase {
 	 * @since 5.0
 	 */
 	public function test_cleanup_pdfs() {
-		$this->setExpectedIncorrectUsage( 'GFPDF\Statics\Queue_Callbacks::cleanup_pdfs' );
-		$this->setExpectedIncorrectUsage( 'GFPDF\Model\Model_PDF::cleanup_pdf' );
+		$this->setExpectedDeprecated( 'GFPDF\Statics\Queue_Callbacks::cleanup_pdfs' );
+		$this->setExpectedDeprecated( 'GFPDF\Model\Model_PDF::cleanup_pdf' );
 
 		$form_class = \GPDFAPI::get_form_class();
 

--- a/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
@@ -4,6 +4,9 @@ declare( strict_types=1 );
 
 namespace GFPDF\Controller;
 
+use GFPDF\Statics\Deprecation;
+use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
+use GFPDF\Tests\Concerns\CreatesLegacyTemplates;
 use GFPDF\Tests\Integration\TestCase;
 
 /**
@@ -21,6 +24,9 @@ use GFPDF\Tests\Integration\TestCase;
  * @group   system-report
  */
 class Test_Controller_System_Report extends TestCase {
+
+	use CreatesLegacyDownloadUrls;
+	use CreatesLegacyTemplates;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -50,31 +56,31 @@ class Test_Controller_System_Report extends TestCase {
 		/* Test that our data is spliced into the correct location in the array */
 		$system_report = apply_filters( 'gform_system_report', [ [] ] );
 
-		$this->assertArrayHasKey( 'memory', $system_report[1]['tables'][0]['items'] );
-		$this->assertArrayHasKey( 'allow_url_fopen', $system_report[1]['tables'][0]['items'] );
-		$this->assertArrayHasKey( 'default_charset', $system_report[1]['tables'][0]['items'] );
-		$this->assertArrayHasKey( 'internal_encoding', $system_report[1]['tables'][0]['items'] );
+		$this->assertArrayHasKey( 'memory', $this->get_report_section( 'php', $system_report ) );
+		$this->assertArrayHasKey( 'allow_url_fopen', $this->get_report_section( 'php', $system_report ) );
+		$this->assertArrayHasKey( 'default_charset', $this->get_report_section( 'php', $system_report ) );
+		$this->assertArrayHasKey( 'internal_encoding', $this->get_report_section( 'php', $system_report ) );
 
-		$this->assertArrayHasKey( 'pdf_working_directory', $system_report[1]['tables'][1]['items'] );
-		$this->assertArrayHasKey( 'pdf_working_directory_url', $system_report[1]['tables'][1]['items'] );
-		$this->assertArrayHasKey( 'font_folder_location', $system_report[1]['tables'][1]['items'] );
-		$this->assertArrayHasKey( 'temp_folder_location', $system_report[1]['tables'][1]['items'] );
-		$this->assertArrayHasKey( 'temp_folder_permission', $system_report[1]['tables'][1]['items'] );
-		$this->assertArrayHasKey( 'temp_folder_protected', $system_report[1]['tables'][1]['items'] );
-		$this->assertArrayHasKey( 'mpdf_temp_folder_location', $system_report[1]['tables'][1]['items'] );
+		$this->assertArrayHasKey( 'pdf_working_directory', $this->get_report_section( 'directories', $system_report ) );
+		$this->assertArrayHasKey( 'pdf_working_directory_url', $this->get_report_section( 'directories', $system_report ) );
+		$this->assertArrayHasKey( 'font_folder_location', $this->get_report_section( 'directories', $system_report ) );
+		$this->assertArrayHasKey( 'temp_folder_location', $this->get_report_section( 'directories', $system_report ) );
+		$this->assertArrayHasKey( 'temp_folder_permission', $this->get_report_section( 'directories', $system_report ) );
+		$this->assertArrayHasKey( 'temp_folder_protected', $this->get_report_section( 'directories', $system_report ) );
+		$this->assertArrayHasKey( 'mpdf_temp_folder_location', $this->get_report_section( 'directories', $system_report ) );
 
-		$this->assertArrayHasKey( 'pdf_entry_list_action', $system_report[1]['tables'][2]['items'] );
-		$this->assertArrayHasKey( 'background_processing_enabled', $system_report[1]['tables'][2]['items'] );
-		$this->assertArrayHasKey( 'debug_mode_enabled', $system_report[1]['tables'][2]['items'] );
+		$this->assertArrayHasKey( 'pdf_entry_list_action', $this->get_report_section( 'global', $system_report ) );
+		$this->assertArrayHasKey( 'background_processing_enabled', $this->get_report_section( 'global', $system_report ) );
+		$this->assertArrayHasKey( 'debug_mode_enabled', $this->get_report_section( 'global', $system_report ) );
 
-		$this->assertArrayHasKey( 'user_restrictions', $system_report[1]['tables'][3]['items'] );
-		$this->assertArrayHasKey( 'logged_out_timeout', $system_report[1]['tables'][3]['items'] );
+		$this->assertArrayHasKey( 'user_restrictions', $this->get_report_section( 'security', $system_report ) );
+		$this->assertArrayHasKey( 'logged_out_timeout', $this->get_report_section( 'security', $system_report ) );
 	}
 
 	public function test_system_report_outdated_template() {
 		/* verify no outdated template info */
 		$system_report = apply_filters( 'gform_system_report', [] );
-		$this->assertArrayNotHasKey( 'outdated_templates', $system_report[0]['tables'][1]['items'] );
+		$this->assertArrayNotHasKey( 'outdated_templates', $this->get_report_section( 'directories', $system_report ) );
 
 		/* copy core template to override location and adjust version number, then verify outdated message is included */
 		$data          = \GPDFAPI::get_data_class();
@@ -84,8 +90,237 @@ class Test_Controller_System_Report extends TestCase {
 		file_put_contents( $override_path, preg_replace( '/Version: (.+?)/', 'Version: 1.5.2', $template ) );
 
 		$system_report = apply_filters( 'gform_system_report', [] );
-		$this->assertArrayHasKey( 'outdated_templates', $system_report[0]['tables'][1]['items'] );
+		$this->assertArrayHasKey( 'outdated_templates', $this->get_report_section( 'directories', $system_report ) );
 
 		@unlink( $override_path );
+	}
+
+	/**
+	 * Get the items of one Gravity PDF report section, by the ID the section declares
+	 *
+	 * Looked up by name so a section added or dropped above doesn't move every assertion below it.
+	 */
+	protected function get_report_section( string $id, ?array $system_report = null ): array {
+		$system_report = $system_report ?? apply_filters( 'gform_system_report', [] );
+
+		foreach ( $system_report as $section ) {
+			foreach ( $section['tables'] ?? [] as $table ) {
+				if ( ( $table['id'] ?? '' ) === $id ) {
+					return $table['items'];
+				}
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * Get the items of the Deprecated section, which is only present when something is detected
+	 */
+	protected function get_deprecated_features(): array {
+		return $this->get_report_section( Deprecation::GROUP_DEPRECATED );
+	}
+
+	public function test_system_report_has_no_deprecated_features_section_by_default() {
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		$this->assertCount( 4, $system_report[0]['tables'] );
+	}
+
+	public function test_system_report_legacy_template() {
+		$this->assertArrayNotHasKey( 'legacy_templates', $this->get_deprecated_features() );
+
+		$legacy_path = $this->create_legacy_template();
+
+		$items = $this->get_deprecated_features();
+		$this->assertArrayHasKey( 'legacy_templates', $items );
+		$this->assertStringContainsString( 'my-legacy-template.php', $items['legacy_templates']['value_export'] );
+
+		/* Every row is handed to Gravity Forms as a failure, so it draws the cross and the message itself */
+		$this->assertFalse( $items['legacy_templates']['is_valid'] );
+
+		$this->delete_legacy_templates( $legacy_path );
+	}
+
+	public function test_system_report_business_plus_template_has_a_row_of_its_own() {
+		$this->assertArrayNotHasKey( 'business_plus_templates', $this->get_deprecated_features() );
+
+		$path = $this->create_legacy_template( 'my-business-plus-template.php', '$mpdf->AddPage();' );
+
+		$items = $this->get_deprecated_features();
+		$this->assertSame( 'my-business-plus-template.php (not configured on a form)', $items['business_plus_templates']['value_export'] );
+
+		/* It upgrades differently to a plain v3 template, so it doesn't share that row or its guide */
+		$this->assertArrayNotHasKey( 'legacy_templates', $items );
+		$this->assertStringContainsString( '#business-plus--tier-2-template-upgrade-guide', $items['business_plus_templates']['validation_message_export'] );
+
+		$this->delete_legacy_templates( $path );
+	}
+
+	public function test_system_report_legacy_endpoint() {
+		$this->assertArrayNotHasKey( 'legacy_endpoint', $this->get_deprecated_features() );
+
+		$form_id = $this->create_form_with_legacy_url();
+
+		$items = $this->get_deprecated_features();
+		$this->assertArrayHasKey( 'legacy_endpoint', $items );
+		$this->assertStringContainsString( (string) $form_id, $items['legacy_endpoint']['value_export'] );
+		$this->assertFalse( $items['legacy_endpoint']['is_valid'] );
+	}
+
+	public function test_system_report_ignores_the_advanced_templating_setting() {
+		$this->create_form_with_advanced_templating();
+
+		/* The template file is what's reported, so a Core template isn't listed for how a PDF is configured */
+		$this->assertArrayNotHasKey( 'legacy_templates', $this->get_deprecated_features() );
+		$this->assertArrayNotHasKey( 'business_plus_templates', $this->get_deprecated_features() );
+	}
+
+	public function test_system_report_deprecated_filters() {
+		$this->assertArrayNotHasKey( 'deprecated_filters', $this->get_deprecated_features() );
+
+		$callback = static function ( $name ) {
+			return $name;
+		};
+
+		add_filter( 'gfpdfe_pdf_filename', $callback );
+
+		$items = $this->get_deprecated_features();
+		$this->assertArrayHasKey( 'deprecated_filters', $items );
+		$this->assertStringContainsString( 'gfpdfe_pdf_filename', $items['deprecated_filters']['value_export'] );
+
+		remove_filter( 'gfpdfe_pdf_filename', $callback );
+	}
+
+	/**
+	 * Get the Site Health test the controller registers
+	 */
+	protected function get_site_health_test(): array {
+		$tests = apply_filters( 'site_status_tests', [ 'direct' => [] ] );
+
+		return $tests['direct']['gravity_pdf_deprecated_features'] ?? [];
+	}
+
+	public function test_site_health_test_is_registered() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$test = $this->get_site_health_test();
+
+		$this->assertIsCallable( $test['test'] );
+		$this->assertSame( 'good', call_user_func( $test['test'] )['status'] );
+	}
+
+	public function test_site_health_test_is_gated_on_the_gravity_forms_capability() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$this->assertSame( [], $this->get_site_health_test() );
+	}
+
+	public function test_debug_information_reports_a_clean_site() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$info = apply_filters( 'debug_information', [] );
+
+		$this->assertSame( 'None detected', $info['gravity-pdf-deprecated']['fields']['deprecated']['value'] );
+
+		/* No registered feature belongs to the other group, so it isn't carried around empty */
+		$this->assertArrayNotHasKey( 'gravity-pdf-unsupported', $info );
+	}
+
+	public function test_debug_information_is_gated_on_the_gravity_forms_capability() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$info = apply_filters( 'debug_information', [] );
+
+		$this->assertArrayNotHasKey( 'gravity-pdf-deprecated', $info );
+	}
+
+	public function test_debug_information_reports_each_signal() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$form_id = $this->create_form_with_legacy_url();
+
+		$fields = apply_filters( 'debug_information', [] )['gravity-pdf-deprecated']['fields'];
+
+		$this->assertArrayNotHasKey( 'deprecated', $fields );
+		$this->assertSame( 'Legacy Download URLs', $fields['legacy_endpoint']['label'] );
+		$this->assertStringContainsString( (string) $form_id, $fields['legacy_endpoint']['value'] );
+	}
+
+	public function test_every_surface_lists_a_template_by_file_name() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$legacy_path = $this->create_legacy_template();
+
+		/* Templates live in one directory, which the report states of its own, so no surface repeats the path */
+		$items = $this->get_deprecated_features();
+		$this->assertSame( 'my-legacy-template.php (not configured on a form)', $items['legacy_templates']['value_export'] );
+
+		$fields = apply_filters( 'debug_information', [] )['gravity-pdf-deprecated']['fields'];
+		$this->assertStringContainsString( 'my-legacy-template.php', $fields['legacy_templates']['value'] );
+		$this->assertStringNotContainsString( 'PDF_EXTENDED_TEMPLATES', $fields['legacy_templates']['value'] );
+
+
+		$result = call_user_func( $this->get_site_health_test()['test'] );
+		$this->assertStringContainsString( 'my-legacy-template.php', $result['description'] );
+		$this->assertStringNotContainsString( 'PDF_EXTENDED_TEMPLATES', $result['description'] );
+
+		$this->delete_legacy_templates( $legacy_path );
+	}
+
+	/**
+	 * The file name alone leaves the reader to search every form for it, so each surface names the forms too
+	 */
+	public function test_every_surface_names_the_forms_a_legacy_template_is_configured_on() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$legacy_path = $this->create_legacy_template( 'my-configured-template.php' );
+		$form_id     = (int) $this->gf_factory()->form->create();
+
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'template' => 'my-configured-template' ] );
+
+		$expected = sprintf( 'my-configured-template.php (form ID %d)', $form_id );
+
+		$items = $this->get_deprecated_features();
+		$this->assertSame( $expected, $items['legacy_templates']['value_export'] );
+
+		/* The display surfaces link each form to its PDF settings, which is where the template is changed */
+		$this->assertStringContainsString( 'subview=PDF', $items['legacy_templates']['value'] );
+		$this->assertStringContainsString( sprintf( '>%d</a>', $form_id ), $items['legacy_templates']['value'] );
+
+		$fields = apply_filters( 'debug_information', [] )['gravity-pdf-deprecated']['fields'];
+		$this->assertStringContainsString( $expected, $fields['legacy_templates']['value'] );
+
+		$result = call_user_func( $this->get_site_health_test()['test'] );
+		$this->assertStringContainsString( sprintf( '>%d</a>', $form_id ), $result['description'] );
+
+		$this->delete_legacy_templates( $legacy_path );
+	}
+
+	/**
+	 * The report detects live, so it leaves the admin notices a fresh record on the way past — a site that has
+	 * fixed everything stops being told about it without waiting for the next release
+	 */
+	public function test_the_report_records_what_it_detects_for_the_notices() {
+		$this->create_form_with_legacy_url();
+
+		apply_filters( 'gform_system_report', [] );
+
+		$this->assertSame( [ 'legacy_endpoint' ], Deprecation::get_detected_features() );
+	}
+
+	public function test_site_health_test_reports_each_signal() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$form_id = $this->create_form_with_legacy_url();
+
+		$result = call_user_func( $this->get_site_health_test()['test'] );
+
+		$this->assertSame( 'recommended', $result['status'] );
+		$this->assertStringContainsString( '<h4>Deprecated</h4>', $result['description'] );
+		$this->assertStringNotContainsString( '<h4>Unsupported</h4>', $result['description'] );
+		$this->assertStringContainsString( 'Legacy Download URLs', $result['description'] );
+		$this->assertStringContainsString( (string) $form_id, $result['description'] );
+		$this->assertStringContainsString( 'page=gf_system_status', $result['actions'] );
 	}
 }

--- a/tests/phpunit/integration/Controller/Test_Controller_Upgrade_Routines.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Upgrade_Routines.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 
 namespace GFPDF\Controller;
 
+use GFPDF\Statics\Deprecation;
+use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
 use GFPDF\Tests\Integration\TestCase;
 
 /**
@@ -22,6 +24,8 @@ use GFPDF\Tests\Integration\TestCase;
  */
 class Test_Controller_Upgrade_Routines extends TestCase {
 
+	use CreatesLegacyDownloadUrls;
+
 	/**
 	 * @var \GFPDF\Helper\Helper_Options_Fields
 	 */
@@ -31,6 +35,33 @@ class Test_Controller_Upgrade_Routines extends TestCase {
 		parent::set_up();
 
 		$this->options = \GPDFAPI::get_options_class();
+	}
+
+	/**
+	 * A release is the moment a new round of removals arrives, so it is where detection runs for the notices that
+	 * report it — they would otherwise have to walk the database on every admin page load
+	 */
+	public function test_a_version_change_records_the_deprecated_functionality_in_use() {
+		$form_id = $this->create_form_with_legacy_url();
+
+		do_action( 'gfpdf_version_changed', '6.16.0', '6.17.0' );
+
+		$this->assertSame( [ 'legacy_endpoint' ], Deprecation::get_detected_features() );
+
+		/* Fixed on the site, so the next release clears the record the notices read */
+		\GFAPI::delete_form( $form_id );
+
+		do_action( 'gfpdf_version_changed', '6.17.0', '6.17.1' );
+
+		$this->assertSame( [], Deprecation::get_detected_features() );
+	}
+
+	public function test_an_install_records_the_deprecated_functionality_in_use() {
+		$this->create_form_with_legacy_url();
+
+		do_action( 'gfpdf_plugin_installed' );
+
+		$this->assertSame( [ 'legacy_endpoint' ], Deprecation::get_detected_features() );
 	}
 
 	public function test_6_0_0_background_process_upgrade_routine() {

--- a/tests/phpunit/integration/Helper/Test_Form_Data.php
+++ b/tests/phpunit/integration/Helper/Test_Form_Data.php
@@ -1508,6 +1508,8 @@ class Test_Form_Data extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_empty_fields() {
+		$this->setExpectedDeprecated( 'GFPDFEntryDetail::lead_detail_grid_array' );
+
 		$entry     = $this->entries[6];
 		$form_data = GFPDFEntryDetail::lead_detail_grid_array( $this->form, $entry );
 
@@ -1582,6 +1584,8 @@ class Test_Form_Data extends TestCase {
 	 * Ensure the Product data calculations are correct when using Euros (or similar comma/decimal switched currency)
 	 */
 	public function test_euro_product_data() {
+		$this->setExpectedDeprecated( 'GFPDFEntryDetail::lead_detail_grid_array' );
+
 		$json                      = json_decode( trim( file_get_contents( PDF_PLUGIN_DIR . '/tools/phpunit/data/entries/all-form-euro-product-entry.json' ) ), true );
 		$json['form_id']           = $this->form['id'];
 		$entry_id                  = $this->gf_factory()->entry->create($json);

--- a/tests/phpunit/integration/Helper/Test_Gravity_Forms.php
+++ b/tests/phpunit/integration/Helper/Test_Gravity_Forms.php
@@ -437,6 +437,8 @@ class Test_Gravity_Forms extends TestCase {
 	 * @dataProvider provider_mergetag_test
 	 */
 	public function test_replace_variables( $mergetag, $value ) {
+		$this->setExpectedDeprecated( 'PDF_Common::do_mergetags' );
+
 		// Per-class form titles are dedup-suffixed by GFAPI (e.g. "Simple Form Testing (1)").
 		// Substitute the provider's expected title with the actual loaded form title.
 		if ( $mergetag === '{form_title}' ) {

--- a/tests/phpunit/integration/Helper/Test_MVC_Abstracts.php
+++ b/tests/phpunit/integration/Helper/Test_MVC_Abstracts.php
@@ -104,6 +104,8 @@ class Test_MVC_Abstracts extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_abstract_view() {
+		$this->setExpectedDeprecated( 'GFPDF\View\View_Settings::tabs' );
+
 		/*
 		 * Test our load function produces the correct output
 		 */

--- a/tests/phpunit/integration/Helper/Test_Notices.php
+++ b/tests/phpunit/integration/Helper/Test_Notices.php
@@ -155,6 +155,33 @@ class Test_Notices extends TestCase {
 		$this->assertStringContainsString( '<p>My First Error</p>', $html );
 	}
 
+	public function test_process_state_class() {
+		$this->notices->add_notice( 'My First Notice' );
+		$this->notices->add_notice( 'My Warning Notice', 'notice-warning' );
+		$this->notices->add_error( 'My Info Error', 'notice-info' );
+
+		ob_start();
+		$this->notices->process();
+		$html = ob_get_clean();
+
+		/* A `notice-*` class replaces the default state, instead of being appended to it */
+		$this->assertStringContainsString( '<div class="notice updated">', $html );
+		$this->assertStringContainsString( '<div class="notice notice-warning">', $html );
+		$this->assertStringContainsString( '<div class="notice notice-info">', $html );
+	}
+
+	public function test_process_same_class_twice() {
+		$this->notices->add_notice( 'My First Notice', 'notice-warning' );
+		$this->notices->add_notice( 'My Second Notice', 'notice-warning' );
+
+		ob_start();
+		$this->notices->process();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( '<p>My First Notice</p>', $html );
+		$this->assertStringContainsString( '<p>My Second Notice</p>', $html );
+	}
+
 	public function test_html_notice() {
 		$form = 'Message <form method="post"><p><button class="button">Action</button><input class="button primary" type="submit" value="Dismiss" /></p></form>';
 

--- a/tests/phpunit/integration/Model/Test_Model_System_Report.php
+++ b/tests/phpunit/integration/Model/Test_Model_System_Report.php
@@ -66,7 +66,12 @@ class Test_Model_System_Report extends TestCase {
 		$this->assertArrayHasKey( 'title', $structure );
 		$this->assertArrayHasKey( 'title_export', $structure );
 		$this->assertArrayHasKey( 'tables', $structure );
-		$this->assertCount( 4, $structure['tables'] );
+
+		/* One section per deprecation group in use, then the four the report has always had */
+		$this->assertSame(
+			[ 'deprecated', 'php', 'directories', 'global', 'security' ],
+			array_column( $structure['tables'], 'id' )
+		);
 	}
 
 	public function test_move_gravitypdf_active_plugins_to_gf_addons() {

--- a/tests/phpunit/integration/Model/Test_PDF.php
+++ b/tests/phpunit/integration/Model/Test_PDF.php
@@ -222,8 +222,8 @@ class Test_PDF extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_process_legacy_pdf_endpoint() {
-		$this->setExpectedIncorrectUsage( 'GFPDF\Controller\Controller_PDF::process_legacy_pdf_endpoint');
-		$this->setExpectedIncorrectUsage( 'GFPDF\Model\Model_PDF::get_legacy_config');
+		$this->setExpectedDeprecated( 'GFPDF\Controller\Controller_PDF::process_legacy_pdf_endpoint');
+		$this->setExpectedDeprecated( 'GFPDF\Model\Model_PDF::get_legacy_config');
 
 		/* Force a failure */
 		$this->assertNull( $this->controller->process_legacy_pdf_endpoint() );
@@ -814,6 +814,7 @@ class Test_PDF extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_get_pdf_name() {
+		$this->setExpectedDeprecated( 'gfpdfe_pdf_filename' );
 
 		/* Setup some test data */
 		$results = $this->form_and_entry();
@@ -1340,7 +1341,7 @@ class Test_PDF extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_cleanup_pdf() {
-		$this->setExpectedIncorrectUsage('GFPDF\Model\Model_PDF::cleanup_pdf');
+		$this->setExpectedDeprecated('GFPDF\Model\Model_PDF::cleanup_pdf');
 
 		$form_class = \GPDFAPI::get_form_class();
 
@@ -1559,7 +1560,7 @@ class Test_PDF extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_get_legacy_config() {
-		$this->setExpectedIncorrectUsage('GFPDF\Model\Model_PDF::get_legacy_config');
+		$this->setExpectedDeprecated('GFPDF\Model\Model_PDF::get_legacy_config');
 
 		/* Setup some test data */
 		$results = $this->form_and_entry();
@@ -1590,7 +1591,7 @@ class Test_PDF extends TestCase {
 	 * @dataProvider provider_get_template_filename
 	 */
 	public function test_get_template_filename( $expected, $template ) {
-		$this->setExpectedIncorrectUsage('GFPDF\View\View_PDF::get_template_filename');
+		$this->setExpectedDeprecated('GFPDF\View\View_PDF::get_template_filename');
 		$this->assertSame( $expected, $this->view->get_template_filename( $template ) );
 	}
 
@@ -1795,6 +1796,8 @@ class Test_PDF extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_legacy_display_page_name() {
+		$this->setExpectedDeprecated( 'GFPDF\View\View_PDF::display_page_name' );
+
 		$form = [
 			'pagination' => [
 				'pages' => [
@@ -1887,6 +1890,10 @@ class Test_PDF extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_apply_backwards_compatibility_filters() {
+		foreach ( [ 'gfpdfe_pdf_name', 'gfpdfe_template', 'gfpdf_orientation', 'gfpdf_security', 'gfpdf_privilages', 'gfpdf_password', 'gfpdf_master_password', 'gfpdf_rtl' ] as $hook ) {
+			$this->setExpectedDeprecated( $hook );
+		}
+
 		$entry            = $this->entry( 'all-form-fields' );
 		$entry['form_id'] = $this->form( 'all-form-fields' )['id'];
 
@@ -2076,6 +2083,8 @@ class Test_PDF extends TestCase {
 	 */
 	public function test_handle_legacy_tier_2_processing() {
 		global $gfpdf;
+
+		$this->setExpectedDeprecated( 'gfpdfe_pre_load_template' );
 
 		$settings  = [ 'id' => '556690c67856b', 'template' => 'zadani' ];
 		$entry     = $this->entry( 'all-form-fields' );

--- a/tests/phpunit/integration/Model/Test_Uninstaller.php
+++ b/tests/phpunit/integration/Model/Test_Uninstaller.php
@@ -9,6 +9,7 @@ use GFPDF\Controller\Controller_Uninstaller;
 use GFPDF\Helper\Helper_Pdf_Queue;
 use GFPDF\Model\Model_Install;
 use GFPDF\Model\Model_Uninstall;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF\Tests\Integration\TestCase;
 
 /**
@@ -167,9 +168,24 @@ class Test_Uninstaller extends TestCase {
 		$gfpdf->data->is_installed = false;
 		$installer->check_install_status();
 
-		update_option( 'gfpdf_settings', [] );
+		/* The deprecation notices' record of what this site uses, and the dismissals against it, ride in this row */
+		update_option(
+			'gfpdf_settings',
+			[
+				'deprecated_features' => [ 'legacy_endpoint' ],
+				'action_dismissal'    => [ 'deprecated_feature_legacy_endpoint' => 'deprecated_feature_legacy_endpoint' ],
+			]
+		);
+
+		/* The forms a legacy download URL has been served for are recorded in a row of their own */
+		update_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION, [ 1 ], false );
+
 		update_option( 'gpdf_sl_abc_123', true );
 		update_option( 'gpdf_sl_failed_123', true );
+
+		$this->assertArrayHasKey( 'deprecated_features', get_option( 'gfpdf_settings' ) );
+		$this->assertNotFalse( get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
+		$this->assertArrayHasKey( 'action_dismissal', get_option( 'gfpdf_settings' ) );
 
 		$this->assertNotFalse( get_option( 'gfpdf_is_installed' ) );
 		$this->assertNotFalse( get_option( 'gfpdf_current_version' ) );
@@ -183,6 +199,7 @@ class Test_Uninstaller extends TestCase {
 		$this->assertFalse( get_option( 'gfpdf_is_installed' ) );
 		$this->assertFalse( get_option( 'gfpdf_current_version' ) );
 		$this->assertFalse( get_option( 'gfpdf_settings' ) );
+		$this->assertFalse( get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
 		$this->assertFalse( get_option( 'gpdf_sl_abc_123' ) );
 		$this->assertFalse( get_option( 'gpdf_sl_failed_123' ) );
 

--- a/tests/phpunit/integration/Statics/Test_Deprecation.php
+++ b/tests/phpunit/integration/Statics/Test_Deprecation.php
@@ -1,0 +1,163 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+use GFPDF\Helper\Helper_Interface_Deprecated_Features;
+use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
+use GFPDF\Tests\Integration\TestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group     statics
+ */
+class Test_Deprecation extends TestCase {
+
+	use CreatesLegacyDownloadUrls;
+
+	public function test_apply_filters_skips_hooks_without_a_listener() {
+		$this->assertSame( 'my-pdf', Deprecation::apply_filters( 'gfpdfe_pdf_filename', [ 'my-pdf' ] ) );
+	}
+
+	public function test_apply_filters_warns_when_a_listener_is_attached() {
+		$this->setExpectedDeprecated( 'gfpdfe_pdf_filename' );
+
+		$callback = static function () {
+			return 'filtered-pdf';
+		};
+
+		add_filter( 'gfpdfe_pdf_filename', $callback );
+
+		$this->assertSame( 'filtered-pdf', Deprecation::apply_filters( 'gfpdfe_pdf_filename', [ 'my-pdf' ] ) );
+
+		remove_filter( 'gfpdfe_pdf_filename', $callback );
+	}
+
+	public function test_get_signals_omits_empty_signals() {
+		$this->create_form_with_legacy_url();
+
+		$this->assertSame( [ 'legacy_endpoint' ], array_keys( Deprecation::get_signals() ) );
+	}
+
+	/**
+	 * Nothing here knows about the v3 layer, so a later round of removals only has to register itself
+	 */
+	public function test_a_provider_supplies_its_own_features() {
+		Fake_Deprecated_Features::$detections = [];
+
+		$this->assertSame( [ 'fake_feature', 'fake_gone_feature' ], array_keys( Fake_Deprecation::get_features() ) );
+
+		/* Each feature names the release it goes in, rather than sharing one with everything else */
+		$this->assertSame( '7.1', Fake_Deprecation::get_feature( 'fake_feature' )['removed_in'] );
+
+		/* A feature the site doesn't use isn't reported */
+		$this->assertSame( [], Fake_Deprecation::get_signals() );
+
+		Fake_Deprecated_Features::$detections = [ 'a detection' ];
+
+		$signals = Fake_Deprecation::get_signals();
+
+		$this->assertSame(
+			[
+				'fake_feature'      => [ 'a detection' ],
+				'fake_gone_feature' => [ 'a detection' ],
+			],
+			$signals
+		);
+
+		/* A provider declaring both groups gets both back, in the order the engine reports them */
+		$this->assertSame(
+			[ Deprecation::GROUP_UNSUPPORTED, Deprecation::GROUP_DEPRECATED ],
+			array_keys( Fake_Deprecation::group_signals( $signals ) )
+		);
+		$this->assertSame(
+			[ Deprecation::GROUP_UNSUPPORTED, Deprecation::GROUP_DEPRECATED ],
+			Fake_Deprecation::get_groups()
+		);
+
+		/* The v3 provider declares one group today, so no surface carries the other around empty */
+		$this->assertSame( [ Deprecation::GROUP_DEPRECATED ], Deprecation::get_groups() );
+
+		Fake_Deprecated_Features::$detections = [];
+	}
+
+	/**
+	 * The uninstaller asks the registry, so a provider's storage goes with it without touching Model_Uninstall
+	 */
+	public function test_delete_stored_data_removes_what_each_provider_stores() {
+		update_option( Fake_Deprecated_Features::OPTION, [ 1 ], false );
+		update_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION, [ 1 => time() ], false );
+
+		Fake_Deprecation::delete_stored_data();
+
+		$this->assertFalse( get_option( Fake_Deprecated_Features::OPTION ) );
+
+		/* The registry is swapped out, so the v3 option is untouched */
+		$this->assertNotFalse( get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
+
+		Deprecation::delete_stored_data();
+
+		$this->assertFalse( get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
+	}
+
+	public function test_get_feature_is_empty_for_an_unregistered_id() {
+		$this->assertSame( [], Deprecation::get_feature( 'not-a-feature' ) );
+	}
+}
+
+/**
+ * A round of removals that has nothing to do with the v3 layer
+ */
+class Fake_Deprecated_Features implements Helper_Interface_Deprecated_Features {
+
+	const OPTION = 'gfpdf_fake_feature_usage';
+
+	/**
+	 * @var array What the feature's detector reports
+	 */
+	public static $detections = [];
+
+	public static function get_features(): array {
+		return [
+			'fake_feature'     => [
+				'label'      => 'Fake Feature',
+				'group'      => Deprecation::GROUP_DEPRECATED,
+				'removed_in' => '7.1',
+				'url'        => 'https://example.org/upgrade/fake-feature/',
+				'detect'     => [ static::class, 'detect' ],
+			],
+
+			'fake_gone_feature' => [
+				'label'      => 'Fake Gone Feature',
+				'group'      => Deprecation::GROUP_UNSUPPORTED,
+				'removed_in' => '7.1',
+				'url'        => 'https://example.org/upgrade/fake-gone-feature/',
+				'detect'     => [ static::class, 'detect' ],
+			],
+		];
+	}
+
+	public static function detect(): array {
+		return static::$detections;
+	}
+
+	public static function get_stored_options(): array {
+		return [ self::OPTION ];
+	}
+}
+
+/**
+ * Swaps the registry out for the fake provider, which is all registering a new one amounts to
+ */
+class Fake_Deprecation extends Deprecation {
+
+	protected static function get_providers(): array {
+		return [ Fake_Deprecated_Features::class ];
+	}
+}

--- a/tests/phpunit/integration/Statics/Test_Deprecation_V3.php
+++ b/tests/phpunit/integration/Statics/Test_Deprecation_V3.php
@@ -1,0 +1,291 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
+use GFPDF\Tests\Concerns\CreatesLegacyTemplates;
+use GFPDF\Tests\Concerns\ResetsDetectedFeatures;
+use GFPDF\Tests\Integration\TestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group     statics
+ */
+class Test_Deprecation_V3 extends TestCase {
+
+	use CreatesLegacyDownloadUrls;
+	use CreatesLegacyTemplates;
+	use ResetsDetectedFeatures;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->reset_detected_features();
+	}
+
+	/**
+	 * Passes either way on Gravity Forms 2.9, which still declares the class; it is 3.0 the shim exists for
+	 */
+	public function test_restore_v3_form_class_puts_back_the_class_v3_templates_guard_on() {
+		Deprecation_V3::restore_v3_form_class();
+
+		$this->assertTrue( class_exists( 'RGForms' ) );
+	}
+
+	/**
+	 * A Business Plus template drives the PDF engine itself, which is the one thing a plain v3 template never does
+	 */
+	public function test_legacy_templates_are_split_by_whether_they_drive_the_pdf_engine() {
+		$standard      = $this->create_legacy_template( 'my-standard-template.php' );
+		$business_plus = $this->create_legacy_template( 'my-business-plus-template.php', '$mpdf->AddPage();' );
+
+		$this->assertSame( [ $business_plus ], array_keys( Deprecation_V3::get_business_plus_templates() ) );
+		$this->assertArrayHasKey( $standard, Deprecation_V3::get_legacy_templates() );
+		$this->assertArrayNotHasKey( $business_plus, Deprecation_V3::get_legacy_templates() );
+
+		$this->delete_legacy_templates( $standard, $business_plus );
+	}
+
+	/**
+	 * A report naming the file alone leaves the reader to search every form for it, so the forms selecting it
+	 * travel with it
+	 */
+	public function test_legacy_templates_are_reported_with_the_forms_they_are_configured_on() {
+		$used   = $this->create_legacy_template( 'my-used-template.php' );
+		$unused = $this->create_legacy_template( 'my-unused-template.php' );
+
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		/* Two PDFs on the one template is still the one form to fix */
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'template' => 'my-used-template' ] );
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'template' => 'my-used-template' ] );
+
+		$templates = Deprecation_V3::get_legacy_templates();
+
+		$this->assertSame( [ $form_id ], $templates[ $used ] );
+		$this->assertSame( [], $templates[ $unused ] );
+
+		$this->delete_legacy_templates( $used, $unused );
+	}
+
+	/**
+	 * The `LIKE` narrowing the scan only gets it to the rows worth reading, so what a PDF actually selects has to
+	 * settle which template a form is reported against
+	 */
+	public function test_a_template_named_elsewhere_in_a_form_is_not_reported_against_it() {
+		$path = $this->create_legacy_template( 'my-mentioned-template.php' );
+		$form = \GFAPI::get_form( $this->gf_factory()->form->create() );
+
+		$form['description'] = 'Grab the my-mentioned-template.php file from the downloads page';
+		\GFAPI::update_form( $form );
+
+		/* The PDF is what puts the form in front of the scan at all, and it selects something else */
+		$this->gf_factory()->pdf->set_form_id( (int) $form['id'] )->create( [ 'template' => 'zadani' ] );
+
+		$this->assertSame( [], Deprecation_V3::get_legacy_templates()[ $path ] );
+
+		$this->delete_legacy_templates( $path );
+	}
+
+	public function test_a_trashed_form_is_not_reported_against_a_template() {
+		$path    = $this->create_legacy_template( 'my-trashed-form-template.php' );
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'template' => 'my-trashed-form-template' ] );
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_legacy_templates()[ $path ] );
+
+		/* A trashed form isn't in the user's form list, so there's nothing for them to act on */
+		\GFAPI::delete_form( $form_id );
+		Deprecation_V3::flush_cache();
+
+		$this->assertSame( [], Deprecation_V3::get_legacy_templates()[ $path ] );
+
+		$this->delete_legacy_templates( $path );
+	}
+
+	public function test_the_v3_features_are_registered() {
+		$features = Deprecation::get_features();
+
+		$this->assertSame(
+			[ 'legacy_templates', 'business_plus_templates', 'legacy_endpoint', 'deprecated_filters' ],
+			array_keys( $features )
+		);
+
+		$this->assertSame( Deprecation_V3::REMOVED_IN, $features['legacy_templates']['removed_in'] );
+		$this->assertSame( Deprecation::GROUP_DEPRECATED, $features['legacy_templates']['group'] );
+	}
+
+	public function test_get_legacy_download_urls_searches_the_whole_form() {
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+
+		$form_ids = [
+			$this->create_form_with_legacy_url( 'form' ),
+			$this->create_form_with_legacy_url( 'confirmations' ),
+			$this->create_form_with_legacy_url( 'notifications' ),
+		];
+
+		sort( $form_ids );
+
+		$this->assertSame( $form_ids, Deprecation_V3::get_legacy_download_urls() );
+
+		/* A form that has never handed out a legacy URL isn't reported */
+		$this->gf_factory()->form->create();
+
+		$this->assertSame( $form_ids, Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_get_legacy_download_urls_ignores_a_partial_marker() {
+		$this->create_form_with_legacy_url( 'form', 'gf_pdf=0' );
+
+		/* Only `gf_pdf=1` routes to the legacy endpoint, so anything else is a false positive */
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_get_legacy_download_urls_includes_the_recorded_forms() {
+		$scanned  = $this->create_form_with_legacy_url();
+		$recorded = (int) $this->gf_factory()->form->create();
+
+		Deprecation_V3::record_legacy_endpoint_usage( $recorded );
+
+		/* A URL served for a form that never handed one out lives somewhere the scan can't see */
+		$this->assertSame( [ $recorded ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+		$this->assertSame( [ min( $scanned, $recorded ), max( $scanned, $recorded ) ], Deprecation_V3::get_legacy_download_urls() );
+
+		/* A form found by both sources is only reported once */
+		Deprecation_V3::record_legacy_endpoint_usage( $scanned );
+
+		$this->assertCount( 2, Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_record_legacy_endpoint_usage_writes_once_a_day_per_form() {
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		/* Written from the front end but read on three admin paths, so it stays out of the autoloaded set */
+		$this->assertArrayNotHasKey( Deprecation_V3::LEGACY_ENDPOINT_OPTION, wp_load_alloptions() );
+
+		$writes = 0;
+		add_action(
+			'update_option_' . Deprecation_V3::LEGACY_ENDPOINT_OPTION,
+			function () use ( &$writes ) {
+				++$writes;
+			}
+		);
+
+		/* Every later request that day reads the record and leaves it alone */
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertSame( 0, $writes );
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+
+		/* A link still being followed a day later refreshes the record, so it never reaches the expiry */
+		$stale = time() - Deprecation_V3::LEGACY_ENDPOINT_REFRESH - 1;
+		update_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION, [ $form_id => $stale ], false );
+
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertGreaterThan( $stale, get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION )[ $form_id ] );
+	}
+
+	public function test_get_recorded_legacy_endpoint_usage_expires_a_quiet_form() {
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+
+		/* Nobody has followed a legacy URL for this form in a month, so it's no longer evidence one exists */
+		update_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION, [ $form_id => time() - Deprecation_V3::LEGACY_ENDPOINT_TTL - 1 ], false );
+
+		$this->assertSame( [], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+
+		/* The expired record is flushed on the way out rather than left for the uninstaller */
+		$this->assertSame( [], get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
+
+		/* The next legacy URL served for the form puts it back */
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+	}
+
+	public function test_get_legacy_download_urls_skips_trashed_recorded_forms() {
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_legacy_download_urls() );
+
+		/* A trashed form isn't in the user's form list, so there's nothing for them to act on */
+		\GFAPI::delete_form( $form_id );
+
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_get_legacy_download_urls_skips_trashed_forms() {
+		$form_id = $this->create_form_with_legacy_url();
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_legacy_download_urls() );
+
+		/* A trashed form isn't in the user's form list, so there's nothing for them to act on */
+		\GFAPI::delete_form( $form_id );
+
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_get_active_deprecated_filters_ignores_our_own_callback() {
+		$this->assertNotFalse( has_filter( 'gfpdfe_pre_load_template', Deprecation_V3::INTERNAL_FILTER_CALLBACK ) );
+		$this->assertArrayNotHasKey( 'gfpdfe_pre_load_template', Deprecation_V3::get_active_deprecated_filters() );
+	}
+
+	public function test_get_active_deprecated_filters_includes_dynamic_hooks() {
+		$callback = '__return_true';
+
+		add_filter( 'gfpdfe_pdf_template_10', $callback );
+		add_filter( 'gfpdf_rtl', $callback );
+
+		$active = Deprecation_V3::get_active_deprecated_filters();
+
+		$this->assertSame( 1, $active['gfpdfe_pdf_template_10'] );
+		$this->assertSame( 1, $active['gfpdf_rtl'] );
+
+		remove_filter( 'gfpdfe_pdf_template_10', $callback );
+		remove_filter( 'gfpdf_rtl', $callback );
+	}
+
+	public function test_get_active_deprecated_filters_includes_the_legacy_hooks() {
+		$callback = '__return_true';
+
+		/* These carry the gfpdf_legacy_ prefix rather than gfpdfe_, so only the map can find them */
+		add_filter( 'gfpdf_legacy_save_path', $callback );
+		add_action( 'gfpdf_legacy_pre_view_or_download_pdf', $callback );
+
+		$active = Deprecation_V3::get_active_deprecated_filters();
+
+		$this->assertSame( 1, $active['gfpdf_legacy_save_path'] );
+		$this->assertSame( 1, $active['gfpdf_legacy_pre_view_or_download_pdf'] );
+
+		remove_filter( 'gfpdf_legacy_save_path', $callback );
+		remove_action( 'gfpdf_legacy_pre_view_or_download_pdf', $callback );
+	}
+
+	/**
+	 * The detection reads template files, not PDF settings, so a Core template stays out of the report no matter
+	 * how a PDF using it is configured
+	 */
+	public function test_the_advanced_templating_setting_alone_does_not_report_a_template() {
+		$this->create_form_with_advanced_templating();
+
+		$this->assertArrayNotHasKey( PDF_PLUGIN_DIR . 'src/templates/zadani.php', Deprecation_V3::get_legacy_templates() );
+		$this->assertSame( [], Deprecation_V3::get_business_plus_templates() );
+	}
+}

--- a/tests/phpunit/integration/Test_Deprecated.php
+++ b/tests/phpunit/integration/Test_Deprecated.php
@@ -104,6 +104,8 @@ class Test_Deprecated extends TestCase {
 	public function test_render_save_pdf() {
 		global $gfpdf;
 
+		$this->setExpectedDeprecated( 'PDFRender::savePDF' );
+
 		$render = new PDFRender();
 		$render->savePDF( 'testing', 'mydocument.pdf', 20 );
 
@@ -136,6 +138,8 @@ class Test_Deprecated extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_common_get_ids() {
+		$this->setExpectedDeprecated( 'PDF_Common::get_ids' );
+
 		$GLOBALS['form_id'] = '20';
 		$_GET['lid']        = '20,21,23';
 
@@ -151,6 +155,8 @@ class Test_Deprecated extends TestCase {
 	 * @since 4.0
 	 */
 	public function test_common_get_pdf_filename() {
+		$this->setExpectedDeprecated( 'PDF_Common::get_pdf_filename' );
+
 		$this->assertSame( 'form-50-entry-2091.pdf', PDF_Common::get_pdf_filename( 50, 2091 ) );
 	}
 
@@ -162,6 +168,8 @@ class Test_Deprecated extends TestCase {
 	 */
 	public function test_deprecated_save_pdf() {
 		global $gfpdf;
+
+		$this->setExpectedDeprecated( 'GFPDF_Core_Model::gfpdfe_save_pdf' );
 
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Multisite saves the PDF under a path the prefix glob does not match (known gfpdfe_save_pdf network-site behaviour).' );

--- a/tests/phpunit/integration/View/Test_View_Actions.php
+++ b/tests/phpunit/integration/View/Test_View_Actions.php
@@ -34,6 +34,21 @@ class Test_View_Actions extends TestCase {
 		$this->assertStringNotContainsString( 'Dismiss Notice', $html );
 	}
 
+	public function test_deprecated_features_lists_each_one_and_links_to_its_upgrade_guide() {
+		$html = $this->view->deprecated_features( [ 'legacy_templates', 'legacy_endpoint' ], 'deprecated_features', 'View the system report' );
+
+		$this->assertStringContainsString( 'Support for Legacy Templates will be removed in Gravity PDF 7.0.', $html );
+		$this->assertStringContainsString( 'upgrade/legacy-templates/', $html );
+
+		$this->assertStringContainsString( 'Support for legacy download URLs will be removed in Gravity PDF 7.0.', $html );
+		$this->assertStringContainsString( 'upgrade/legacy-download-urls/', $html );
+
+		/* The notice can be acted on or dismissed, and one dismissal covers everything it listed */
+		$this->assertStringContainsString( 'View the system report', $html );
+		$this->assertStringContainsString( 'value="gfpdf_deprecated_features"', $html );
+		$this->assertStringContainsString( 'Dismiss Notice', $html );
+	}
+
 	public function test_core_font_concatenates_notice_and_disabled_buttons() {
 		$html = $this->view->core_font( 'install_core_fonts', 'Install Now' );
 

--- a/tests/phpunit/integration/View/Test_View_PDF.php
+++ b/tests/phpunit/integration/View/Test_View_PDF.php
@@ -123,7 +123,7 @@ class Test_View_PDF extends TestCase {
 	 * @group slow
 	 */
 	public function test_generate_pdf() {
-		$this->setExpectedIncorrectUsage( 'GFPDF\View\View_PDF::generate_pdf' );
+		$this->setExpectedDeprecated( 'GFPDF\View\View_PDF::generate_pdf' );
 
 		global $gfpdf;
 

--- a/tests/playwright/core/entry-list-and-details/multiple-pdfs.spec.ts
+++ b/tests/playwright/core/entry-list-and-details/multiple-pdfs.spec.ts
@@ -1,9 +1,10 @@
 import { expect } from '@wordpress/e2e-test-utils-playwright';
-import { takeSnapshot } from '@chromatic-com/playwright';
+import { snapshot } from '@self:playwright/utils/snapshot';
 import type { Admin, RequestUtils } from '@wordpress/e2e-test-utils-playwright';
 import type { Page } from '@playwright/test';
 import { test } from '@self:playwright/fixtures/test';
 import Pdf from '@self:playwright/utils/gravitypdf';
+import { FIXED_ENTRY_DATE } from '@self:playwright/utils/gravityforms';
 
 test.describe('Multiple PDF', () => {
 	let form = null;
@@ -30,7 +31,10 @@ test.describe('Multiple PDF', () => {
 			}
 
 			// create entry
-			entry = await pdf.createEntry({ form_id: form.id });
+			entry = await pdf.createEntry({
+				form_id: form.id,
+				date_created: FIXED_ENTRY_DATE,
+			});
 		}
 	);
 
@@ -48,7 +52,7 @@ test.describe('Multiple PDF', () => {
 		await page.locator('.has-row-actions').first().hover();
 		await pdfLink.hover();
 
-		await takeSnapshot(page, testinfo);
+		await snapshot(page, testinfo);
 
 		await pdf.downloadAndVerifyPdf(
 			page.getByRole('link', { name: 'Multiple #2' }),
@@ -70,6 +74,6 @@ test.describe('Multiple PDF', () => {
 			page.getByLabel('View or download Multiple #2.pdf')
 		).toBeAttached();
 
-		await takeSnapshot(page, testinfo);
+		await snapshot(page, testinfo);
 	});
 });

--- a/tests/playwright/core/entry-list-and-details/single-pdf.spec.ts
+++ b/tests/playwright/core/entry-list-and-details/single-pdf.spec.ts
@@ -2,7 +2,8 @@ import type { Admin, RequestUtils } from '@wordpress/e2e-test-utils-playwright';
 import type { Page } from '@playwright/test';
 import { test } from '@self:playwright/fixtures/test';
 import Pdf from '@self:playwright/utils/gravitypdf';
-import { takeSnapshot } from '@chromatic-com/playwright';
+import { FIXED_ENTRY_DATE } from '@self:playwright/utils/gravityforms';
+import { snapshot } from '@self:playwright/utils/snapshot';
 
 test.describe('Single PDF', () => {
 	let form = null;
@@ -28,7 +29,10 @@ test.describe('Single PDF', () => {
 			await pdf.createPdf(form.id, 'Single #1');
 
 			// create entry
-			entry = await pdf.createEntry({ form_id: form.id });
+			entry = await pdf.createEntry({
+				form_id: form.id,
+				date_created: FIXED_ENTRY_DATE,
+			});
 		}
 	);
 
@@ -45,7 +49,7 @@ test.describe('Single PDF', () => {
 		const pdfLink = page.getByRole('link', { name: 'View PDF' });
 		await page.locator('.has-row-actions').first().hover();
 
-		await takeSnapshot(page, testinfo);
+		await snapshot(page, testinfo);
 		await pdf.downloadAndVerifyPdf(pdfLink, 'Single #1.pdf');
 	});
 

--- a/tests/playwright/core/global-settings/license.spec.ts
+++ b/tests/playwright/core/global-settings/license.spec.ts
@@ -2,7 +2,7 @@ import type { Admin } from '@wordpress/e2e-test-utils-playwright';
 import { expect } from '@wordpress/e2e-test-utils-playwright';
 import type { Page } from '@playwright/test';
 import { test } from '@self:playwright/fixtures/test';
-import { takeSnapshot } from '@chromatic-com/playwright';
+import { snapshot } from '@self:playwright/utils/snapshot';
 
 test.describe('License Tab', () => {
 	test('should display License field information', async ({
@@ -110,7 +110,7 @@ test.describe('License Tab', () => {
 			await page.locator('[name="submit"]').click();
 
 			await page.waitForTimeout(1000);
-			await takeSnapshot(page, testinfo);
+			await snapshot(page, testinfo);
 
 			await page
 				.getByRole('button', { name: 'Deactivate License' })

--- a/tests/playwright/core/global-settings/tools.spec.ts
+++ b/tests/playwright/core/global-settings/tools.spec.ts
@@ -2,7 +2,7 @@ import type { Admin } from '@wordpress/e2e-test-utils-playwright';
 import { expect } from '@wordpress/e2e-test-utils-playwright';
 import type { Page } from '@playwright/test';
 import { test } from '@self:playwright/fixtures/test';
-import { takeSnapshot } from '@chromatic-com/playwright';
+import { snapshot } from '@self:playwright/utils/snapshot';
 
 test.describe('Tools Tab', () => {
 	test.describe('Install Core Fonts', () => {
@@ -65,7 +65,7 @@ test.describe('Tools Tab', () => {
 				})
 			).toBeVisible({ timeout: 60000 });
 
-			await takeSnapshot(page, testinfo);
+			await snapshot(page, testinfo);
 		});
 
 		test('should return download core fonts error/failed response', async ({

--- a/tests/playwright/core/pdf-settings/pdf-settings.spec.ts
+++ b/tests/playwright/core/pdf-settings/pdf-settings.spec.ts
@@ -4,7 +4,7 @@ import type { Page } from '@playwright/test';
 import { test, resourcesPath } from '@self:playwright/fixtures/test';
 import Pdf from '@self:playwright/utils/gravitypdf';
 import * as path from 'node:path';
-import { takeSnapshot } from '@chromatic-com/playwright';
+import { snapshot } from '@self:playwright/utils/snapshot';
 
 test.describe('Form PDF Settings', () => {
 	let pdf = null;
@@ -64,7 +64,7 @@ test.describe('Form PDF Settings', () => {
 
 			await pdf.page.waitForTimeout(1000);
 			await pdf.switchToCodeEditor();
-			await takeSnapshot(pdf.page, testinfo);
+			await snapshot(pdf.page, testinfo);
 		});
 
 		test('Notifications', async () => {
@@ -119,7 +119,7 @@ test.describe('Form PDF Settings', () => {
 
 			await pdf.page.waitForTimeout(1000);
 			await pdf.switchToCodeEditor();
-			await takeSnapshot(pdf.page, testinfo);
+			await snapshot(pdf.page, testinfo);
 
 			// Entry 1: Radio = "Second Choice" → PDF hidden by conditional logic
 			const entry1 = await pdf.createEntry({
@@ -184,7 +184,7 @@ test.describe('Form PDF Settings', () => {
 
 			await pdf.page.waitForTimeout(1000);
 			await pdf.switchToCodeEditor();
-			await takeSnapshot(pdf.page, testinfo);
+			await snapshot(pdf.page, testinfo);
 		});
 
 		test('Color Picker', async ({}, testinfo) => {
@@ -208,7 +208,7 @@ test.describe('Form PDF Settings', () => {
 
 			await pdf.switchToCodeEditor();
 			await colorPicker.click();
-			await takeSnapshot(pdf.page, testinfo);
+			await snapshot(pdf.page, testinfo);
 		});
 
 		test('Reverse Text RTL', async () => {
@@ -260,7 +260,7 @@ test.describe('Form PDF Settings', () => {
 			);
 
 			await pdf.switchToCodeEditor();
-			await takeSnapshot(pdf.page, testinfo);
+			await snapshot(pdf.page, testinfo);
 		});
 
 		test('Show Empty Fields', async () => {
@@ -382,7 +382,7 @@ test.describe('Form PDF Settings', () => {
 				.click();
 
 			await pdf.switchToCodeEditor();
-			await takeSnapshot(pdf.page, testinfo);
+			await snapshot(pdf.page, testinfo);
 		});
 
 		test('Public Access', async () => {

--- a/tests/playwright/core/system-status/deprecated-features.spec.ts
+++ b/tests/playwright/core/system-status/deprecated-features.spec.ts
@@ -1,0 +1,257 @@
+import type { Admin, RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+import { expect } from '@wordpress/e2e-test-utils-playwright';
+import type { Page } from '@playwright/test';
+import { test } from '@self:playwright/fixtures/test';
+import Pdf from '@self:playwright/utils/gravitypdf';
+import {
+	clearDeprecatedDetection,
+	clearDeprecatedUsage,
+	installLegacyTemplates,
+	maskFormIds,
+	recordDeprecatedUsage,
+	refreshDeprecatedDetection,
+	removeLegacyTemplates,
+	removeLegacyTemplateFromForm,
+	setLegacyDownloadUrl,
+	useLegacyTemplateOnForm,
+} from '@self:playwright/utils/deprecation';
+import { isolateForSnapshot, snapshot } from '@self:playwright/utils/snapshot';
+
+test.describe('Deprecated Features', () => {
+	// The signals are site-wide, so the tests share one set-up and run in order. Keeping the rest of the suite out
+	// while they are installed is the `core-isolated` project's job, since serial mode only orders this file.
+	test.describe.configure({ mode: 'serial' });
+
+	let pdf: Pdf;
+	let formId: number;
+
+	test.beforeAll(async ({ requestUtils }: { requestUtils: RequestUtils }) => {
+		recordDeprecatedUsage();
+		installLegacyTemplates();
+
+		// createForm only touches requestUtils, the one fixture a beforeAll hook can take
+		pdf = new Pdf(requestUtils, undefined!, undefined!);
+
+		const form: any = await pdf.createForm('Legacy Download URL');
+		formId = form.id;
+
+		await setLegacyDownloadUrl(pdf, formId, true);
+		useLegacyTemplateOnForm(formId);
+
+		refreshDeprecatedDetection();
+	});
+
+	test.afterAll(async () => {
+		clearDeprecatedUsage();
+		removeLegacyTemplates();
+		removeLegacyTemplateFromForm(formId);
+
+		// Leave the site as we found it: the form carries one of the signals, and forms outlive the run
+		await setLegacyDownloadUrl(pdf, formId, false);
+
+		// Leave the notices nothing to report, so the permalink pass runs against a site without them
+		clearDeprecatedDetection();
+	});
+
+	test('should list each detected feature in the system report', async ({
+		page,
+		admin,
+	}: {
+		page: Page;
+		admin: Admin;
+	}, testinfo) => {
+		await admin.visitAdminPage('admin.php', 'page=gf_system_status');
+
+		// The section title is the table's caption, matched whole so a stray "Deprecated" elsewhere can't join in
+		const sectionByTitle = (title: string) =>
+			page.locator('table.gform_system_report').filter({
+				has: page.locator('caption', {
+					hasText: new RegExp(`^\\s*${title}\\s*$`),
+				}),
+			});
+
+		const deprecated = sectionByTitle('Deprecated');
+
+		await expect(deprecated).toBeVisible();
+
+		// No registered feature has already been removed, so that section isn't carried around empty
+		await expect(sectionByTitle('Unsupported')).toHaveCount(0);
+
+		// Templates are listed by file name alone, since the report states the working directory of its own, and
+		// by the forms configured to render through them
+		await expect(deprecated).toContainText(
+			'Support for Legacy Templates will be removed in Gravity PDF 7.0.'
+		);
+		await expect(deprecated).toContainText(
+			`e2e-legacy.php (form ID ${formId})`
+		);
+		await expect(deprecated).not.toContainText('PDF_EXTENDED_TEMPLATES');
+
+		// A template that drives the PDF engine is a Business Plus one, and reports under its own heading
+		await expect(deprecated).toContainText(
+			'Support for Business Plus Templates will be removed in Gravity PDF 7.0.'
+		);
+		await expect(deprecated).toContainText(
+			'e2e-business-plus.php (not configured on a form)'
+		);
+
+		// Each detected form links to its own PDF settings, which is where both the template and the URL are replaced
+		await expect(deprecated).toContainText(`In use on form ID ${formId}`);
+
+		const formLinks = deprecated.getByRole('link', {
+			name: `${formId}`,
+			exact: true,
+		});
+
+		await expect(formLinks).toHaveCount(2);
+		await expect(formLinks.first()).toHaveAttribute(
+			'href',
+			new RegExp(`subview=PDF&id=${formId}$`)
+		);
+
+		// Both hook shapes are reported: the v3 `gfpdfe_` prefix, and the ones only the map can name
+		await expect(deprecated).toContainText('gfpdf_rtl has 1 listener');
+		await expect(deprecated).toContainText(
+			'gfpdf_legacy_templates has 1 listener'
+		);
+
+		await isolateForSnapshot(page, [deprecated]);
+		await maskFormIds(page);
+
+		await snapshot(page, testinfo);
+	});
+
+	test('should report the detected features in Site Health', async ({
+		page,
+		admin,
+	}: {
+		page: Page;
+		admin: Admin;
+	}, testinfo) => {
+		await admin.visitAdminPage('site-health.php');
+
+		const heading = page.locator('.health-check-accordion-heading', {
+			hasText:
+				'Your site uses Gravity PDF functionality that is scheduled for removal',
+		});
+
+		await expect(heading).toBeVisible({ timeout: 30000 });
+		await heading.click();
+
+		const panel = page.locator(
+			'#health-check-accordion-block-gravity_pdf_deprecated_features'
+		);
+
+		// Each feature reads as it does in the system report, under the group heading it belongs to
+		await expect(
+			panel.getByRole('heading', { name: 'Deprecated', exact: true })
+		).toBeVisible();
+
+		await expect(panel).toContainText(
+			`e2e-legacy.php (form ID ${formId}). Support for Legacy Templates will be removed in Gravity PDF 7.0.`
+		);
+		await expect(panel).not.toContainText('PDF_EXTENDED_TEMPLATES');
+		await expect(panel).toContainText(`In use on form ID ${formId}`);
+		await expect(panel).toContainText('gfpdf_rtl has 1 listener');
+		await expect(
+			panel.getByRole('link', { name: 'Learn how to upgrade' }).first()
+		).toHaveAttribute('href', /upgrade\/legacy-templates\//);
+		await expect(
+			panel.getByRole('link', {
+				name: 'View the Gravity Forms system report',
+			})
+		).toBeVisible();
+
+		await isolateForSnapshot(page, [heading, panel]);
+		await maskFormIds(page);
+
+		await snapshot(page, testinfo);
+	});
+
+	test('should include the detected features in the Site Health Info tab', async ({
+		page,
+		admin,
+	}: {
+		page: Page;
+		admin: Admin;
+	}, testinfo) => {
+		await admin.visitAdminPage('site-health.php', 'tab=debug');
+
+		// The group gets its own section, so a support ticket carries the detections with it
+		const deprecatedHeading = page.locator(
+			'.health-check-accordion-heading',
+			{
+				hasText: 'Gravity PDF - Deprecated Functionality',
+			}
+		);
+
+		await expect(deprecatedHeading).toBeVisible();
+		await deprecatedHeading.click();
+
+		const deprecated = page.locator(
+			'#health-check-accordion-block-gravity-pdf-deprecated'
+		);
+
+		// Templates are named by file, with the upgrade URL travelling in the support ticket beside them
+		await expect(deprecated).toContainText(
+			`e2e-legacy.php (form ID ${formId}). Support for Legacy Templates will be removed in Gravity PDF 7.0.`
+		);
+		await expect(deprecated).toContainText(
+			'https://docs.gravitypdf.com/upgrade/legacy-templates/'
+		);
+		await expect(deprecated).toContainText(`In use on form ID ${formId}`);
+		await expect(deprecated).toContainText('gfpdf_rtl has 1 listener');
+
+		await isolateForSnapshot(page, [deprecatedHeading, deprecated]);
+		await maskFormIds(page);
+
+		await snapshot(page, testinfo);
+	});
+
+	test('should raise one dismissible notice covering every detected feature', async ({
+		page,
+		admin,
+	}: {
+		page: Page;
+		admin: Admin;
+	}, testinfo) => {
+		await admin.visitAdminPage('index.php');
+
+		// One notice for the lot, rather than one per feature competing for the same screen
+		const notice = page.locator('.notice', {
+			hasText: 'This site uses deprecated Gravity PDF functionality',
+		});
+
+		await expect(notice).toHaveCount(1);
+		await expect(notice).toBeVisible();
+
+		// Functionality still working, but not for much longer, reads as a warning rather than an error
+		await expect(notice).toHaveClass(/notice-warning/);
+
+		// Every detected feature is listed, each linking to the guide that covers it
+		await expect(notice).toContainText(
+			'Support for Legacy Templates will be removed in Gravity PDF 7.0.'
+		);
+		await expect(notice).toContainText(
+			'Support for Business Plus Templates will be removed in Gravity PDF 7.0.'
+		);
+		await expect(notice).toContainText(
+			'Support for legacy download URLs will be removed in Gravity PDF 7.0.'
+		);
+
+		// The hooks item says what is actually affected: out of its report row, "Actions and Filters" reads as the lot
+		await expect(notice).toContainText(
+			'Code on this site uses Gravity PDF hooks that are removed in version 7.0.'
+		);
+		await expect(
+			notice.getByRole('button', { name: 'View the system report' })
+		).toBeVisible();
+		await expect(
+			notice.getByRole('button', { name: 'Dismiss Notice' })
+		).toBeVisible();
+
+		await isolateForSnapshot(page, [notice]);
+
+		await snapshot(page, testinfo);
+	});
+});

--- a/tests/playwright/permalinks/download-shortcode/copy-to-clipboard.spec.ts
+++ b/tests/playwright/permalinks/download-shortcode/copy-to-clipboard.spec.ts
@@ -3,7 +3,7 @@ import type { Page } from '@playwright/test';
 import { expect } from '@wordpress/e2e-test-utils-playwright';
 import { test } from '@self:playwright/fixtures/test';
 import Pdf from '@self:playwright/utils/gravitypdf';
-import { takeSnapshot } from '@chromatic-com/playwright';
+import { snapshot } from '@self:playwright/utils/snapshot';
 
 test.describe('[gravitypdf] Shortcode', () => {
 	test('Copy to Clipboard', async ({
@@ -22,7 +22,7 @@ test.describe('[gravitypdf] Shortcode', () => {
 		const pdfId = await pdf.createPdf(form.id, pdfLabel);
 		await pdf.copyDownloadShortcodeToClipboard(form.id, pdfId);
 
-		await takeSnapshot(page, testinfo);
+		await snapshot(page, testinfo);
 
 		// Add a new PDF and paste into the Label
 		await pdf.navigateToNewFormPdf(form.id);

--- a/tools/mu-plugins/gravitypdf.php
+++ b/tools/mu-plugins/gravitypdf.php
@@ -52,3 +52,39 @@ $addon = static function () {
 };
 
 add_action( 'init', $addon, 20 );
+
+/* The deprecation notices are under test, so only the core-font one stays suppressed for E2E runs */
+remove_filter( 'gfpdf_one_time_action_routes', '__return_empty_array' );
+
+add_filter(
+	'gfpdf_one_time_action_routes',
+	static function ( $routes ) {
+		return array_values(
+			array_filter(
+				$routes,
+				static function ( $route ) {
+					return $route['action'] !== 'install_core_fonts';
+				}
+			)
+		);
+	}
+);
+
+/* Give the deprecation detection a third-party filter listener to find, on a hook of each shape it looks for: one
+   carrying the v3 `gfpdfe_` prefix and one it can only match by name. The callbacks are pass-throughs, so they
+   change nothing for the tests that run alongside them */
+add_action(
+	'init',
+	static function () {
+		if ( ! get_option( 'gfpdf_e2e_deprecated_filter' ) ) {
+			return;
+		}
+
+		$passthrough = static function ( $value ) {
+			return $value;
+		};
+
+		add_filter( 'gfpdf_rtl', $passthrough );
+		add_filter( 'gfpdf_legacy_templates', $passthrough );
+	}
+);

--- a/tools/playwright/config.ts
+++ b/tools/playwright/config.ts
@@ -5,6 +5,11 @@ process.env.WP_ARTIFACTS_PATH = path.join(process.cwd(), 'tmp/artifacts');
 
 import baseConfig = require('@wordpress/scripts/config/playwright.config.js');
 
+// Specs whose fixtures change state the whole site can see. The deprecation notice renders on every admin page
+// the other snapshots are taken on, so `fullyParallel` running these beside them puts a notice in an unrelated
+// baseline. They get a project to themselves, ordered into the chain below so nothing else is in flight.
+const ISOLATED = /core\/system-status\/.*(test|spec)\.(js|ts|mjs)/;
+
 const config = defineConfig({
 	...baseConfig,
 
@@ -69,6 +74,22 @@ const config = defineConfig({
 			dependencies: ['setup-core'],
 			testDir: path.join(process.cwd(), 'tests/playwright'),
 			testMatch: /(core|permalinks)\/.*(test|spec).(js|ts|mjs)/,
+			testIgnore: ISOLATED,
+			use: {
+				...devices['Desktop Chrome'],
+				baseURL: 'http://localhost:8702',
+				storageState: path.join(
+					process.cwd(),
+					'tmp/artifacts/storage-states/e2e.json'
+				),
+			},
+		},
+
+		{
+			name: 'core-isolated',
+			dependencies: ['core'],
+			testDir: path.join(process.cwd(), 'tests/playwright'),
+			testMatch: ISOLATED,
 			use: {
 				...devices['Desktop Chrome'],
 				baseURL: 'http://localhost:8702',
@@ -81,7 +102,7 @@ const config = defineConfig({
 
 		{
 			name: 'setup-core-with-permalinks',
-			dependencies: ['core'],
+			dependencies: ['core-isolated'],
 			testDir: path.join(process.cwd(), 'tools/playwright'),
 			testMatch: /.*global-setup\.ts/,
 			use: {

--- a/tools/playwright/fixtures/test.ts
+++ b/tools/playwright/fixtures/test.ts
@@ -3,6 +3,16 @@ import { test as wpTests } from '@wordpress/e2e-test-utils-playwright';
 import { test as chromeTests } from '@chromatic-com/playwright';
 import * as path from 'node:path';
 
-export const test = mergeTests(wpTests, chromeTests);
+export const test = mergeTests(wpTests, chromeTests).extend({
+	page: async ({ page }, use) => {
+		// Gravatar is unreachable from wp-env, so the admin bar's avatar hangs for the life of the test rather
+		// than resolving either way. That leaves a snapshot's layout to depend on whether the request happened to
+		// come back, which differs between a laptop and CI. Failing them at once is what the suite renders in
+		// practice anyway, only deterministically.
+		await page.route('**://*.gravatar.com/**', (route) => route.abort());
+
+		await use(page);
+	},
+});
 
 export const resourcesPath = path.join(__dirname, '..', 'data');

--- a/tools/playwright/global-setup.ts
+++ b/tools/playwright/global-setup.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'node:child_process';
 import { test as setup } from '@playwright/test';
+import { wpCli } from '@self:playwright/utils/wp-cli';
 
 setup('setup', async ({ request }, testInfo) => {
 	const storageStatePath = testInfo.project.metadata
@@ -22,19 +22,9 @@ setup('setup', async ({ request }, testInfo) => {
 		permalinkStructure === ''
 			? '(rm -f /var/www/html/.htaccess || true)'
 			: 'wp rewrite flush --hard';
-	const cmd = `yarn wp-env:e2e run cli bash -c "wp option update permalink_structure '${permalinkStructure}' && ${flush}"`;
-	try {
-		execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] });
-	} catch (err) {
-		const e = err as {
-			stderr?: Buffer;
-			stdout?: Buffer;
-			status?: number;
-		};
-		throw new Error(
-			`Permalink flip failed (exit ${e.status ?? '?'})\n--- stdout ---\n${e.stdout?.toString() ?? '(empty)'}\n--- stderr ---\n${e.stderr?.toString() ?? '(empty)'}`
-		);
-	}
+	wpCli(
+		`wp option update permalink_structure '${permalinkStructure}' && ${flush}`
+	);
 
 	const { RequestUtils } =
 		await import('@wordpress/e2e-test-utils-playwright');

--- a/tools/playwright/utils/deprecation.ts
+++ b/tools/playwright/utils/deprecation.ts
@@ -1,0 +1,170 @@
+import type { Page } from '@playwright/test';
+import type Pdf from '@self:playwright/utils/gravitypdf';
+import { wpCli } from '@self:playwright/utils/wp-cli';
+
+const FILTER_LISTENER_OPTION = 'gfpdf_e2e_deprecated_filter';
+
+/**
+ * Attach a third-party listener to a deprecated filter, one of the signals the System Report and Site Health
+ * surfaces detect.
+ *
+ * A browser can't hook a filter on its own, so an mu-plugin adds one whenever this option is set. The other
+ * signals are the templates installLegacyTemplates() writes, and a legacy download URL on a form.
+ */
+export function recordDeprecatedUsage() {
+	wpCli(`wp option update ${FILTER_LISTENER_OPTION} 1`);
+}
+
+/**
+ * Stop recording the deprecated usage, so the rest of the suite runs against a site without it
+ */
+export function clearDeprecatedUsage() {
+	wpCli(`wp option delete ${FILTER_LISTENER_OPTION}`);
+}
+
+const LEGACY_TEMPLATE_ID = 'e2e-legacy';
+const LEGACY_TEMPLATE = `${LEGACY_TEMPLATE_ID}.php`;
+const BUSINESS_PLUS_TEMPLATE = 'e2e-business-plus.php';
+
+/**
+ * Install one legacy template of each kind
+ *
+ * A v3 template is one carrying no file headers. What separates the two kinds is whether the file drives the PDF
+ * engine, which only a Business Plus (Tier 2) template does — chr(36) writes the dollar sign, keeping it out of
+ * the shell command where it would expand before WP-CLI saw it.
+ */
+export function installLegacyTemplates() {
+	wpCli(
+		`wp eval 'file_put_contents( GPDFAPI::get_data_class()->template_location . \\"${LEGACY_TEMPLATE}\\", \\"<?php // a plain v3 template\\" ); file_put_contents( GPDFAPI::get_data_class()->template_location . \\"${BUSINESS_PLUS_TEMPLATE}\\", \\"<?php \\" . chr( 36 ) . \\"mpdf->AddPage();\\" );'`
+	);
+}
+
+/**
+ * Remove them again, so the rest of the suite doesn't see them in the template list
+ */
+export function removeLegacyTemplates() {
+	wpCli(
+		`wp eval '@unlink( GPDFAPI::get_data_class()->template_location . \\"${LEGACY_TEMPLATE}\\" ); @unlink( GPDFAPI::get_data_class()->template_location . \\"${BUSINESS_PLUS_TEMPLATE}\\" );'`
+	);
+}
+
+const LEGACY_TEMPLATE_PDF = 'e2elegacypdf';
+
+/**
+ * Configure a PDF on the form that renders through the legacy template
+ *
+ * The reports name a legacy template by the forms it is configured on, which is what the PDF puts on the record.
+ * @param formId
+ */
+export function useLegacyTemplateOnForm(formId: number) {
+	wpCli(
+		`wp eval 'GPDFAPI::add_pdf( ${formId}, [ \\"id\\" => \\"${LEGACY_TEMPLATE_PDF}\\", \\"name\\" => \\"Legacy Template\\", \\"filename\\" => \\"legacy\\", \\"template\\" => \\"${LEGACY_TEMPLATE_ID}\\" ] );'`
+	);
+}
+
+/**
+ * Take it off again, so the form is left as the rest of the suite expects to find it
+ * @param formId
+ */
+export function removeLegacyTemplateFromForm(formId: number) {
+	wpCli(
+		`wp eval 'GPDFAPI::delete_pdf( ${formId}, \\"${LEGACY_TEMPLATE_PDF}\\" );'`
+	);
+}
+
+/**
+ * Roll the recorded plugin version back, so the next admin page load takes a fresh detection
+ *
+ * The admin notices read what the last detection recorded rather than detecting on every page load, and a release
+ * is when that record is taken — `check_install_status()` runs on `wp_loaded`, ahead of the notices themselves. The
+ * version has to differ from PDF_EXTENDED_VERSION for that to fire, so this is well below any release.
+ */
+export function refreshDeprecatedDetection() {
+	wpCli('wp option update gfpdf_current_version 6.0.0');
+}
+
+/**
+ * Empty the record the notices read
+ *
+ * Cleanup can't wait for the next admin page load to re-detect: the notice renders from the stale record on
+ * whichever page loads first, which for a full-page snapshot elsewhere in the suite means an unrelated baseline.
+ */
+export function clearDeprecatedDetection() {
+	wpCli(
+		`wp eval 'GPDFAPI::get_options_class()->update_option( \\"deprecated_features\\", [] );'`
+	);
+}
+
+/**
+ * Set the form's confirmation to one that hands out a legacy `?gf_pdf=1` download URL, or a plain one that doesn't
+ *
+ * The detector searches the stored form for the URL rather than waiting for someone to follow one, so the
+ * confirmation alone is enough to trip it.
+ * @param pdf
+ * @param formId
+ * @param inUse
+ */
+export async function setLegacyDownloadUrl(
+	pdf: Pdf,
+	formId: number,
+	inUse: boolean
+) {
+	const message = inUse
+		? `<a href="/?gf_pdf=1&fid=${formId}&lid=1&template=zadani.php">Download PDF</a>`
+		: 'Thanks for contacting us! We will get in touch with you shortly.';
+
+	await pdf.updateForm(formId, {
+		confirmations: [
+			{
+				id: 'bbb222bbb222b',
+				name: 'Default Confirmation',
+				type: 'message',
+				message,
+			},
+		],
+	});
+}
+
+/**
+ * Swap the detected form ID for a fixed one wherever the page renders it
+ *
+ * The ID belongs to a form the run creates, so it differs between environments and would churn the Chromatic
+ * baseline of every surface that names it. A constant keeps the layout identical too, which masking the region
+ * alone would not — a second digit would still shift the text that follows.
+ * @param page
+ */
+export async function maskFormIds(page: Page) {
+	await page.evaluate(() => {
+		const MASK = '0';
+
+		// The system report links each ID to that form's PDF settings
+		Array.from(
+			document.querySelectorAll<HTMLAnchorElement>(
+				'a[href*="subview=PDF&id="]'
+			)
+		).forEach((link) => {
+			link.textContent = MASK;
+		});
+
+		// Site Health and the Info tab render the same list as plain text
+		const walker = document.createTreeWalker(
+			document.body,
+			NodeFilter.SHOW_TEXT
+		);
+		const nodes: Text[] = [];
+
+		while (walker.nextNode()) {
+			nodes.push(walker.currentNode as Text);
+		}
+
+		nodes.forEach((node) => {
+			if (node.nodeValue) {
+				// Both the legacy download URLs and the legacy templates name the forms they were found on
+				node.nodeValue = node.nodeValue.replace(
+					/(form IDs? )[\d, ]+/g,
+					`$1${MASK}`
+				);
+			}
+		});
+	});
+}

--- a/tools/playwright/utils/gravityforms.ts
+++ b/tools/playwright/utils/gravityforms.ts
@@ -12,7 +12,18 @@ type Entry = {
 	form_id: number;
 	created_by?: number;
 	ip?: string;
+	date_created?: string;
 };
+
+/**
+ * A `date_created` for entries whose creation date ends up in a Chromatic snapshot
+ *
+ * Gravity Forms stamps a new entry with the current UTC time and the entry list renders it to the minute, so a
+ * snapshot of that screen differs on every run no matter how long the test waits. GFAPI takes this verbatim when
+ * it is supplied. Pass it only where the date is on screen: an entry is also what Gravity PDF times anonymous
+ * access from, so backdating one withdraws access a logged out visitor is supposed to still have.
+ */
+export const FIXED_ENTRY_DATE = '2020-01-01 00:00:00';
 
 export default class GravityForms {
 	protected requestUtils: RequestUtils;
@@ -28,6 +39,24 @@ export default class GravityForms {
 	/*
 	 * Form management
 	 */
+	/**
+	 * Merge `patch` into a form over the REST API
+	 *
+	 * The endpoint replaces the whole form, so the current one is read back first. Used for settings the admin UI
+	 * doesn't offer, and for those it does when the point of the test is elsewhere.
+	 */
+	async updateForm(formId: number, patch: object) {
+		const form: object = await this.requestUtils.rest({
+			path: `/gf/v2/forms/${formId}`,
+		});
+
+		return await this.requestUtils.rest({
+			method: 'PUT',
+			path: `/gf/v2/forms/${formId}`,
+			data: { ...form, ...patch },
+		});
+	}
+
 	async createForm(title: string, type: string = 'standard.json') {
 		const formJson: string = await readFile(
 			__dirname + '/../data/forms/' + type,
@@ -157,6 +186,11 @@ export default class GravityForms {
 	) {
 		const container = await this.page.locator(containerSelector);
 
+		// The caller may have only just clicked through to this screen. `switchToCodeEditor()` cannot stand in
+		// for the wait: with nothing rendered yet it finds no editor to switch and returns at once, leaving the
+		// fill below to time out on a textarea that had not arrived.
+		await container.locator('.wp-editor-wrap').waitFor();
+
 		await this.switchToCodeEditor();
 
 		const textbox = container.getByRole('textbox').last();
@@ -173,6 +207,43 @@ export default class GravityForms {
 	}
 
 	async switchToCodeEditor() {
+		// The Code tab hands off to WordPress' `switchEditor()`, which calls `editor.hide()` and copies the
+		// TinyMCE iframe's height onto the textarea it reveals. Both need an initialised editor: clicking early
+		// throws out of `hide()` before the class swap below it, leaving the editor in visual mode with its
+		// textarea still hidden, and the height it copies is whatever the iframe had reached by then — which is
+		// what moves the box between snapshots. The images inside count too, since they are what the editor
+		// sizes itself around.
+		await this.page.waitForFunction(
+			() => {
+				const tinymce = (window as any).tinymce;
+
+				return Array.from(
+					document.querySelectorAll('.wp-editor-wrap.tmce-active')
+				)
+					.filter((wrap) => (wrap as HTMLElement).offsetParent)
+					.every((wrap) => {
+						const editor = tinymce?.get?.(
+							wrap.id.replace(/^wp-/, '').replace(/-wrap$/, '')
+						);
+
+						if (!editor?.initialized) {
+							return false;
+						}
+
+						const doc = editor.getDoc?.();
+
+						return (
+							!doc ||
+							Array.from(doc.images).every(
+								(image: any) => image.complete
+							)
+						);
+					});
+			},
+			undefined,
+			{ timeout: 15000 }
+		);
+
 		for (const button of await this.page
 			.locator('.wp-editor-tabs')
 			.getByRole('button', { name: /^Code$/ })

--- a/tools/playwright/utils/snapshot.ts
+++ b/tools/playwright/utils/snapshot.ts
@@ -1,0 +1,140 @@
+import type { Locator, Page, TestInfo } from '@playwright/test';
+import { takeSnapshot } from '@chromatic-com/playwright';
+
+// Long enough for an upload to lay out in the editor, short enough that a page which never holds still (a
+// spinner, a marquee) costs one wait rather than stalling the suite.
+const STABLE_LAYOUT_BUDGET_MS = 5000;
+
+/**
+ * Reduce the page to `targets` and their ancestors, so a Chromatic snapshot captures the container alone.
+ *
+ * Chromatic archives the whole document and offers no element-level crop, so the surrounding admin chrome has to be
+ * hidden before the snapshot is taken. Pass every element the snapshot should keep — an accordion heading and its
+ * panel are siblings, so hiding one to isolate the other would drop it.
+ */
+export async function isolateForSnapshot(page: Page, targets: Locator[]) {
+	for (const target of targets) {
+		await target.evaluate((el) => {
+			el.setAttribute('data-snapshot', 'keep');
+
+			for (let node = el.parentElement; node; node = node.parentElement) {
+				node.setAttribute('data-snapshot', 'ancestor');
+			}
+		});
+	}
+
+	await page.evaluate(() => {
+		Array.from(document.querySelectorAll<HTMLElement>('body *')).forEach(
+			(el) => {
+				if (
+					el.dataset.snapshot === undefined &&
+					!el.closest('[data-snapshot="keep"]')
+				) {
+					el.style.display = 'none';
+				}
+			}
+		);
+
+		// Hiding a grid or flex item reflows what is left onto the track its sibling occupied, which sizes the
+		// container to the chrome we just removed. Ancestors lay nothing else out now, so make them plain blocks.
+		Array.from(
+			document.querySelectorAll<HTMLElement>('[data-snapshot="ancestor"]')
+		).forEach((el) => {
+			if (/grid|flex/.test(getComputedStyle(el).display)) {
+				el.style.display = 'block';
+			}
+		});
+
+		// The admin layout reserves space for the chrome we just hid, which would pad the snapshot out again
+		const reset = document.createElement('style');
+		reset.textContent =
+			'html.wp-toolbar{padding-top:0}#wpcontent,#wpfooter{margin-left:0}#wpbody-content{padding-bottom:0}';
+		document.head.append(reset);
+	});
+}
+
+/**
+ * Hold until the page stops moving, then hand it to Chromatic.
+ *
+ * Chromatic archives the DOM at the moment it is called and re-renders that, so whatever is mid-flight is what
+ * gets baselined. Three things on these screens land after the interaction that triggered them: WordPress
+ * relocates admin notices to sit after `.wp-header-end` on jQuery ready (`common.js`), TinyMCE's `wpautoresize`
+ * recomputes the editor height from its own document once the content inside it lays out, and web fonts restyle
+ * every text metric on the page. Waiting on any one of them by name would leave the next one to be found in a
+ * baseline, so this waits on the geometry itself settling.
+ *
+ * The predicate polls on a timer and stays synchronous. `requestAnimationFrame` does not fire in a headless page
+ * the compositor considers hidden, which is every page here once the worker moves on, and awaiting one inside the
+ * page hangs until the test times out.
+ */
+export async function snapshot(page: Page, testinfo: TestInfo) {
+	await page
+		.waitForFunction(
+			() => {
+				const state = ((window as any).gfpdfSettle ??= {
+					hash: NaN,
+					held: 0,
+				});
+
+				// The editor content lives in an iframe, and it is the one whose height is in question
+				const documents = [
+					document,
+					...Array.from(document.querySelectorAll('iframe')).map(
+						(frame) => {
+							try {
+								return frame.contentDocument;
+							} catch {
+								return null;
+							}
+						}
+					),
+				].filter((doc): doc is Document => !!doc?.body);
+
+				// Only this site's own images: an external one the container cannot reach never completes, and
+				// waiting on it would burn the budget on every page the admin bar renders an avatar into.
+				const settling = documents.some(
+					(doc) =>
+						(doc.fonts && doc.fonts.status !== 'loaded') ||
+						Array.from(doc.images).some(
+							(image) =>
+								!image.complete &&
+								image.src.startsWith(location.origin)
+						)
+				);
+
+				if (settling) {
+					return false;
+				}
+
+				let hash = 0;
+
+				for (const doc of documents) {
+					for (const el of Array.from(
+						doc.body.querySelectorAll('*')
+					)) {
+						const box = el.getBoundingClientRect();
+
+						hash =
+							(hash * 31 +
+								box.x +
+								box.y * 7 +
+								box.width * 13 +
+								box.height * 17) %
+							2147483647;
+					}
+				}
+
+				// Two polls that measure the same geometry is as settled as this gets
+				state.held = hash === state.hash ? state.held + 1 : 0;
+				state.hash = hash;
+
+				return state.held >= 2;
+			},
+			undefined,
+			{ polling: 100, timeout: STABLE_LAYOUT_BUDGET_MS }
+		)
+		// A page that never holds still is a diff to look at, not a test failure
+		.catch(() => {});
+
+	await takeSnapshot(page, testinfo);
+}

--- a/tools/playwright/utils/wp-cli.ts
+++ b/tools/playwright/utils/wp-cli.ts
@@ -1,0 +1,24 @@
+import { execSync } from 'node:child_process';
+
+// Bounded: an unbounded execSync against a wedged Docker hangs the worker until the 6h job cap.
+const CLI_TIMEOUT = 120_000;
+
+/**
+ * Run one or more WP-CLI commands in the e2e wp-env container
+ *
+ * Batch with `&&` rather than calling this twice, so a docker-exec round trip is paid once.
+ */
+export function wpCli(command: string) {
+	try {
+		execSync(`yarn wp-env:e2e run cli bash -c "${command}"`, {
+			stdio: ['ignore', 'pipe', 'pipe'],
+			timeout: CLI_TIMEOUT,
+		});
+	} catch (err) {
+		const e = err as { stderr?: Buffer; stdout?: Buffer; status?: number };
+
+		throw new Error(
+			`WP-CLI command failed (exit ${e.status ?? '?'}): ${command}\n--- stdout ---\n${e.stdout?.toString() ?? '(empty)'}\n--- stderr ---\n${e.stderr?.toString() ?? '(empty)'}`
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Gravity PDF 7.0 removes the v3 backwards compatibility layer, and today there is no way to tell which sites still depend on it. Legacy templates already render blank on Gravity Forms 3.0 and nothing says so: no fatal error, no warning, nothing in the debug log. The `gfpdfe_*` filters fire silently, so we don't know whether anyone still listens to them. The deprecated methods call `_doing_it_wrong()`, which never reaches WordPress' deprecation logging, and around twenty of them are empty stubs that emit nothing at all.

This PR detects the four kinds of leftover v3 usage a site can have and reports them in the Gravity Forms System Report, both WordPress Site Health surfaces, and a dismissible admin notice. It also swaps the deprecated methods and filters onto the real WordPress deprecation functions so they reach the deprecation log and Query Monitor, and restores the `RGForms` class that Gravity Forms 3.0 removed, which stops legacy templates rendering blank in the meantime.

Detection is a registry rather than a fixed list. `Deprecation` knows how to detect, group, record and warn about whatever its providers declare, and names neither the v3 layer nor the release removing it, so the next round of removals registers a provider class instead of being wired through the engine, model, view and controller. Everything detected here is grouped as deprecated: it all still works, and 7.0 is what removes it.

The work is admin-only apart from one write. The legacy download endpoint records the form it served, because a `?gf_pdf=1` link sitting in an email sent years ago is exactly the case scanning the forms table cannot find.

## Try it

```bash
yarn wp-env start

# Install a plain v3 template and a Business Plus one (the difference is the engine call)
yarn wp-env run cli wp eval 'file_put_contents( GPDFAPI::get_data_class()->template_location . "my-legacy.php", "<?php // a v3 template" );'
yarn wp-env run cli wp eval 'file_put_contents( GPDFAPI::get_data_class()->template_location . "my-business-plus.php", "<?php \$mpdf->AddPage();" );'

# Roll the recorded version back so the admin notices take a fresh detection
yarn wp-env run cli wp option update gfpdf_current_version 6.16.0
```

Then look at `Forms -> System Status`, `Tools -> Site Health` (both the Status and Info tabs), and any Gravity PDF admin screen for the notices. Delete the two files again and the rows clear on the next page load.

## Test plan

- [ ] `Forms -> System Status` shows a **Deprecated** section listing *Legacy Templates* and *Business Plus Templates* by file name, each linking to its upgrade guide
- [ ] `Tools -> Site Health` raises a recommendation, and the Info tab carries a matching section for a support ticket
- [ ] One notice lists every detected feature, and dismissing it clears all of them; a feature detected afterwards raises it again
- [ ] Deleting the template files clears every surface without needing a version bump
- [ ] A PDF using a v3 template renders with content on Gravity Forms 3.0 (blank on `development`)
- [ ] A `?gf_pdf=1` download still works, and adds its form to the report
- [ ] `yarn test:php`, `yarn test:php:multisite` and `yarn test:e2e` pass

<details>
<summary>More info</summary>

### Detection

`GFPDF\Statics\Deprecation` is a registry rather than a fixed list. It knows how to detect, group and warn about whatever its providers declare, and nothing in it names the v3 layer or the release removing it. `GFPDF\Statics\Deprecation_V3` is the one provider today, declaring four features and the version each goes in — so a later round of removals (a feature going in 7.1, say) registers itself instead of being wired through the engine, the model and the controller. The contract is `Helper_Interface_Deprecated_Features`.

Every feature is either **unsupported** (already stopped working) or **deprecated** (still works, scheduled to go). Every v3 feature is deprecated: 7.0 is what removes the layer, so nothing detected here has stopped working yet. `Deprecation::get_groups()` drops a group nothing declares, so no surface carries an empty section around and the vocabulary is in place for a later round without a section reading *None detected* until one arrives. The engine owns the group list and its order; the view names them, once, for all three surfaces. `Deprecation::refresh_signals()` pairs detection with recording, so both Site Health surfaces call the engine directly rather than reaching through the system report's model for a detection that has nothing to do with the report.

| Feature | Group | How |
|---|---|---|
| **Legacy Templates** | Deprecated | Any template `Helper_Templates` classifies in the `Legacy` group, which is one carrying no file headers (core templates declare `Group: Core`, so they're never flagged). |
| **Business Plus Templates** | Deprecated | The same set as above, split on whether the file calls `$mpdf->`. Driving the PDF engine is the one thing the Tier 2 add-on gave a template and a plain v3 template never had, so the call is what tells them apart. Reported under their own label, linking to the part of the guide that covers them — a plain v3 template is rebuilt from the existing developer docs, while one of these is a Bespoke build being ported to the Developer Toolkit. |

Both template rows read the template files and nothing else. An earlier revision also walked `gf_form_meta` for PDFs set to `advanced_template => Yes` and reported whatever template they pointed at, which meant toggling that setting on a Core template listed *zadani.php* in the report. A template is now reported for what it is rather than for how one PDF happens to be configured, and the detection loses a DB query. `is_advanced_template_pdf()` stays — the render path still branches on the setting.
| **Legacy Download URLs** | Deprecated | Two sources, unioned in one query. A `LIKE` for `gf_pdf=1` across the three columns Gravity Forms splits a form over finds a form *handing the URL out* — these are hand-written into a confirmation, notification or field, so the scan finds one nobody has followed yet. The endpoint itself records the form it served, which finds a URL living somewhere the scan can't see: a page, or an email that has already gone out. Matching `gf_pdf=1` rather than `gf_pdf=` keeps the scan to the value that actually routes to the legacy endpoint. |
| **Actions and Filters** | Deprecated | Walks `$wp_filter` for third-party listeners on the `gfpdfe_*` hooks, the v3-shaped `gfpdf_*` aliases (`gfpdf_orientation`, `gfpdf_privilages`, …) and the three `gfpdf_legacy_*` hooks. Walking rather than checking a fixed list picks up dynamic hooks like `gfpdfe_pdf_template_{form_id}`. Core's own `PDFRender::prepare_ids` registration is excluded via a shared constant. |

Trashed forms are skipped throughout — they aren't in the user's form list, so there's nothing to act on.

### Surfacing

**System Report** gains a **Deprecated** section at the head of the Gravity PDF Environment block. Rows follow the report's own condensed convention: the detections on one line, then the cross and a red message, which Gravity Forms renders itself from the `is_valid` and `validation_message` keys rather than us building the markup. Legacy templates are listed by file name alone, since the report already states the PDF working directory, and each form that served a legacy URL links to its own PDF settings, which is where those URLs get replaced. Sections with no items are dropped, which is how these stay hidden on a clean site.

Sections and their rows are matched by name rather than by position. Two sections at the head would otherwise have renumbered the four below them, and every section added after would do it again — which also moves the ground under `gfpdf_system_status_report_items`, a public filter keyed by that same index. The two group sections are built from `View_System_Report::get_deprecated_groups()`, so a group is named once for all three surfaces instead of again in the model.

Legacy templates moved here out of **Outdated Templates**, where the first pass of this branch put them — the two conditions have entirely different remedies and reading as one run-on warning wasn't helping anyone.

**Site Health** gains a test reporting the same detections, grouped, with a link to the system report. This is the surface that can't be permanently dismissed: it clears itself once the site stops using the deprecated functionality, returns if it starts again, and carries onto the Dashboard through the Site Health Status widget. The Info tab gains a matching section per group, so the detections travel in the debug export users paste into a support ticket — always present, reporting "None detected" on a clean site rather than leaving the reader to guess whether the check ran. Both are gated on `gravityforms_view_settings`, so form titles, PDF names and template paths aren't exposed to administrators without Gravity Forms access.

Site Health has room the one-line report row doesn't, so it names a template's full path where the report abbreviates to the file name.

**One admin notice** listing every detected feature, raised through the existing one-time action routes. One rather than one per feature: four warnings stacked on the same screen is noise a reader learns to scroll past, and they all say the same thing — go and look at the system report.

Dismissing it records each feature it was listing, rather than the notice itself, so silencing today's list says nothing about the next round of removals: a feature detected later was never on it and raises the notice again on its own. That needed a `dismiss` key on the route, which `route()` now honours the way it already honours `process`; a route supplying one owns suppressing itself through `condition`, since `route_notices()` still reads the action's own dismissal. Each line uses `Deprecation::get_feature_notice()`, the same sentence the report uses, which derives from the registration's group, label and version rather than living in either view. A registration can also declare a `notice` of its own, which is what the hooks feature needs: its label is a category, so "Support for Actions and Filters will be removed" reads as the whole hook API once it is out of the report row that lists the hook names underneath it. It says "Code on this site uses Gravity PDF hooks that are removed in version 7.0." instead, on every surface. That also moved the report's two per-feature copy overrides into the registrations, so the notice and the report can no longer drift. Functionality that has already gone reads as an error, the rest as a warning, and the button leads to the system report where the detections are listed. It reaches Network Admin as well — `Helper_Notices` already switches to `network_admin_notices`, and the network dashboard and plugins screens both match the pages a notice may appear on. What it reports there is the main site, which is the scope `gfpdf_settings` and the detection record live at; a subsite raises its own notice in its own admin. Aggregating a whole network is deliberately out of scope for 6.17.

The notices don't detect anything themselves — they read what the last detection recorded. Detection walks the form table and the template directory, which is far too much to repeat on every admin page a notice can appear on. `Controller_Upgrade_Routines` takes that record at install and, ungated, on every version change — a release being both when a new round of removals arrives and the only moment the notices need to learn of one. The report and Site Health screens refresh it as they go, since they detect live regardless, so a site that fixes everything stops being told about it without waiting for the next release. The record and the dismissals beside it live in `gfpdf_settings`, which the uninstaller already drops whole.

**The legacy endpoint records the form it served**, in a `gfpdf_legacy_endpoint_usage` option of its own. It is written after the request resolves to a real PDF, never before — `$_GET['fid']` is anonymous input, and recording it unvalidated would let any visitor write arbitrary IDs into the option. It is written before the PDF is served, though, so a request the middleware turns away still counts as one made: the signal is that the URL is out there being used. Each form is stored against the time it was last served and expires 30 days later: Gravity PDF can't tell whether a URL it served last year still exists, and without an expiry a form whose links were fixed months ago would be reported forever. The stamp is refreshed at most once a day, so a link still in use never reaches the expiry while one nobody follows drops off on its own, and the front end writes about as often as it did when only the first request counted. Expired entries are pruned by the read, on the admin screens that check them. A write also adds the feature to the notices' record, which is otherwise only taken at install and on each version change — a URL followed since then would go unmentioned until the next release. The option is deliberately not in `gfpdf_settings` and not autoloaded: it is written from the front end and read only by the report, Site Health and the uninstaller. `Model_Uninstall` doesn't name the option: `Helper_Interface_Deprecated_Features::get_stored_options()` declares what a provider stores and `Deprecation::delete_stored_data()` fans the delete out across the registry, so a later round of removals brings its own storage with it rather than needing a line added to the uninstaller.

**A shim for the class Gravity Forms 3.0 removed.** `RGForms` was an empty subclass of `GFForms`, deprecated in GF 2.10.5 (`@remove-in 3.0`) and removed in 3.0. Every v3 template Gravity PDF ever shipped opens with `if ( ! class_exists( 'RGForms' ) ) { return; }`, so on GF 3.0 those PDFs render with no content at all — no fatal, nothing in the log, a ~1.1KB blank page and no way for the site owner to find out why. Verified against GF 3.0.2. `Deprecation_V3::restore_v3_form_class()` aliases `GFForms` back to the old name when a legacy template is about to render, called from `Helper_PDF::set_template()` and from `Model_PDF::handle_legacy_tier_2_processing()`, which runs the template file itself and never reaches `set_template()`. Detection is unchanged, but the group isn't: a legacy template renders correctly again, so it is reported as **Deprecated** — it works today and goes in 7.0, which is what that group means. Worth a reviewer's eye — it re-declares a name Gravity Forms deliberately dropped, guarded on `class_exists()` both ways, and scoped to the legacy render path rather than declared globally.

**Log warnings** on Advanced Templating processing and any `gfpdfe_*` filter that has a listener, so support can identify an affected site from a submitted log file without a back-and-forth. The filter warning is written once per hook per request — otherwise `gfpdfe_pdf_template` would write a line for every PDF field. Rendering a legacy template writes nothing: all three report surfaces already name the file, so a line per PDF told a reader nothing they couldn't see there, and `View_PDF::autoprocess_core_template_options()` stays the styling decision it was.

### Real deprecation notices

- `_doing_it_wrong()` → `_deprecated_function()` / `_deprecated_argument()` across the legacy-endpoint, v3-template and stale-stub surface. These now fire `deprecated_function_run` and land in WordPress' deprecation log and Query Monitor. The bespoke prose messages collapse into the `$replacement` argument.
- The ~20 silent stubs (`Model_Settings` font methods, `Model_Install` uninstall proxies, `Helper_Notices`, the `pdf.php` canonical-release notices) now emit a notice instead of returning quietly. None of them are hooked, so nothing fires on a normal request.
- The v3 shim classes in `src/deprecated.php` warn from their implemented methods, not just the `__call` fallback — `PDF_Common::get_ids()` and friends previously warned about nothing, and the `mPDF` shim constructor means a v3 template calling `new mPDF()` is no longer silent. `GFPDF_Core::setup_constants()` and `PDFRender::prepare_ids()` are deliberately excluded: core calls those itself.
- The `gfpdfe_*` filters route through `Deprecation::apply_filters()`, a thin wrapper over `apply_filters_deprecated()` that takes the replacement and the removal version from whichever registered feature owns the hook. It early-returns when nothing is listening, so the PDF render path (~16 call sites) pays nothing on sites that have already moved on.

### Helper_Notices fixes

Two fixes came out of building the notice, both on the pre-existing `view_class` route key that any add-on can already use:

- A caller-supplied `notice-*` class now replaces the default `updated` state rather than joining it — `div.updated` out-specifies `.notice-warning`, so an appended warning still rendered green.
- Queued notices are stored as message/class pairs rather than keyed by their class, which silently dropped a second notice sharing the same one.

`Controller_Actions::route_notices()` also returns early on the admin pages where `Helper_Notices` discards the notice anyway, so route conditions no longer run on every admin request.

### Notes

- **`gfpdfe_signature_width` already has a v4 replacement** — `gfpdf_signature_width` is fired immediately after it in `Field_Signature.php`. The plan lists creating one as an open question; it isn't needed.
- A dismissal is permanent *for that feature*. Fix your legacy templates, dismiss the notice, install another one next year and it won't return — Site Health will, and can't be dismissed at all, which is what makes the per-feature dismissal defensible.

### Testing

- `Test_Deprecation` covers the engine, including a fake provider declaring a feature removed in 7.1 — which is the whole of what registering a later round of removals amounts to. `Test_Deprecation_V3` covers the v3 detectors, with forms from a new `CreatesLegacyDownloadUrls` concern shared with the system report tests — including the endpoint recorder: the union of both sources, write-once, the option staying out of `wp_load_alloptions()`, a trashed recorded form dropping out, and `gf_pdf=0` no longer reading as a legacy URL. `Test_Controller_PDF` covers a request to the endpoint recording the form it served.
- `Test_Controller_System_Report` covers each signal, the *Enable Advanced Templating* setting reporting nothing on its own, a Business Plus template taking a row of its own, every surface naming a template by file rather than by path, and the registration, capability gate and reported detections of both Site Health surfaces. It looks report sections up by the ID they declare rather than by position, so adding or dropping one doesn't move every assertion below it.
- `Test_Controller_Actions` covers the one route the features share, its severity, and the full dismissal cycle through rendered HTML: both features named in the notice, gone after dismissing, then a feature detected afterwards bringing the notice back naming only itself. It also pins that the notice reaches Network Admin. `Test_Controller_Upgrade_Routines` covers the record being taken at install and on a version change, and cleared on the next release once the site is fixed. `Test_Uninstaller` pins that the record and the dismissals go with `gfpdf_settings`, and that the endpoint's own option is deleted beside it. `Test_Deprecation` pins the fan-out itself, through a fake provider with storage of its own.
- `setExpectedIncorrectUsage()` → `setExpectedDeprecated()` wherever the primitive changed; tests that reach a deprecated path incidentally now declare it.
- New Playwright coverage with Chromatic snapshots of four new screens: the system report sections, the Site Health test expanded, the Site Health Info tab panels, and one of the admin notices. Chromatic archives the whole document and has no element-level crop, so `isolateForSnapshot()` hides everything but the target and its ancestors first. The detected form ID is swapped for a constant before each snapshot, since it differs between environments.
- Every Chromatic snapshot in the suite now goes through one `snapshot()` helper that holds until the page stops moving — fonts loaded, local images complete, geometry unchanged across two polls — because the archive is taken at the call and whatever is mid-flight is what gets baselined. This is why the existing snapshot specs are touched. It fixes three sources of baseline churn that predate this branch: WordPress relocating admin notices after `.wp-header-end` on jQuery ready, and the entry list rendering `date_created` to the minute (the two specs that snapshot that screen pass a fixed date, which GFAPI takes verbatim; it is opt-in rather than the factory default, since an entry's creation time is also what times a logged out visitor's PDF access). The admin bar's Gravatar is aborted in the fixture: wp-env cannot reach that origin, so whether the avatar resolved was down to network luck.
- `switchToCodeEditor()` waits for TinyMCE to finish initialising before clicking the tab. WordPress' `switchEditor()` calls `editor.hide()` and copies the TinyMCE iframe's height onto the textarea it reveals; instrumenting the click found the editor uninitialised on four runs in five, where `hide()` throws above the line that swaps `tmce-active` for `html-active` — leaving the editor in visual mode with its textarea hidden, which is the intermittent `Notifications` failure. The same moment fixes the textarea's height, so this also settles the rich text boxes that moved between snapshots; a height baked in at the switch cannot be settled afterwards.
- Integration suite: 1616 tests, 0 failures, 46 skipped. Multisite: 1616 tests, 0 failures. The deprecation spec now runs in a Playwright project of its own, `core-isolated`, chained between `core` and the permalink pass: its fixtures install site-wide signals, and the notice they raise renders on every admin page the suite's other full-page snapshots are taken on, so `fullyParallel` running it beside them put the notice into an unrelated Chromatic baseline. That spec has not been re-run since it moved projects, so CI is the first pass on it there. The E2E spec installs one template of each kind for the run — a headerless file, and one calling `$mpdf->` — so both template rows appear in the snapshot rather than being covered only by PHPUnit. `composer run phpcs:lint .`, `composer run phpcs:compatibility .`, `yarn lint:js` and `yarn lint:css` all clean.

### Follow-ups (not in this PR)

- Publish the upgrade guides before release: `/upgrade/legacy-templates/`, `/upgrade/legacy-download-urls/` and `/upgrade/deprecated-filters/`. All are linked from the report, Site Health and the notices, and none exist yet. The Advanced Templating row links into the legacy templates guide, since a PDF using the add-on is always a legacy template as well. Drafted in [gravity-pdf-documentation#204](https://github.com/GravityPDF/gravity-pdf-documentation/pull/204).
- Tier 2 add-on customers need a commercial conversation, not just a notice — flag to support before 7.0 ships.
- Changelog entry — there's no 6.17.0 section yet, and this repo writes those at release time.

</details>








