### PR TITLE
ci: resolve the wp-env core pin through a shared script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -278,10 +278,11 @@ jobs:
 
       # Pre-fetch the pinned WordPress core so wp-env's start has nothing to download. Its in-start core
       # fetch silently aborts provisioning on the CI runners (only the DB container comes up); pointing
-      # WP_ENV_CORE at a local directory sidesteps that. URL is read from the config to stay single-source.
+      # WP_ENV_CORE at a local directory sidesteps that. URL is derived from the config's pin to stay single-source.
       - name: Pre-download WordPress core
         run: |
-          curl -fsSL "$(jq -r '.core' tools/wp-env/integration.json)" -o "$RUNNER_TEMP/wp-core.zip"
+          url=$(node tools/wp-env/wp-version.mjs download-url tools/wp-env/integration.json)
+          curl -fsSL "$url" -o "$RUNNER_TEMP/wp-core.zip"
           unzip -q "$RUNNER_TEMP/wp-core.zip" -d "$RUNNER_TEMP/wp-core"
           echo "WP_ENV_CORE=$RUNNER_TEMP/wp-core/wordpress" >> "$GITHUB_ENV"
 
@@ -457,7 +458,8 @@ jobs:
       # See the integration job: pre-fetch core so wp-env's start has nothing to download.
       - name: Pre-download WordPress core
         run: |
-          curl -fsSL "$(jq -r '.core' tools/wp-env/e2e.json)" -o "$RUNNER_TEMP/wp-core.zip"
+          url=$(node tools/wp-env/wp-version.mjs download-url tools/wp-env/e2e.json)
+          curl -fsSL "$url" -o "$RUNNER_TEMP/wp-core.zip"
           unzip -q "$RUNNER_TEMP/wp-core.zip" -d "$RUNNER_TEMP/wp-core"
           echo "WP_ENV_CORE=$RUNNER_TEMP/wp-core/wordpress" >> "$GITHUB_ENV"
 

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -23,34 +23,22 @@ jobs:
           php-version: 7.4
           tools: composer
 
+      - name: Setup Node JS
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Add auth details for private composer packages
         run: composer config http-basic.composer.gravity.io ${{ secrets.GF_LICENSE }} http://localhost
 
-      - name: Resolve latest stable WordPress version
+      # Pins the newest WordPress release, or its release candidate when one is in flight.
+      - name: Resolve target WordPress version
         id: wp
-        run: |
-          latest=$(curl -fsSL https://api.wordpress.org/core/version-check/1.7/ \
-            | python3 -c "import sys, json; print(json.load(sys.stdin)['offers'][0]['version'])")
-          if [ -z "$latest" ]; then
-            echo "Failed to resolve latest WordPress version" >&2
-            exit 1
-          fi
-          # integration.json is the canonical source for the current WP pin;
-          # the three wp-env configs are kept in lockstep.
-          current=$(grep -oE 'wordpress-[0-9]+\.[0-9]+(\.[0-9]+)?\.zip' tools/wp-env/integration.json \
-            | head -n1 | sed -E 's/wordpress-([0-9.]+)\.zip/\1/')
-          echo "latest=$latest" >> "$GITHUB_OUTPUT"
-          echo "current=$current" >> "$GITHUB_OUTPUT"
-          [ "$latest" != "$current" ] && echo "changed=true" >> "$GITHUB_OUTPUT" || echo "changed=false" >> "$GITHUB_OUTPUT"
+        run: node tools/wp-env/wp-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Update wp-env configs
         if: steps.wp.outputs.changed == 'true'
-        run: |
-          for file in tools/wp-env/development.json \
-                      tools/wp-env/integration.json \
-                      tools/wp-env/e2e.json; do
-            sed -i -E "s|wordpress-[0-9]+\.[0-9]+(\.[0-9]+)?\.zip|wordpress-${{ steps.wp.outputs.latest }}.zip|g" "$file"
-          done
+        run: node tools/wp-env/wp-version.mjs update "${{ steps.wp.outputs.latest }}"
 
       # Snapshot before/after so the PR body can render a Before/After table.
       - name: Snapshot current Composer versions
