### PR TITLE
fix: fatal error during update check when plugin requirements aren't met

### DIFF
--- a/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
+++ b/src/Helper/Licensing/EDD_SL_Plugin_Updater.php
@@ -505,7 +505,7 @@ class EDD_SL_Plugin_Updater {
 		}
 
 		/* The primary site checks for updates on behalf of network-activated installs */
-		if ( \GPDFAPI::get_misc_class()->is_secondary_network_site( $this->name ) ) {
+		if ( $this->is_secondary_network_site() ) {
 			return false;
 		}
 
@@ -1000,5 +1000,25 @@ class EDD_SL_Plugin_Updater {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Whether the current site is a secondary site on a Multisite network where the plugin is network activated
+	 *
+	 * Mirrors Helper_Misc::is_secondary_network_site(), which cannot be used here: the updater runs even when the
+	 * plugin's minimum requirements aren't met, and GPDFAPI is only available once the plugin has fully loaded.
+	 *
+	 * @return bool
+	 *
+	 * @since 6.16.1
+	 */
+	protected function is_secondary_network_site() {
+		if ( ! is_multisite() || is_main_site() ) {
+			return false;
+		}
+
+		$network_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+
+		return isset( $network_plugins[ $this->name ] );
 	}
 }

--- a/tests/phpunit/integration/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
+++ b/tests/phpunit/integration/Helper/Licensing/Test_EDD_SL_Plugin_Updater.php
@@ -962,6 +962,15 @@ class Test_EDD_SL_Plugin_Updater extends TestCase {
 		$this->assertStringNotContainsString( 'is_plugin_active(', $source );
 	}
 
+	/*
+	 * The updater loads even when the plugin's minimum requirements aren't met, so update checks keep working; GPDFAPI
+	 * only exists once the plugin has fully loaded. The PHPUnit bootstrap always loads it, so scan the source instead.
+	 */
+	public function test_updater_does_not_depend_on_gpdfapi() {
+		$source = php_strip_whitespace( ( new \ReflectionClass( EDD_SL_Plugin_Updater::class ) )->getFileName() );
+		$this->assertStringNotContainsString( 'GPDFAPI', $source );
+	}
+
 	public function test_set_version_info_cache_promotes_active_licensed_package_to_network() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Multisite tests only' );

--- a/tools/phpcs/GravityPDF/Sniffs/EarlyLoad/GPDFAPIUsageSniff.php
+++ b/tools/phpcs/GravityPDF/Sniffs/EarlyLoad/GPDFAPIUsageSniff.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+namespace GravityPDF\Sniffs\EarlyLoad;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Forbid unguarded use of GPDFAPI in the files pdf.php loads before it checks the plugin's minimum requirements.
+ *
+ * Those files (the plugin updater, the activation hooks) run so update and license checks keep working on a site that
+ * cannot run the plugin itself. GPDFAPI is only declared by src/bootstrap.php, which is reached only when every
+ * requirement passes, so calling it from there fatals for the users who need the updater most.
+ *
+ * @see https://github.com/GravityPDF/gravity-pdf/issues/1703
+ *
+ * @since 6.16.1
+ */
+class GPDFAPIUsageSniff implements Sniff {
+
+	/**
+	 * The class that isn't loaded yet
+	 */
+	private const API_CLASS = 'GPDFAPI';
+
+	/**
+	 * The tokens that open a new variable scope, and so a new place a guard has to be repeated
+	 */
+	private const FUNCTION_TOKENS = [ T_FUNCTION, T_CLOSURE, T_FN ];
+
+	/**
+	 * @return array
+	 */
+	public function register() {
+		return [ T_STRING ];
+	}
+
+	/**
+	 * @param File $phpcsFile
+	 * @param int  $stackPtr
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		if ( $tokens[ $stackPtr ]['content'] !== self::API_CLASS ) {
+			return;
+		}
+
+		if ( $this->has_class_exists_guard( $phpcsFile, $stackPtr ) ) {
+			return;
+		}
+
+		$phpcsFile->addError(
+			'%1$s is not declared until Gravity PDF has fully loaded, which never happens when the plugin\'s minimum requirements are not met. Guard the call with class_exists( \'%1$s\' ), or do without it so updates keep working.',
+			$stackPtr,
+			'Unguarded',
+			[ self::API_CLASS ]
+		);
+	}
+
+	/**
+	 * Whether a class_exists( 'GPDFAPI' ) check precedes $stackPtr in the same function
+	 *
+	 * @param File $phpcsFile
+	 * @param int  $stackPtr
+	 *
+	 * @return bool
+	 */
+	private function has_class_exists_guard( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		/* A guard in another function says nothing about this one, so only search the enclosing scope */
+		$start = 0;
+		foreach ( array_reverse( $tokens[ $stackPtr ]['conditions'], true ) as $scopePtr => $code ) {
+			if ( in_array( $code, self::FUNCTION_TOKENS, true ) && isset( $tokens[ $scopePtr ]['scope_opener'] ) ) {
+				$start = $tokens[ $scopePtr ]['scope_opener'];
+				break;
+			}
+		}
+
+		for ( $i = $start; $i < $stackPtr; $i++ ) {
+			if ( $tokens[ $i ]['code'] !== T_STRING || $tokens[ $i ]['content'] !== 'class_exists' ) {
+				continue;
+			}
+
+			$opener = $phpcsFile->findNext( T_WHITESPACE, $i + 1, null, true );
+			if ( $opener === false || $tokens[ $opener ]['code'] !== T_OPEN_PARENTHESIS ) {
+				continue;
+			}
+
+			$argument = $phpcsFile->findNext( T_WHITESPACE, $opener + 1, $tokens[ $opener ]['parenthesis_closer'], true );
+			if ( $argument !== false && trim( $tokens[ $argument ]['content'], '\'"\\' ) === self::API_CLASS ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/tools/phpcs/config.xml
+++ b/tools/phpcs/config.xml
@@ -59,6 +59,14 @@
 
     <rule ref="Generic.Files.ByteOrderMark"/>
 
+    <!-- pdf.php loads these before it checks the plugin's minimum requirements, so GPDFAPI may not exist yet -->
+    <rule ref="./GravityPDF/Sniffs/EarlyLoad/GPDFAPIUsageSniff.php">
+        <include-pattern>/pdf\.php</include-pattern>
+        <include-pattern>/gravity-pdf-updater\.php</include-pattern>
+        <include-pattern>/src/Helper/Licensing/*</include-pattern>
+        <include-pattern>/src/Controller/Controller_Activation\.php</include-pattern>
+    </rule>
+
     <!-- Customise the WordPress Core Rules -->
     <rule ref="WordPress.Files.FileName">
         <properties>


### PR DESCRIPTION
Fixes #1703

## The problem

`EDD_SL_Plugin_Updater::get_version_info()` called `\GPDFAPI::get_misc_class()->is_secondary_network_site()`, added in 6.16.0. The updater is loaded from `pdf.php` **before** the minimum requirement checks run — deliberately, so update and license checks keep working on a site missing Gravity Forms (or any other requirement). `GPDFAPI` is only defined once `src/bootstrap.php` has run, which happens only when every requirement passes.

The result on those sites is a fatal on the `pre_set_site_transient_update_plugins` filter, which fires on every `admin_init` — locking the user out of wp-admin entirely:

```
Fatal error: Uncaught Error: Class "GPDFAPI" not found in
.../src/Helper/Licensing/EDD_SL_Plugin_Updater.php:508
```

## The fix

Move the check onto the updater itself. It's four plain WordPress calls (`is_multisite()`, `is_main_site()`, `get_site_option( 'active_sitewide_plugins' )`) with no container dependency, so Multisite behaviour is unchanged and the vendored EDD class keeps zero coupling to the rest of the plugin.

`Helper_Misc::is_secondary_network_site()` is left as-is — having a general helper delegate into the licensing class would invert the layering.

## Stopping it happening again

Nothing prevented the same mistake in the other files that load before the requirement checks, so this adds a `GravityPDF.EarlyLoad.GPDFAPIUsage` sniff (`tools/phpcs/GravityPDF/Sniffs/EarlyLoad/`), scoped in `tools/phpcs/config.xml` to `pdf.php`, `gravity-pdf-updater.php`, `src/Helper/Licensing/*` and `Controller_Activation.php`.

It's guard-aware, so the `class_exists( 'GPDFAPI' )` checks `gravity-pdf-updater.php` and `Controller_Activation.php` already have pass unchanged. The guard has to be repeated per function — one in a sibling closure says nothing about this one.

Verified both ways:

- Restoring the pre-fix line reports the crash line from the issue verbatim: `508 | ERROR | GPDFAPI is not declared until Gravity PDF has fully loaded… (GravityPDF.EarlyLoad.GPDFAPIUsage.Unguarded)`
- An unguarded call added to a sibling closure in `gravity-pdf-updater.php` is caught, while the guarded ones next to it are not.
- Unguarded use outside the scoped files (e.g. `Helper_Abstract_Addon.php`) is correctly ignored.

`tools/` is stripped by `tools/release/build.sh`, so nothing new ships in the plugin zip.

The PHPUnit test is kept alongside it and asserts something stricter for the one file that matters most: `EDD_SL_Plugin_Updater` must not mention `GPDFAPI` **at all**, guarded or not.

## Testing

- `Test_EDD_SL_Plugin_Updater`: 47 passing on single site and multisite. The multisite run exercises `test_get_version_info_skipped_on_secondary_network_site`, confirming secondary sites still skip the API call.
- Full integration suite: 1570 tests, no failures attributable to this change.
- `composer phpcs:lint .`: 366 files, clean — including all four scoped files.
- `composer phpcs:compatibility .`: clean (7.4+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)