@@ -92,6 +80,11 @@ jobs:
             echo ""
             if [ "${{ steps.wp.outputs.changed }}" = "true" ]; then
               echo "**WordPress core (wp-env configs):** \`${{ steps.wp.outputs.current }}\` → \`${{ steps.wp.outputs.latest }}\`"
+              if [ "${{ steps.wp.outputs.prerelease }}" = "true" ]; then
+                echo ""
+                echo "> [!NOTE]"
+                echo "> This is a release candidate, not a final release."
+              fi
               echo ""
             fi
             echo "**Composer packages** — \`gravity/gravityforms\`"

--- a/tools/wp-env/development.json
+++ b/tools/wp-env/development.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.1.zip",
+  "core": "WordPress/WordPress#7.1",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/e2e.json
+++ b/tools/wp-env/e2e.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.1-RC3.zip",
+  "core": "WordPress/WordPress#7.1",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/integration.json
+++ b/tools/wp-env/integration.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": "https://wordpress.org/wordpress-7.1-RC3.zip",
+  "core": "WordPress/WordPress#7.1",
   "phpVersion": "8.5",
   "plugins": [],
   "mappings": {

--- a/tools/wp-env/wp-version.mjs
+++ b/tools/wp-env/wp-version.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+/**
+ * Resolve the WordPress version the wp-env configs should pin to, and rewrite them.
+ *
+ *   wp-version.mjs                  print `current`/`latest`/`changed`/`prerelease` lines (for $GITHUB_OUTPUT)
+ *   wp-version.mjs update X         rewrite every wp-env config's core pin to version X
+ *   wp-version.mjs download-url C   print the core zip URL for config C's pin, whichever format it uses
+ *
+ * Release candidates are pinned so the suite runs against in-flight releases; alphas and betas are not.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+// The beta channel adds in-flight releases to the stable offers. version=6.0 is an arbitrary old release,
+// which guarantees every newer version is offered.
+const API =
+	'https://api.wordpress.org/core/version-check/1.7/?channel=beta&version=6.0';
+
+// integration.json is the canonical source for the current pin; the three configs are kept in lockstep.
+const CANONICAL = 'tools/wp-env/integration.json';
+
+const CONFIGS = [
+	'tools/wp-env/development.json',
+	CANONICAL,
+	'tools/wp-env/e2e.json',
+];
+
+const VERSION = /(\d+)\.(\d+)(?:\.(\d+))?(?:-([A-Za-z]+)(\d*))?/;
+const EXACT_VERSION = new RegExp(`^${VERSION.source}$`);
+
+// Matches both pin formats — a wordpress.org zip URL and a GitHub ref (WordPress/WordPress#7.1) — each
+// optionally carrying a prerelease suffix (-RC3, -beta1).
+const PIN = new RegExp(
+	`(?<prefix>wordpress-|WordPress/WordPress#)(?<version>${VERSION.source})`
+);
+
+// alpha < beta < RC < final, so a superseded prerelease bumps to its stable release while a pin that runs
+// ahead of stable is never downgraded.
+const PHASES = { alpha: 0, beta: 1, rc: 2 };
+const FINAL = 3;
+
+function fail(message) {
+	console.error(message);
+	process.exit(1);
+}
+
+// Ordering tuple for a WordPress version, or null if it isn't a plain release/prerelease (e.g. a nightly).
+function sortKey(version) {
+	const match = EXACT_VERSION.exec(version);
+	if (!match) {
+		return null;
+	}
+
+	const [, major, minor, patch, phase, build] = match;
+	return [
+		Number(major),
+		Number(minor),
+		Number(patch ?? 0),
+		PHASES[(phase ?? '').toLowerCase()] ?? FINAL,
+		Number(build || 0),
+	];
+}
+
+const phase = (version) => sortKey(version)?.[3];
+
+function compare(a, b) {
+	const difference = a.findIndex((part, index) => part !== b[index]);
+	return difference === -1 ? 0 : a[difference] - b[difference];
+}
+
+function pinnedVersion(path) {
+	return PIN.exec(readFileSync(path, 'utf8'))?.groups.version ?? '';
+}
+
+function downloadUrl(path) {
+	const version = pinnedVersion(path);
+	if (!version) {
+		fail(`No WordPress version pin found in ${path}`);
+	}
+
+	// Both pin formats resolve to the same download; wp-env's own fetch is bypassed via WP_ENV_CORE anyway.
+	console.log(`https://wordpress.org/wordpress-${version}.zip`);
+}
+
+async function latestOffered() {
+	const response = await fetch(API);
+	if (!response.ok) {
+		fail(`WordPress API returned ${response.status}`);
+	}
+
+	const { offers } = await response.json();
+	// Anything below RC — betas, alphas, nightlies — is too unstable to run the suite against.
+	const candidates = [
+		...new Set(offers.map((offer) => offer.version ?? '')),
+	].filter((version) => phase(version) >= PHASES.rc);
+
+	if (candidates.length === 0) {
+		fail('No WordPress release or RC offered by the API');
+	}
+
+	return candidates.reduce((latest, version) =>
+		compare(sortKey(version), sortKey(latest)) > 0 ? version : latest
+	);
+}
+
+async function resolve() {
+	const current = pinnedVersion(CANONICAL);
+	const latest = await latestOffered();
+
+	if (!current) {
+		// An unpinned config, or a branch ref like #trunk — leave core alone.
+		console.error(
+			`No WordPress version pin found in ${CANONICAL}; skipping core update`
+		);
+	}
+
+	const changed = current
+		? compare(sortKey(latest), sortKey(current)) > 0
+		: false;
+
+	console.log(`current=${current}`);
+	console.log(`latest=${latest}`);
+	console.log(`changed=${changed}`);
+	console.log(`prerelease=${phase(latest) < FINAL}`);
+}
+
+function update(version) {
+	if (!sortKey(version)) {
+		fail(`Unrecognised WordPress version: ${version}`);
+	}
+
+	for (const path of CONFIGS) {
+		const original = readFileSync(path, 'utf8');
+		// Each config keeps whichever pin format it already uses.
+		const updated = original.replace(PIN, `$<prefix>${version}`);
+		if (updated !== original) {
+			writeFileSync(path, updated);
+		}
+	}
+}
+
+const [command, argument] = process.argv.slice(2);
+
+if (!command) {
+	await resolve();
+} else if (command === 'update' && argument) {
+	update(argument);
+} else if (command === 'download-url' && argument) {
+	downloadUrl(argument);
+} else {
+	fail('Usage: wp-version.mjs [update <version> | download-url <config>]');
+}


### PR DESCRIPTION
The weekly dependency workflow only ever matched one shape of WordPress pin — `wordpress-7.1.zip`. The wp-env configs now use the GitHub ref form (`WordPress/WordPress#7.1`), which the updater could not see: it read an empty `current`, its `sed` found nothing to rewrite, and the weekly PR arrived with a Gravity Forms bump and core quietly left behind. Prerelease pins like `wordpress-7.1-RC3.zip` failed the same way.

All of the version handling moves out of the YAML into `tools/wp-env/wp-version.mjs`, which becomes the single thing in the repo that understands the `core` field. It reads both pin formats, and when it rewrites the three configs each one keeps whichever format it already had. Versions order as `alpha < beta < RC < final`, so a superseded RC bumps to its stable release while a pin that runs ahead of what the API offers is left alone rather than downgraded.

Release candidates are now pinned as they land, so the suite runs against an in-flight release instead of waiting for it to ship. They are resolved from the API's beta channel with everything below RC filtered out — betas, alphas and nightlies are never pinned. When the target is a prerelease the weekly PR body says so, so nobody is moved onto an RC without noticing.

The same `core` field is read a second time in `tests.yml`, which pre-downloads core by curling it directly. That step only understood the zip URL, so it would have failed outright on the ref format; it now derives the download URL from the pin through the same script.

## Try it

```bash
# What the weekly job would pin right now
node tools/wp-env/wp-version.mjs

# The URL CI pre-downloads, from either pin format
node tools/wp-env/wp-version.mjs download-url tools/wp-env/integration.json
```

## Test plan

- [x] Resolves the current pin from both formats, and from a prerelease zip (`wordpress-6.8-RC1.zip`)
- [x] Ordering verified across `7.0.4` / `7.1-RC3` / `7.1` / `7.2-beta1` / `7.2-RC1` / `7.2`; nightlies (`6.9-alpha-59000`) are rejected outright
- [x] RC selected over a stable release when one is in flight; a beta-only offer falls back to stable
- [x] `RC10` sorts above `RC9` rather than string-sorting below it
- [x] A pin ahead of the offered version reports `changed=false` (no downgrade)
- [x] An unpinned config (`"core": null`) skips the core update instead of opening an empty PR
- [x] `update` rewrites all three configs, preserving each file's format, for both an RC and a final target
- [x] `download-url` output downloads and unzips exactly as CI does, yielding `$wp_version = '7.1'`
- [x] Both workflow files parse as YAML; the script is clean under `wp-scripts lint-js` apart from `no-console`
- [ ] CI green on this PR (the real check on the `tests.yml` change)

<details>
<summary>Implementation notes</summary>

**One regex, one grammar.** `VERSION` defines what a WordPress version looks like; `PIN` interpolates it behind a prefix group that alternates the two formats, and `EXACT_VERSION` anchors it for parsing a bare version string. Rewriting is a single `String.replace` with a `$<prefix>` backreference, which is what preserves each config's format without the script needing to know which file uses which.

**Ordering.** `sortKey()` returns `[major, minor, patch, phase, build]` with `phase` from `{alpha: 0, beta: 1, rc: 2}` defaulting to `3` for a final release. That one tuple gives every behaviour the workflow needs: `7.1-RC3 < 7.1` (RC superseded, bump), `7.1 < 7.2-RC1` (next RC, bump), `7.2-RC1 > 7.1` (pinned ahead, hold). Because `build` is compared as a number, `RC10` sorts above `RC9` — worth noting since `semver` would compare those prerelease identifiers as strings and get it backwards. Anything that is not a plain release or prerelease returns `null` and is filtered out, which is how nightlies like `6.9-alpha-59000` are excluded — they fail the anchored match on the second hyphen.

**Why the beta channel.** `?channel=beta&version=6.0` returns in-flight releases alongside the stable offers; the `version` parameter is an arbitrary old release chosen so every newer offer comes back. The script takes the max of the offers ranked RC or above rather than trusting `offers[0]`, so it does not depend on the API's ordering.

**Script interface.** A bare invocation prints `current` / `latest` / `changed` / `prerelease` as `key=value`, which the workflow appends straight to `$GITHUB_OUTPUT`; the script computes the prerelease flag but the workflow decides how to render it. `update <version>` rewrites the configs; `download-url <config>` maps a pin to `https://wordpress.org/wordpress-<version>.zip`, verified to resolve for stable, RC and beta builds. `integration.json` stays the canonical source for the current pin, with the three configs kept in lockstep as before.

**Node.** Written as `.mjs` since the package has no `"type": "module"`, and invoked directly from CI the way `tools/release/build.sh` and `tools/phpunit/retry.sh` are, rather than through a `package.json` script. The updater job gains the same `actions/setup-node` + `.nvmrc` step the other workflows use; both `tests.yml` jobs already set Node up well before their pre-download step.

**Unpinned configs.** Previously a `core` value with no version match produced an empty `current`, which compared unequal to `latest` and set `changed=true` — the update step then ran and did nothing. Now a config with no version pin, or a branch ref like `#trunk`, reports `changed=false` and the core update is skipped.

</details>
