### PR TITLE
Detect and warn about deprecated v3 functionality ahead of 7.0

### DIFF
--- a/src/Controller/Controller_Actions.php
+++ b/src/Controller/Controller_Actions.php
@@ -119,6 +119,12 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 * condition: The function or method to call to determine if a notice should be displayed (Boolean)
 	 * process: The function to handle a successful action. On success the disable_route() method should be called
 	 * view: The function used to display the notice content
+	 * view_class: Optional classes for the notice box, including a `notice-*` state like `notice-warning`. A
+	 *             non-string callable is resolved when the notice displays, rather than when the route table is
+	 *             built; a string is always taken as the class itself
+	 * dismiss: Optional function to call when the notice is dismissed, instead of dismissing the route's own
+	 *          action ID. A route that supplies one records the dismissal wherever it likes, so it also owns
+	 *          suppressing itself afterwards through `condition`
 	 *
 	 * @return array
 	 *
@@ -126,20 +132,57 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 */
 	public function get_routes() {
 
-		$routes = [
+		$routes = array_merge(
 			[
-				'action'      => 'install_core_fonts',
-				'action_text' => esc_html__( 'Install Core Fonts', 'gravity-pdf' ),
-				'condition'   => [ $this->model, 'core_font_condition' ],
-				'process'     => [ $this->model, 'core_font_redirect' ],
-				'view'        => [ $this->view, 'core_font' ],
-				'capability'  => 'gravityforms_edit_settings',
+				[
+					'action'      => 'install_core_fonts',
+					'action_text' => esc_html__( 'Install Core Fonts', 'gravity-pdf' ),
+					'condition'   => [ $this->model, 'core_font_condition' ],
+					'process'     => [ $this->model, 'core_font_redirect' ],
+					'view'        => [ $this->view, 'core_font' ],
+					'capability'  => 'gravityforms_edit_settings',
+				],
 			],
-		];
+			$this->get_deprecated_feature_routes()
+		);
 
 		/* See https://docs.gravitypdf.com/developers/filters/gfpdf_one_time_action_routes for more details about this filter */
 
 		return apply_filters( 'gfpdf_one_time_action_routes', $routes );
+	}
+
+	/**
+	 * Build the one notice route covering every deprecated feature in use
+	 *
+	 * One notice rather than one per feature: five separate warnings on the same admin screen is noise a reader
+	 * learns to scroll past. Dismissing it records each feature it listed, so silencing today's list says nothing
+	 * about the next round of removals — that arrives undismissed and raises the notice again. Site Health keeps
+	 * the whole picture either way, so nothing here is the last word on a feature.
+	 *
+	 * The condition reads what was recorded the last time deprecated functionality was detected, rather than
+	 * detecting for itself — see Deprecation::get_detected_features().
+	 *
+	 * @return array
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_feature_routes(): array {
+		return [
+			[
+				'action'      => 'deprecated_features',
+				'action_text' => esc_html__( 'View the system report', 'gravity-pdf' ),
+				'condition'   => [ $this->model, 'has_deprecated_features' ],
+				'process'     => [ $this->model, 'system_report_redirect' ],
+				/* One notice covers them all, so dismissing it dismisses each feature it was listing */
+				'dismiss'     => [ $this->model, 'dismiss_deprecated_features' ],
+				'view'        => function ( $action, $button_text ) {
+					return $this->view->deprecated_features( $this->model->get_undismissed_deprecated_features(), $action, $button_text );
+				},
+				'view_class'  => function () {
+					return $this->model->has_unsupported_deprecated_feature() ? 'notice-error' : 'notice-warning';
+				},
+				'capability'  => 'gravityforms_view_settings',
+			],
+		];
 	}
 
 	/**
@@ -158,6 +201,11 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 			return null;
 		}
 
+		/* Don't run the route conditions, which query the database, on pages that discard the notice anyway */
+		if ( ! $this->notices->can_display_notice_on_this_page() ) {
+			return null;
+		}
+
 		foreach ( $this->get_routes() as $route ) {
 
 			/* Before displaying check the user has the correct capabilities, the notice isn't already been dismissed and the route condition has been met */
@@ -173,8 +221,17 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 					]
 				);
 
-				$class = ( isset( $route['view_class'] ) ) ? $route['view_class'] : '';
-				$this->notices->add_notice( call_user_func( $route['view'], $route['action'], $route['action_text'] ), $class );
+				$view_class = $route['view_class'] ?? '';
+
+				/* A string is always a CSS class: `is_callable()` alone matches any class name sharing a function name */
+				if ( ! is_string( $view_class ) && is_callable( $view_class ) ) {
+					$view_class = call_user_func( $view_class );
+				}
+
+				$this->notices->add_notice(
+					call_user_func( $route['view'], $route['action'], $route['action_text'] ),
+					$view_class
+				);
 			}
 		}
 	}
@@ -187,6 +244,11 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 * @since 4.0
 	 */
 	public function route() {
+
+		/* Runs on every admin_init, including ajax, and the route table costs more to build than this check */
+		if ( rgpost( 'gfpdf_action' ) === '' ) {
+			return;
+		}
 
 		foreach ( $this->get_routes() as $route ) {
 
@@ -225,7 +287,11 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 						]
 					);
 
-					$this->model->dismiss_notice( $route['action'] );
+					if ( isset( $route['dismiss'] ) ) {
+						call_user_func( $route['dismiss'] );
+					} else {
+						$this->model->dismiss_notice( $route['action'] );
+					}
 				} else {
 					$this->log->notice(
 						'Trigger Action Process.',

--- a/src/Controller/Controller_Install.php
+++ b/src/Controller/Controller_Install.php
@@ -204,6 +204,6 @@ class Controller_Install extends Helper_Abstract_Controller implements Helper_In
 	 * @since 4.0
 	 */
 	public function maybe_uninstall() {
-		_doing_it_wrong( __METHOD__, 'This method has been moved to Controller_Uninstall::uninstall_addon()', '6.0' );
+		_deprecated_function( __METHOD__, '6.0', 'Controller_Uninstall::uninstall_addon()' );
 	}
 }

--- a/src/Controller/Controller_PDF.php
+++ b/src/Controller/Controller_PDF.php
@@ -11,9 +11,9 @@ use GFPDF\Helper\Helper_Interface_Actions;
 use GFPDF\Helper\Helper_Interface_Filters;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Model\Model_PDF;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF\View\View_PDF;
 use Psr\Log\LoggerInterface;
-use SiteGround_Optimizer\Minifier\Minifier;
 
 /**
  * @package     Gravity PDF
@@ -221,7 +221,7 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_filter( 'gfpdf_pdf_core_template_html_output', [ $this->gform, 'process_tags' ], 10, 3 );
 
 		/* Backwards compatibility for our Tier 2 plugin */
-		add_filter( 'gfpdfe_pre_load_template', [ 'PDFRender', 'prepare_ids' ], 1, 8 );
+		add_filter( 'gfpdfe_pre_load_template', Deprecation_V3::INTERNAL_FILTER_CALLBACK, 1, 8 );
 
 		/* Pre-process our template arguments and automatically render them in PDF */
 		add_filter( 'gfpdf_template_args', [ $this->model, 'preprocess_template_arguments' ] );
@@ -231,8 +231,6 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 		add_filter( 'gform_before_resend_notifications', [ $this->model, 'resend_notification_pdf_cleanup' ], 10, 2 );
 
 		/* Third Party Conflict Fixes */
-		add_filter( 'gfpdf_pre_view_or_download_pdf', [ $this, 'sgoptimizer_html_minification_fix' ] );
-		add_filter( 'gfpdf_legacy_pre_view_or_download_pdf', [ $this, 'sgoptimizer_html_minification_fix' ] );
 		add_filter(
 			'gfpdf_pre_pdf_generation_output',
 			function () {
@@ -304,6 +302,8 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 
 		$this->prevent_index();
 
+		_deprecated_function( __METHOD__, '4.0', 'the [gravitypdf] shortcode or PDF merge tags, https://docs.gravitypdf.com/upgrade/legacy-download-urls/' );
+
 		$config = [
 			'lid'      => (int) explode( ',', $_GET['lid'] )[0],
 			'fid'      => (int) $_GET['fid'],
@@ -327,10 +327,15 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 			$this->pdf_error( $pid );
 		}
 
+		/* Report the form from now on, whether or not the URL itself lives anywhere the form scan can find it */
+		Deprecation_V3::record_legacy_endpoint_usage( $config['fid'] );
+
 		/* Store our ids in the WP query_vars object */
 		$GLOBALS['wp']->query_vars['gpdf'] = 1;
 		$GLOBALS['wp']->query_vars['pid']  = $pid;
 		$GLOBALS['wp']->query_vars['lid']  = $config['lid'];
+
+		$this->log->warning( sprintf( 'Legacy download URLs are removed in Gravity PDF %s. Replace with the [gravitypdf] shortcode or PDF merge tags. See https://docs.gravitypdf.com/upgrade/legacy-download-urls/ for upgrade instructions.', Deprecation_V3::REMOVED_IN ) );
 
 		/* Send to our model to handle validation / authentication */
 		do_action( 'gfpdf_legacy_pre_view_or_download_pdf', $config['lid'], $pid, $config['action'] );
@@ -373,20 +378,11 @@ class Controller_PDF extends Helper_Abstract_Controller implements Helper_Interf
 	 * Disables the Siteground HTML Minifier when generating PDFs for the browser
 	 *
 	 * @since 5.1.5
-	 *
-	 * @see   https://github.com/GravityPDF/gravity-pdf/issues/863
+	 * @see https://github.com/GravityPDF/gravity-pdf/issues/863
+	 * @deprecated 6.12 All buffers are auto-closed before a PDF is sent to the browser
 	 */
 	public function sgoptimizer_html_minification_fix() {
-		if ( class_exists( '\SiteGround_Optimizer\Minifier\Minifier' ) ) {
-
-			/* Remove the shutdown buffer and manually close an open buffers */
-			$minifier = Minifier::get_instance();
-			remove_action( 'shutdown', [ $minifier, 'end_html_minifier_buffer' ] );
-
-			while ( ob_get_level() > 0 ) {
-				ob_end_clean();
-			}
-		}
+		_deprecated_function( __METHOD__, '6.12' );
 	}
 
 	/**

--- a/src/Controller/Controller_Pdf_Queue.php
+++ b/src/Controller/Controller_Pdf_Queue.php
@@ -243,7 +243,7 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 */
 	public function queue_dispatch_resend_notification_tasks( $form = null, $entry = null ) {
 		if ( ! is_null( $entry ) ) {
-			_doing_it_wrong( __METHOD__, '$entry argument ignored and now set in self::should_send_async_notification()', '6.13.5' );
+			_deprecated_argument( __METHOD__, '6.13.5', 'The $entry argument is ignored and now set in self::should_send_async_notification()' );
 		}
 
 		/* loop over all form/entries */
@@ -525,6 +525,6 @@ class Controller_Pdf_Queue extends Helper_Abstract_Controller {
 	 * @deprecated 6.11
 	 */
 	public function queue_async_resend_notification_tasks( $notification, $form, $entry ) {
-		_doing_it_wrong( esc_html( 'queue_async_resend_notification_tasks() was removed in Gravity PDF 6.11' ) );
+		_deprecated_function( __METHOD__, '6.11' );
 	}
 }

--- a/src/Controller/Controller_System_Report.php
+++ b/src/Controller/Controller_System_Report.php
@@ -3,10 +3,12 @@
 namespace GFPDF\Controller;
 
 use GFPDF\Helper\Helper_Abstract_Controller;
+use GFPDF\Helper\Helper_Abstract_Form;
 use GFPDF\Helper\Helper_Abstract_Model;
 use GFPDF\Helper\Helper_Abstract_View;
 use GFPDF\Model\Model_System_Report;
 use GFPDF\View\View_System_Report;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -38,12 +40,23 @@ class Controller_System_Report extends Helper_Abstract_Controller {
 	 */
 	public $view;
 
-	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view ) {
+	/**
+	 * Holds the abstracted Gravity Forms API specific to Gravity PDF
+	 *
+	 * @var Helper_Abstract_Form
+	 *
+	 * @since 6.17.0
+	 */
+	protected $gform;
+
+	public function __construct( Helper_Abstract_Model $model, Helper_Abstract_View $view, Helper_Abstract_Form $gform ) {
 		$this->model = $model;
 		$this->model->setController( $this );
 
 		$this->view = $view;
 		$this->view->setController( $this );
+
+		$this->gform = $gform;
 	}
 
 	/**
@@ -62,6 +75,61 @@ class Controller_System_Report extends Helper_Abstract_Controller {
 	 */
 	public function add_filters() {
 		add_filter( 'gform_system_report', [ $this, 'system_report' ] );
+		add_filter( 'site_status_tests', [ $this, 'site_status_tests' ] );
+		add_filter( 'debug_information', [ $this, 'debug_information' ] );
+	}
+
+	/**
+	 * Register a Site Health test for any deprecated functionality in use on this site
+	 *
+	 * The admin notice can be dismissed for good, and the Gravity Forms system report has to be sought out. This
+	 * puts the same detections where WordPress reports the rest of a site's problems, and keeps them there until
+	 * they're fixed.
+	 *
+	 * @param array $tests
+	 *
+	 * @return array
+	 * @since 6.17.0
+	 */
+	public function site_status_tests( $tests ) {
+		if ( ! is_array( $tests ) || ! $this->gform->has_capability( 'gravityforms_view_settings' ) ) {
+			return $tests;
+		}
+
+		$tests['direct']['gravity_pdf_deprecated_features'] = [
+			'label' => esc_html__( 'Deprecated Gravity PDF functionality', 'gravity-pdf' ),
+			'test'  => [ $this, 'deprecated_features_test' ],
+		];
+
+		return $tests;
+	}
+
+	/**
+	 * Run the deprecated functionality Site Health test
+	 *
+	 * @return array
+	 * @since 6.17.0
+	 */
+	public function deprecated_features_test() {
+		return $this->view->get_deprecated_features_test( Deprecation::refresh_signals() );
+	}
+
+	/**
+	 * Add the deprecated functionality to the Site Health Info tab
+	 *
+	 * The Info tab is what users copy into a support ticket, so the detections travel with it.
+	 *
+	 * @param array $info
+	 *
+	 * @return array
+	 * @since 6.17.0
+	 */
+	public function debug_information( $info ) {
+		if ( ! is_array( $info ) || ! $this->gform->has_capability( 'gravityforms_view_settings' ) ) {
+			return $info;
+		}
+
+		return array_merge( $info, $this->view->get_deprecated_debug_information( Deprecation::refresh_signals() ) );
 	}
 
 	/**

--- a/src/Controller/Controller_Upgrade_Routines.php
+++ b/src/Controller/Controller_Upgrade_Routines.php
@@ -5,6 +5,7 @@ namespace GFPDF\Controller;
 use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Data;
 use GFPDF\Model\Model_Custom_Fonts;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -44,6 +45,7 @@ class Controller_Upgrade_Routines {
 	 */
 	public function init(): void {
 		add_action( 'gfpdf_version_changed', [ $this, 'maybe_run_upgrade' ], 10, 2 );
+		add_action( 'gfpdf_plugin_installed', [ $this, 'record_deprecated_functionality' ] );
 	}
 
 	/**
@@ -63,6 +65,23 @@ class Controller_Upgrade_Routines {
 			$this->remove_legacy_update_cache();
 			$this->remove_legacy_license_check_cron();
 		}
+
+		/* Deliberately ungated: every release is a chance for a new round of removals to arrive. Runs last, so it
+		   reflects the routines above */
+		$this->record_deprecated_functionality();
+	}
+
+	/**
+	 * Record the deprecated functionality this site uses, for the admin notices to read
+	 *
+	 * Taken at install and on every version change, since the notices would otherwise have to detect it on each of
+	 * the admin pages they can appear on. The system report and Site Health screens keep the record current in
+	 * between, detecting live as they do.
+	 *
+	 * @since 6.17.0
+	 */
+	public function record_deprecated_functionality(): void {
+		Deprecation::refresh_signals();
 	}
 
 	/**

--- a/src/Helper/Fields/Field_Signature.php
+++ b/src/Helper/Fields/Field_Signature.php
@@ -4,6 +4,7 @@ namespace GFPDF\Helper\Fields;
 
 use GFFormsModel;
 use GFPDF\Helper\Helper_Abstract_Fields;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -132,7 +133,7 @@ class Field_Signature extends Helper_Abstract_Fields {
 			 * @param integer The original image width
 			 */
 			if ( $signature_details !== false ) {
-				$optimised_width = apply_filters( 'gfpdfe_signature_width', $signature_details[0] / 3, $signature_details[0] ); /* backwards compat */
+				$optimised_width = Deprecation::apply_filters( 'gfpdfe_signature_width', [ $signature_details[0] / 3, $signature_details[0] ] );
 
 				/* See https://docs.gravitypdf.com/developers/filters/gfpdf_signature_width/ for more details about this filter */
 				$optimised_width = apply_filters( 'gfpdf_signature_width', $optimised_width, $signature_details[0] );

--- a/src/Helper/Helper_Abstract_View.php
+++ b/src/Helper/Helper_Abstract_View.php
@@ -107,6 +107,10 @@ abstract class Helper_Abstract_View extends Helper_Abstract_Model {
 
 		$args = array_merge( $this->data_cache, $args );
 
+		if ( isset( $args['content'] ) ) {
+			_deprecated_argument( esc_html( $this->view_type . '/' . $filename . '.php' ), '6.4.0', "Use \$args['callback'] instead" );
+		}
+
 		if ( is_readable( $path ) ) {
 
 			if ( $output ) {

--- a/src/Helper/Helper_Interface_Deprecated_Features.php
+++ b/src/Helper/Helper_Interface_Deprecated_Features.php
@@ -1,0 +1,70 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Describes a set of Gravity PDF functionality being removed, for Deprecation to detect and report on
+ *
+ * @since 6.17.0
+ */
+interface Helper_Interface_Deprecated_Features {
+
+	/**
+	 * The features this class contributes to the deprecation registry
+	 *
+	 * Each entry is keyed by the ID it is detected and reported under, and holds:
+	 *
+	 * - `label`      (string)   The name the feature is known by to the user
+	 * - `group`      (string)   Deprecation::GROUP_UNSUPPORTED or Deprecation::GROUP_DEPRECATED
+	 * - `removed_in` (string)   The Gravity PDF version the feature is, or will be, removed in
+	 * - `url`        (string)   Where the upgrade instructions live
+	 * - `detect`     (callable) Returns what was found on this site, and an empty array when the feature is unused
+	 *
+	 * A feature the default sentence describes badly declares one more:
+	 *
+	 * - `notice`     (string)   What becomes of the feature, taking the removal version as `%s`. Read by every
+	 *                           surface, so it has to make sense with nothing else around it
+	 *
+	 * A feature made up of hooks declares two more, so Deprecation::apply_filters() can warn the listeners by name:
+	 *
+	 * - `hooks`         (array<string, string>) Each deprecated hook mapped to its replacement, '' when none exists
+	 * - `deprecated_in` (string)                The Gravity PDF version the hooks were deprecated in
+	 * - `hook_prefix`   (string)                Optional. Claims any hook starting with it as well, which is how
+	 *                                           the dynamic hooks are matched
+	 *
+	 * @return array<string, array>
+	 * @since 6.17.0
+	 */
+	public static function get_features(): array;
+
+	/**
+	 * The WordPress options this class stores its own detection data in, for the uninstaller to remove
+	 *
+	 * @return string[] Option names, empty when the class stores nothing of its own
+	 * @since 6.17.0
+	 */
+	public static function get_stored_options(): array;
+
+	/**
+	 * Forget anything this class held for the request, so the next detection reads the site as it is now
+	 *
+	 * Called by Deprecation::flush_cache(), which is the one entry point callers use. A class caching nothing
+	 * implements it empty.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function flush_cache(): void;
+}

--- a/src/Helper/Helper_Notices.php
+++ b/src/Helper/Helper_Notices.php
@@ -61,7 +61,9 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @since 6.5
 	 * @deprecated 6.11 No longer required. Running all notices through standard WP hooks, but have included `gf-notice` class so GF does not remove it
 	 */
-	public function maybe_remove_non_pdf_messages(): void {}
+	public function maybe_remove_non_pdf_messages(): void {
+		_deprecated_function( __METHOD__, '6.11' );
+	}
 
 	/**
 	 * Determine which notice should be triggered
@@ -80,32 +82,32 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * Public endpoint for adding a new notice
 	 *
 	 * @param string $notice    The message to be queued
-	 * @param string $css_class The class that should be included with the notice box
+	 * @param string $css_class The class that should be included with the notice box. Pass a WordPress `notice-*`
+	 *                          state class, like `notice-warning`, to override the default success styling.
 	 *
 	 * @since 4.0
 	 */
 	public function add_notice( $notice, $css_class = '' ): void {
-		if ( empty( $css_class ) ) {
-			$this->notices[] = $notice;
-		} else {
-			$this->notices[ $css_class ] = $notice;
-		}
+		$this->notices[] = [
+			'message' => $notice,
+			'class'   => $css_class,
+		];
 	}
 
 	/**
 	 * Public endpoint for adding a new notice
 	 *
 	 * @param string $error     The error message that should be added
-	 * @param string $css_class Any class names that should apply to the error
+	 * @param string $css_class Any class names that should apply to the error, including a WordPress `notice-*`
+	 *                          state class to override the default error styling
 	 *
 	 * @since    4.0
 	 */
 	public function add_error( $error, $css_class = '' ) {
-		if ( empty( $css_class ) ) {
-			$this->errors[] = $error;
-		} else {
-			$this->errors[ $css_class ] = $error;
-		}
+		$this->errors[] = [
+			'message' => $error,
+			'class'   => $css_class,
+		];
 	}
 
 	/**
@@ -154,26 +156,26 @@ class Helper_Notices implements Helper_Interface_Actions {
 			return;
 		}
 
-		foreach ( $this->notices as $css_class => $notice ) {
-			$include_class = ( ! is_int( $css_class ) ) ? $css_class : '';
-			$this->html( $notice, 'updated ' . $include_class );
+		foreach ( $this->notices as $notice ) {
+			$this->html( $notice['message'], $notice['class'], 'updated' );
 		}
 
-		foreach ( $this->errors as $css_class => $error ) {
-			$include_class = ( ! is_int( $css_class ) ) ? $css_class : '';
-			$this->html( $error, 'error ' . $include_class );
+		foreach ( $this->errors as $error ) {
+			$this->html( $error['message'], $error['class'], 'error' );
 		}
 	}
 
 	/**
 	 * Generate the HTML used to display the notice / error
 	 *
-	 * @param string $text      The message to be displayed
-	 * @param string $css_class The class name (updated / error)
+	 * @param string $text          The message to be displayed
+	 * @param string $css_class     Any classes the caller asked for
+	 * @param string $default_state The state class used when the caller hasn't chosen one (updated / error)
 	 *
 	 * @since 4.0
+	 * @since 6.17.0 Added $default_state
 	 */
-	protected function html( string $text, string $css_class = 'updated' ): void {
+	protected function html( string $text, string $css_class = '', string $default_state = 'updated' ): void {
 		$allow_form_elements = static function ( $tags ) {
 			$tags['input'] = [
 				'type'  => true,
@@ -187,12 +189,16 @@ class Helper_Notices implements Helper_Interface_Actions {
 
 		add_filter( 'wp_kses_allowed_html', $allow_form_elements );
 
+		/* `div.updated` out-specifies `.notice-warning`, so a caller-supplied state replaces ours instead of joining it */
+		$state   = strpos( $css_class, 'notice-' ) === false ? $default_state : '';
+		$classes = trim( $state . ' ' . $css_class );
+
 		/* Add specific classes on Gravity Forms page so the notice displays correctly */
 		if ( class_exists( 'GFForms' ) && \GFForms::is_gravity_page() ) {
-			$classes  = 'notice gf-notice gform-settings__wrapper ' . $css_class;
-			$classes .= strpos( $css_class, 'updated' ) !== false ? ' notice-success' : '';
+			$classes  = 'notice gf-notice gform-settings__wrapper ' . $classes;
+			$classes .= $state === 'updated' ? ' notice-success' : '';
 		} else {
-			$classes = 'notice ' . $css_class;
+			$classes = 'notice ' . $classes;
 		}
 
 		?>
@@ -214,8 +220,9 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @return bool
 	 *
 	 * @since 6.11
+	 * @since 6.17.0 Made public so callers can skip building a notice that would be discarded
 	 */
-	protected function can_display_notice_on_this_page() {
+	public function can_display_notice_on_this_page() {
 		global $pagenow;
 
 		$misc = \GPDFAPI::get_misc_class();
@@ -251,6 +258,8 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @deprecated 6.11 No longer required. Running all notices through standard WP hooks, but have included `gf-notice` class so GF does not remove it
 	 */
 	public function reset_gravityforms_messages( $messages ) {
+		_deprecated_function( __METHOD__, '6.11' );
+
 		return $messages;
 	}
 
@@ -265,6 +274,8 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @deprecated 6.11 No longer required. Running all notices through standard WP hooks, but have included `gf-notice` class so GF does not remove it
 	 */
 	public function set_gravitypdf_notices( $messages ) {
+		_deprecated_function( __METHOD__, '6.11' );
+
 		return $messages;
 	}
 
@@ -279,6 +290,8 @@ class Helper_Notices implements Helper_Interface_Actions {
 	 * @deprecated 6.11 No longer required. Running all notices through standard WP hooks, but have included `gf-notice` class so GF does not remove it
 	 */
 	public function set_gravitypdf_errors( $errors ) {
+		_deprecated_function( __METHOD__, '6.11' );
+
 		return $errors;
 	}
 }

--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -2,6 +2,8 @@
 
 namespace GFPDF\Helper;
 
+use GFPDF\Statics\Deprecation_V3;
+
 /**
  * @package     Gravity PDF
  * @copyright   Copyright (c) 2026, Blue Liquid Designs
@@ -505,9 +507,11 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 	 */
 	public function get_advanced_template_field( $settings ) {
 
-		if ( ! class_exists( 'gfpdfe_business_plus' ) ) {
+		if ( ! Deprecation_V3::has_tier_2_addon() ) {
 			return $settings;
 		}
+
+		_deprecated_function( __METHOD__, '6.12', 'a Gravity PDF 6 template, https://docs.gravitypdf.com/upgrade/legacy-templates/' );
 
 		$settings['advanced_template'] = [
 			'id'   => 'advanced_template',

--- a/src/Helper/Helper_PDF.php
+++ b/src/Helper/Helper_PDF.php
@@ -4,8 +4,10 @@ namespace GFPDF\Helper;
 
 use Exception;
 use GFPDF\Helper\Mpdf\Request;
+use GFPDF\Statics\Deprecation;
 use GFPDF_Vendor\Mpdf\Config\FontVariables;
 use GFPDF\Helper\Mpdf\Mpdf;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF_Vendor\Mpdf\MpdfException;
 use GFPDF_Vendor\Mpdf\Utils\UtfString;
 use GFPDF_Vendor\Mpdf\Container\SimpleContainer;
@@ -265,8 +267,8 @@ class Helper_PDF {
 		}
 
 		/* Apply our filters */
-		$html = apply_filters( 'gfpdfe_pdf_template', $html, $form['id'], $this->entry['id'], $args['settings'] ); /* Backwards compat */
-		$html = apply_filters( 'gfpdfe_pdf_template_' . $form['id'], $html, $this->entry['id'], $args['settings'] ); /* Backwards compat */
+		$html = Deprecation::apply_filters( 'gfpdfe_pdf_template', [ $html, $form['id'], $this->entry['id'], $args['settings'] ] );
+		$html = Deprecation::apply_filters( 'gfpdfe_pdf_template_' . $form['id'], [ $html, $this->entry['id'], $args['settings'] ], 'gfpdf_pdf_html_output_' . $form['id'] );
 
 		/* See https://docs.gravitypdf.com/developers/filters/gfpdf_pdf_html_output/ for more details about these filters */
 		$html = apply_filters( 'gfpdf_pdf_html_output', $html, $form, $this->entry, $args['settings'], $this );
@@ -303,9 +305,11 @@ class Helper_PDF {
 		$this->mpdf = apply_filters( 'gfpdf_mpdf_class', $this->mpdf, $form, $this->entry, $this->settings, $this );
 
 		/* deprecated backwards compatibility filters */
-		$this->mpdf = apply_filters( 'gfpdfe_mpdf_class_pre_render', $this->mpdf, $this->entry['form_id'], $this->entry['id'], $this->settings, '', $this->get_filename() );
-		$this->mpdf = apply_filters( 'gfpdfe_pre_render_pdf', $this->mpdf, $this->entry['form_id'], $this->entry['id'], $this->settings, '', $this->get_filename() );
-		$this->mpdf = apply_filters( 'gfpdfe_mpdf_class', $this->mpdf, $this->entry['form_id'], $this->entry['id'], $this->settings, '', $this->get_filename() );
+		$legacy_args = [ $this->entry['form_id'], $this->entry['id'], $this->settings, '', $this->get_filename() ];
+
+		foreach ( [ 'gfpdfe_mpdf_class_pre_render', 'gfpdfe_pre_render_pdf', 'gfpdfe_mpdf_class' ] as $legacy_hook ) {
+			$this->mpdf = Deprecation::apply_filters( $legacy_hook, array_merge( [ $this->mpdf ], $legacy_args ) );
+		}
 
 		do_action( 'gfpdf_pre_pdf_generation_output', $this->mpdf, $form, $this->entry, $this->settings, $this );
 
@@ -386,6 +390,11 @@ class Helper_PDF {
 
 		/* Check if there are version requirements */
 		$template_info = $this->templates->get_template_info_by_path( $this->template_path );
+
+		if ( $this->templates->is_legacy_template( $template_info ) ) {
+			Deprecation_V3::restore_v3_form_class();
+		}
+
 		if ( ! $this->templates->is_template_compatible( $template_info['required_pdf_version'] ) ) {
 			throw new Exception( sprintf( esc_html__( 'The PDF Template %1$s requires Gravity PDF version %2$s. Upgrade to the latest version.', 'gravity-pdf' ), '<em>' . esc_html( $template ) . '</em>', '<em>' . esc_html( $template_info['required_pdf_version'] ) . '</em>' ) );
 		}

--- a/src/Helper/Helper_Templates.php
+++ b/src/Helper/Helper_Templates.php
@@ -3,6 +3,7 @@
 namespace GFPDF\Helper;
 
 use Exception;
+use GFPDF\Statics\Deprecation;
 use GPDFAPI;
 use Psr\Log\LoggerInterface;
 use stdClass;
@@ -271,6 +272,19 @@ class Helper_Templates {
 			},
 			$this->get_all_templates()
 		);
+	}
+
+	/**
+	 * Check if the template info describes a legacy (v3) template
+	 *
+	 * A v3 template has no `Group` header, so self::get_template_info_by_path() falls back to the Legacy group.
+	 *
+	 * @param array $info The template header info
+	 *
+	 * @since 6.17.0
+	 */
+	public function is_legacy_template( array $info ): bool {
+		return ( $info['group'] ?? '' ) === esc_html__( 'Legacy', 'gravity-pdf' );
 	}
 
 	/**
@@ -766,7 +780,7 @@ class Helper_Templates {
 
 				'form_id'   => $form['id'], /* backwards compat */
 				'lead_ids'  => $legacy_ids, /* backwards compat */
-				'lead_id'   => apply_filters( 'gfpdfe_lead_id', $entry['id'], $form, $entry, $gfpdf ), /* backwards compat */
+				'lead_id'   => Deprecation::apply_filters( 'gfpdfe_lead_id', [ $entry['id'], $form, $entry, $gfpdf ] ), /* backwards compat */
 
 				'form'      => $form,
 				'entry'     => $entry,

--- a/src/Model/Model_Actions.php
+++ b/src/Model/Model_Actions.php
@@ -7,6 +7,7 @@ use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Options_Fields;
+use GFPDF\Statics\Deprecation;
 use GPDFAPI;
 
 /**
@@ -28,6 +29,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0
  */
 class Model_Actions extends Helper_Abstract_Model {
+
+	/**
+	 * The prefix each deprecated feature's dismissal is recorded under in `action_dismissal`
+	 *
+	 * @since 6.17.0
+	 */
+	const DEPRECATED_FEATURE_DISMISSAL = 'deprecated_feature_';
 
 	/**
 	 * Holds our Helper_Data object
@@ -106,9 +114,29 @@ class Model_Actions extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function dismiss_notice( $type ) {
+		$this->dismiss_notices( [ $type ] );
+	}
 
-		$dismissed_notices          = $this->options->get_option( 'action_dismissal', [] );
-		$dismissed_notices[ $type ] = $type;
+	/**
+	 * Mark several notices as dismissed at once
+	 *
+	 * Written in one go, since each update_option() rewrites the whole autoloaded settings blob.
+	 *
+	 * @param string[] $types The notice IDs
+	 *
+	 * @since 6.17.0
+	 */
+	public function dismiss_notices( array $types ): void {
+		if ( $types === [] ) {
+			return;
+		}
+
+		$dismissed_notices = $this->options->get_option( 'action_dismissal', [] );
+
+		foreach ( $types as $type ) {
+			$dismissed_notices[ $type ] = $type;
+		}
+
 		$this->options->update_option( 'action_dismissal', $dismissed_notices );
 	}
 
@@ -138,6 +166,83 @@ class Model_Actions extends Helper_Abstract_Model {
 	 */
 	public function core_font_redirect() {
 		wp_safe_redirect( admin_url( 'admin.php?page=gf_settings&subview=PDF&tab=tools#/downloadCoreFonts' ) );
+		exit;
+	}
+
+	/**
+	 * The deprecated features in use that the user hasn't dismissed a notice for
+	 *
+	 * The recorded detections are read rather than detected here, because this runs on every admin page a notice
+	 * can appear on. Deprecation records a fresh set on every version change — which is when a new round of
+	 * removals arrives — and again whenever the system report or Site Health screens detect for themselves.
+	 *
+	 * @return string[] The feature IDs the notice should list
+	 * @since 6.17.0
+	 */
+	public function get_undismissed_deprecated_features(): array {
+		$features = Deprecation::get_features();
+
+		return array_values(
+			array_filter(
+				Deprecation::get_detected_features(),
+				function ( $key ) use ( $features ) {
+					/* A record taken before a provider was removed can name a feature nothing declares any more */
+					return isset( $features[ $key ] ) && ! $this->is_notice_already_dismissed( static::DEPRECATED_FEATURE_DISMISSAL . $key );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Whether anything in use is worth raising the deprecation notice for
+	 *
+	 * @since 6.17.0
+	 */
+	public function has_deprecated_features(): bool {
+		return $this->get_undismissed_deprecated_features() !== [];
+	}
+
+	/**
+	 * Whether anything the notice lists has already been removed, which reads as an error rather than a warning
+	 *
+	 * @since 6.17.0
+	 */
+	public function has_unsupported_deprecated_feature(): bool {
+		foreach ( $this->get_undismissed_deprecated_features() as $key ) {
+			if ( ( Deprecation::get_feature( $key )['group'] ?? '' ) === Deprecation::GROUP_UNSUPPORTED ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Dismiss every feature the notice was listing when the user dismissed it
+	 *
+	 * Recorded per feature rather than against the notice itself, so a round of removals arriving later raises the
+	 * notice again instead of being silenced by a dismissal that predates it.
+	 *
+	 * @since 6.17.0
+	 */
+	public function dismiss_deprecated_features(): void {
+		$this->dismiss_notices(
+			array_map(
+				function ( $key ) {
+					return static::DEPRECATED_FEATURE_DISMISSAL . $key;
+				},
+				$this->get_undismissed_deprecated_features()
+			)
+		);
+	}
+
+	/**
+	 * Send the user to the system report, which lists every detection behind the notice
+	 *
+	 * @since 6.17.0
+	 */
+	public function system_report_redirect() {
+		wp_safe_redirect( admin_url( 'admin.php?page=gf_system_status' ) );
 		exit;
 	}
 }

--- a/src/Model/Model_Install.php
+++ b/src/Model/Model_Install.php
@@ -10,6 +10,7 @@ use GFPDF\Helper\Helper_Form;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Pdf_Queue;
+use GFPDF\Statics\Deprecation;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -182,8 +183,8 @@ class Model_Install extends Helper_Abstract_Model {
 		$upload_dir_url = $this->data->upload_dir_url;
 
 		/* Legacy Filters */
-		$this->data->template_location     = trailingslashit( apply_filters( 'gfpdfe_template_location', $template_dir, $working_folder, $upload_dir ) );
-		$this->data->template_location_url = trailingslashit( apply_filters( 'gfpdfe_template_location_uri', $template_url, $working_folder, $upload_dir_url ) );
+		$this->data->template_location     = trailingslashit( Deprecation::apply_filters( 'gfpdfe_template_location', [ $template_dir, $working_folder, $upload_dir ] ) );
+		$this->data->template_location_url = trailingslashit( Deprecation::apply_filters( 'gfpdfe_template_location_uri', [ $template_url, $working_folder, $upload_dir_url ] ) );
 
 		/* Allow user to change directory location(s) */
 
@@ -399,6 +400,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function uninstall_plugin() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::uninstall_plugin()' );
+
 		$this->uninstall->uninstall_plugin();
 	}
 
@@ -410,6 +413,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function remove_plugin_options() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::remove_plugin_options()' );
+
 		$this->uninstall->remove_plugin_options();
 	}
 
@@ -422,6 +427,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function remove_plugin_form_settings() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::remove_plugin_form_settings()' );
+
 		$this->uninstall->remove_plugin_form_settings();
 	}
 
@@ -433,6 +440,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function remove_folder_structure() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::remove_folder_structure()' );
+
 		$this->uninstall->remove_folder_structure();
 	}
 
@@ -444,6 +453,8 @@ class Model_Install extends Helper_Abstract_Model {
 	 * @since 4.0
 	 */
 	public function deactivate_plugin() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Uninstall::deactivate_plugin()' );
+
 		$this->uninstall->deactivate_plugin();
 	}
 

--- a/src/Model/Model_PDF.php
+++ b/src/Model/Model_PDF.php
@@ -22,6 +22,8 @@ use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Options_Fields;
 use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Templates;
+use GFPDF\Statics\Deprecation;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF_Vendor\Mpdf\Mpdf;
 use GFPDF_Vendor\Spatie\UrlSigner\Exceptions\InvalidSignatureKey;
 use GFQuiz;
@@ -259,31 +261,31 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
-		$settings['filename'] = $this->misc->remove_extension_from_string( apply_filters( 'gfpdfe_pdf_name', $settings['filename'], $form, $entry ) );
-		$settings['template'] = $this->misc->remove_extension_from_string( apply_filters( 'gfpdfe_template', $settings['template'], $form, $entry ), '.php' );
+		$settings['filename'] = $this->misc->remove_extension_from_string( Deprecation::apply_filters( 'gfpdfe_pdf_name', [ $settings['filename'], $form, $entry ] ) );
+		$settings['template'] = $this->misc->remove_extension_from_string( Deprecation::apply_filters( 'gfpdfe_template', [ $settings['template'], $form, $entry ] ), '.php' );
 
 		if ( isset( $settings['orientation'] ) ) {
-			$settings['orientation'] = apply_filters( 'gfpdf_orientation', $settings['orientation'], $form, $entry );
+			$settings['orientation'] = Deprecation::apply_filters( 'gfpdf_orientation', [ $settings['orientation'], $form, $entry ] );
 		}
 
 		if ( isset( $settings['security'] ) ) {
-			$settings['security'] = $this->misc->update_deprecated_config( apply_filters( 'gfpdf_security', $settings['security'], $form, $entry ) );
+			$settings['security'] = $this->misc->update_deprecated_config( Deprecation::apply_filters( 'gfpdf_security', [ $settings['security'], $form, $entry ] ) );
 		}
 
 		if ( isset( $settings['privileges'] ) ) {
-			$settings['privileges'] = apply_filters( 'gfpdf_privilages', $settings['privileges'], $form, $entry );
+			$settings['privileges'] = Deprecation::apply_filters( 'gfpdf_privilages', [ $settings['privileges'], $form, $entry ] );
 		}
 
 		if ( isset( $settings['password'] ) ) {
-			$settings['password'] = apply_filters( 'gfpdf_password', $settings['password'], $form, $entry );
+			$settings['password'] = Deprecation::apply_filters( 'gfpdf_password', [ $settings['password'], $form, $entry ] );
 		}
 
 		if ( isset( $settings['master_password'] ) ) {
-			$settings['master_password'] = apply_filters( 'gfpdf_master_password', $settings['master_password'], $form, $entry );
+			$settings['master_password'] = Deprecation::apply_filters( 'gfpdf_master_password', [ $settings['master_password'], $form, $entry ] );
 		}
 
 		if ( isset( $settings['rtl'] ) ) {
-			$settings['rtl'] = $this->misc->update_deprecated_config( apply_filters( 'gfpdf_rtl', $settings['rtl'], $form, $entry ) );
+			$settings['rtl'] = $this->misc->update_deprecated_config( Deprecation::apply_filters( 'gfpdf_rtl', [ $settings['rtl'], $form, $entry ] ) );
 		}
 
 		return $settings;
@@ -834,7 +836,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		$name = apply_filters( 'gfpdf_pdf_filename', $name, $form, $entry, $settings );
 
 		/* Backwards compatible filter */
-		$name = apply_filters( 'gfpdfe_pdf_filename', $name, $form, $entry, $settings );
+		$name = Deprecation::apply_filters( 'gfpdfe_pdf_filename', [ $name, $form, $entry, $settings ] );
 
 		/* Remove any characters that cannot be present in a filename */
 		$name = $this->misc->strip_invalid_characters( $name );
@@ -859,7 +861,7 @@ class Model_PDF extends Helper_Abstract_Model {
 		global $wp_rewrite;
 
 		if ( $esc !== true ) {
-			_doing_it_wrong( __METHOD__, '$esc has been deprecated. Late-escape the returned value where appropriate.', '6.4.0' );
+			_deprecated_argument( __METHOD__, '6.4.0', 'The $esc argument is ignored. Late-escape the returned value where appropriate.' );
 		}
 
 		/*
@@ -1234,7 +1236,7 @@ class Model_PDF extends Helper_Abstract_Model {
 				$pdf->set_output_type( 'save' );
 
 				/* Add Backwards compatibility support for our v3 Tier 2 Add-on */
-				if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) === 'yes' ) {
+				if ( Deprecation_V3::is_advanced_template_pdf( $settings ) ) {
 
 					/* Check if we should process this document using our legacy system */
 					if ( $this->handle_legacy_tier_2_processing( $pdf, $entry, $settings, $args ) ) {
@@ -1426,17 +1428,24 @@ class Model_PDF extends Helper_Abstract_Model {
 
 		$form = apply_filters( 'gfpdf_current_form_object', $this->gform->get_form( $entry['form_id'] ), $entry, __FUNCTION__ );
 
-		$prevent_main_pdf_loader = apply_filters(
+		$this->log->warning( sprintf( 'Advanced Templating (Tier 2) processing is removed in Gravity PDF %s. Contact GravityPDF.com to discuss upgrade options.', Deprecation_V3::REMOVED_IN ) );
+
+		/* The add-on runs the template file itself, so Helper_PDF::set_template() never sees it */
+		Deprecation_V3::restore_v3_form_class();
+
+		$prevent_main_pdf_loader = Deprecation::apply_filters(
 			'gfpdfe_pre_load_template',
-			$form['id'],
-			$entry['id'],
-			basename( $pdf->get_template_path() ),
-			$form['id'] . $entry['id'],
-			$this->misc->backwards_compat_output( $pdf->get_output_type() ),
-			$pdf->get_filename(),
-			$this->misc->backwards_compat_conversion( $settings, $form, $entry ),
-			$args
-		); /* Backwards Compatibility */
+			[
+				$form['id'],
+				$entry['id'],
+				basename( $pdf->get_template_path() ),
+				$form['id'] . $entry['id'],
+				$this->misc->backwards_compat_output( $pdf->get_output_type() ),
+				$pdf->get_filename(),
+				$this->misc->backwards_compat_conversion( $settings, $form, $entry ),
+				$args,
+			]
+		);
 
 		return $prevent_main_pdf_loader === true;
 	}
@@ -2189,6 +2198,7 @@ class Model_PDF extends Helper_Abstract_Model {
 	 * @since  4.0
 	 */
 	public function get_legacy_config( $config ) {
+		_deprecated_function( __METHOD__, '4.0', 'the [gravitypdf] shortcode or PDF merge tags, https://docs.gravitypdf.com/upgrade/legacy-download-urls/' );
 
 		/* Get the form settings */
 		$pdfs = $this->options->get_form_pdfs( $config['fid'] );

--- a/src/Model/Model_Settings.php
+++ b/src/Model/Model_Settings.php
@@ -718,7 +718,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Removed in 6.0. Use GPDFAPI::delete_pdf_font()
 	 */
-	public function remove_font_file( $fonts ) {}
+	public function remove_font_file( $fonts ) {
+		_deprecated_function( __METHOD__, '6.0', 'GPDFAPI::delete_pdf_font()' );
+	}
 
 	/**
 	 * Check that the font name passed conforms to our expected naming convention
@@ -729,7 +731,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Moved in 6.0. Use Model_Custom_Fonts::check_font_name_valid()
 	 */
-	public function is_font_name_valid( $name ) {}
+	public function is_font_name_valid( $name ) {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Custom_Fonts::check_font_name_valid()' );
+	}
 
 	/**
 	 * Query our custom fonts options table and check if the font name already exists
@@ -741,7 +745,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Removed in 6.0. Font names no longer need to be unique
 	 */
-	public function is_font_name_unique( $name, $id = '' ) {}
+	public function is_font_name_unique( $name, $id = '' ) {
+		_deprecated_function( __METHOD__, '6.0' );
+	}
 
 	/**
 	 * Handles the database updates required to save a new font
@@ -752,7 +758,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Moved in 6.0 to Model_Custom_Fonts::add_font()
 	 */
-	public function install_fonts( $fonts ) {}
+	public function install_fonts( $fonts ) {
+		_deprecated_function( __METHOD__, '6.0', 'Model_Custom_Fonts::add_font()' );
+	}
 
 	/**
 	 * AJAX Endpoint for saving the custom font
@@ -761,7 +769,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Moved in 6.0. Use GPDFAPI::add_pdf_font()
 	 */
-	public function save_font() {}
+	public function save_font() {
+		_deprecated_function( __METHOD__, '6.0', 'GPDFAPI::add_pdf_font()' );
+	}
 
 	/**
 	 * AJAX Endpoint for deleting a custom font
@@ -770,7 +780,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Moved in 6.0. Use GPDFAPI::delete_pdf_font()
 	 */
-	public function delete_font() {}
+	public function delete_font() {
+		_deprecated_function( __METHOD__, '6.0', 'GPDFAPI::delete_pdf_font()' );
+	}
 
 	/**
 	 * Validate user input and save as new font
@@ -781,7 +793,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Removed in 6.0. Use GPDFAPI::add_pdf_font()
 	 */
-	public function process_font( $font ) {}
+	public function process_font( $font ) {
+		_deprecated_function( __METHOD__, '6.0', 'GPDFAPI::add_pdf_font()' );
+	}
 
 	/**
 	 * Find the font unique ID from the font name
@@ -792,7 +806,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Removed in 6.0. Font names no longer linked to IDs.
 	 */
-	public function get_font_id_by_name( $font_name ) {}
+	public function get_font_id_by_name( $font_name ) {
+		_deprecated_function( __METHOD__, '6.0' );
+	}
 
 	/**
 	 * Create a file in our tmp directory and check if it is publicly accessible (i.e no .htaccess protection)
@@ -801,7 +817,9 @@ class Model_Settings extends Helper_Abstract_Model {
 	 *
 	 * @deprecated Functionality removed in 6.0
 	 */
-	public function check_tmp_pdf_security() {}
+	public function check_tmp_pdf_security() {
+		_deprecated_function( __METHOD__, '6.0' );
+	}
 
 	/**
 	 * Create a file in our tmp directory and verify if it's protected from the public
@@ -813,6 +831,8 @@ class Model_Settings extends Helper_Abstract_Model {
 	 * @deprecated Moved in 6.0. Use Model_System_Report::test_public_tmp_directory_access()
 	 */
 	public function test_public_tmp_directory_access() {
+		_deprecated_function( __METHOD__, '6.0', 'Model_System_Report::test_public_tmp_directory_access()' );
+
 		/** @var Model_System_Report $model_system_report */
 		$model_system_report = \GPDFAPI::get_mvc_class( 'Model_System_Report' );
 

--- a/src/Model/Model_Shortcodes.php
+++ b/src/Model/Model_Shortcodes.php
@@ -47,7 +47,7 @@ class Model_Shortcodes extends Helper_Abstract_Pdf_Shortcode {
 	 * @internal Deprecated in 5.2. Use self::process()
 	 */
 	public function gravitypdf( $attributes ) {
-		_doing_it_wrong( __METHOD__, esc_html__( 'This method has been superseded by self::process()', 'gravity-pdf' ), '5.2' );
+		_deprecated_function( __METHOD__, '5.2', 'Model_Shortcodes::process()' );
 
 		return $this->process( $attributes );
 	}

--- a/src/Model/Model_System_Report.php
+++ b/src/Model/Model_System_Report.php
@@ -35,6 +35,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Model_System_Report extends Helper_Abstract_Model {
 
 	/**
+	 * The section each index of the pre-6.17.0 report items array stood for, in order
+	 *
+	 * Frozen — never extend or reorder. These are the four indexes a pre-6.17.0 listener names.
+	 *
+	 * @var array
+	 *
+	 * @since 6.17.0
+	 */
+	private const POSITIONAL_SECTIONS = [ 'php', 'directories', 'global', 'security' ];
+
+	/**
 	 * @var Helper_Abstract_Options
 	 *
 	 * @since 6.0
@@ -187,6 +198,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 	 *
 	 * @return array
 	 * @since 6.0
+	 * @since 6.17.0 Keyed by section name, filtered by `gfpdf_system_status_report_sections`
 	 */
 	protected function get_report_items(): array {
 		$items                  = [];
@@ -343,7 +355,45 @@ class Model_System_Report extends Helper_Abstract_Model {
 			],
 		];
 
-		return apply_filters( 'gfpdf_system_status_report_items', $items );
+		$items = $this->apply_deprecated_report_items_filter( $items );
+
+		return apply_filters( 'gfpdf_system_status_report_sections', $items );
+	}
+
+	/**
+	 * Pass the sections through the positional `gfpdf_system_status_report_items` filter
+	 *
+	 * Deliberately not registered on `Deprecation`: that registry is the v3 layer 7.0 removes, and this filter has
+	 * no removal scheduled.
+	 *
+	 * @param array $items Sections keyed by name
+	 *
+	 * @return array
+	 *
+	 * @since 6.17.0
+	 */
+	protected function apply_deprecated_report_items_filter( array $items ): array {
+		$positional = [];
+
+		/* Only the four a pre-6.17.0 listener knew: numbering the sections added since renumbers these */
+		foreach ( self::POSITIONAL_SECTIONS as $index => $section ) {
+			$positional[ $index ] = $items[ $section ] ?? [];
+		}
+
+		$positional = apply_filters_deprecated(
+			'gfpdf_system_status_report_items',
+			[ $positional ],
+			'6.17.0',
+			'gfpdf_system_status_report_sections',
+			esc_html__( 'The report sections are keyed by name rather than by position.', 'gravity-pdf' )
+		);
+
+		/* Read back off the same indexes, so an index the listener invents has no section to land in */
+		foreach ( self::POSITIONAL_SECTIONS as $index => $section ) {
+			$items[ $section ] = $positional[ $index ] ?? [];
+		}
+
+		return $items;
 	}
 
 	/**

--- a/src/Model/Model_System_Report.php
+++ b/src/Model/Model_System_Report.php
@@ -9,6 +9,8 @@ use GFPDF\Helper\Helper_Abstract_Options;
 use GFPDF\Helper\Helper_Data;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Templates;
+use GFPDF\Statics\Deprecation;
+use GFPDF\View\View_System_Report;
 use GFPDF_Major_Compatibility_Checks;
 use Psr\Log\LoggerInterface;
 
@@ -90,11 +92,19 @@ class Model_System_Report extends Helper_Abstract_Model {
 	 */
 	public function build_gravitypdf_report(): array {
 		$structure = $this->get_report_structure();
-		foreach ( $this->get_report_items() as $index => $report ) {
-			foreach ( $report as $id => $info ) {
-				$structure[0]['tables'][ $index ]['items'][ $id ] = $info;
-			}
+		$items     = $this->get_report_items();
+
+		foreach ( $structure[0]['tables'] as $index => $table ) {
+			$structure[0]['tables'][ $index ]['items'] = $items[ $table['id'] ] ?? [];
 		}
+
+		/* Drop any section with nothing to show, which is how the Deprecated section stays hidden on a clean site */
+		$structure[0]['tables'] = array_filter(
+			$structure[0]['tables'],
+			static function ( $table ) {
+				return ! empty( $table['items'] );
+			}
+		);
 
 		return $structure;
 	}
@@ -106,35 +116,49 @@ class Model_System_Report extends Helper_Abstract_Model {
 	 */
 	public function get_report_structure(): array {
 		$title_export_prefix = 'Gravity PDF - ';
+		$deprecated_tables   = [];
+
+		/* Deprecation decides which groups there are and in what order; the view names them, once, for all three surfaces */
+		foreach ( View_System_Report::get_deprecated_groups() as $group => $names ) {
+			$deprecated_tables[] = [
+				'id'           => $group,
+				'title'        => esc_html( $names['label'] ),
+				'title_export' => $title_export_prefix . $names['label'],
+			];
+		}
+
 		return [
 			[
 				'title'        => esc_html__( 'Gravity PDF Environment', 'gravity-pdf' ),
 				'title_export' => 'Gravity PDF Environment',
-				'tables'       => [
+				'tables'       => array_merge(
+					$deprecated_tables,
 					[
-						'title'        => esc_html__( 'PHP', 'gravity-pdf' ),
-						'title_export' => $title_export_prefix . 'PHP',
-						'items'        => [],
-					],
+						[
+							'id'           => 'php',
+							'title'        => esc_html__( 'PHP', 'gravity-pdf' ),
+							'title_export' => $title_export_prefix . 'PHP',
+						],
 
-					[
-						'title'        => esc_html__( 'Directories and Permissions', 'gravity-pdf' ),
-						'title_export' => $title_export_prefix . 'Directories and Permissions',
-						'items'        => [],
-					],
+						[
+							'id'           => 'directories',
+							'title'        => esc_html__( 'Directories and Permissions', 'gravity-pdf' ),
+							'title_export' => $title_export_prefix . 'Directories and Permissions',
+						],
 
-					[
-						'title'        => esc_html__( 'Global Settings', 'gravity-pdf' ),
-						'title_export' => $title_export_prefix . 'Global Settings',
-						'items'        => [],
-					],
+						[
+							'id'           => 'global',
+							'title'        => esc_html__( 'Global Settings', 'gravity-pdf' ),
+							'title_export' => $title_export_prefix . 'Global Settings',
+						],
 
-					[
-						'title'        => esc_html__( 'Security Settings', 'gravity-pdf' ),
-						'title_export' => $title_export_prefix . 'Security Settings',
-						'items'        => [],
-					],
-				],
+						[
+							'id'           => 'security',
+							'title'        => esc_html__( 'Security Settings', 'gravity-pdf' ),
+							'title_export' => $title_export_prefix . 'Security Settings',
+						],
+					]
+				),
 			],
 		];
 	}
@@ -171,8 +195,13 @@ class Model_System_Report extends Helper_Abstract_Model {
 		$temp_folder_protected  = $this->check_temp_folder_permission();
 		$temp_folder_permission = $this->is_temporary_folder_writable();
 
+		/* Keyed by group, which is what the matching report sections are named after */
+		foreach ( Deprecation::group_signals( Deprecation::refresh_signals() ) as $group => $signals ) {
+			$items[ $group ] = $this->get_deprecated_feature_items( $signals );
+		}
+
 		/* PHP */
-		$items[0] = [
+		$items['php'] = [
 			'memory'            => [
 				'label'        => esc_html__( 'WP Memory', 'gravity-pdf' ),
 				'label_export' => 'WP Memory',
@@ -200,7 +229,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 		];
 
 		/* Directory and Permissions */
-		$items[1] = [
+		$items['directories'] = [
 			'pdf_working_directory'     => [
 				'label'        => esc_html__( 'PDF Working Directory', 'gravity-pdf' ),
 				'label_export' => 'PDF Working Directory',
@@ -246,10 +275,10 @@ class Model_System_Report extends Helper_Abstract_Model {
 			],
 		];
 
-		/* Check if outdated core template overrides and display warning */
+		/* Check for outdated core template overrides and display a warning */
 		$template_status = $this->check_core_template_override_versions();
 		if ( ! empty( $template_status ) ) {
-			$items[1]['outdated_templates'] = [
+			$items['directories']['outdated_templates'] = [
 				'label'        => esc_html__( 'Outdated Templates', 'gravity-pdf' ),
 				'label_export' => 'Outdated Templates',
 				'value'        => $template_status['value'],
@@ -268,7 +297,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 			[ 'a' => [ 'href' => true ] ]
 		);
 
-		$items[2] = [
+		$items['global'] = [
 			'canonical_release'             => [
 				'label'        => esc_html__( 'Canonical Release', 'gravity-pdf' ),
 				'label_export' => 'Canonical Release',
@@ -299,7 +328,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 		];
 
 		/* Security Settings */
-		$items[3] = [
+		$items['security'] = [
 			'user_restrictions'  => [
 				'label'        => esc_html__( 'User Restrictions', 'gravity-pdf' ),
 				'label_export' => 'User Restrictions',
@@ -315,6 +344,27 @@ class Model_System_Report extends Helper_Abstract_Model {
 		];
 
 		return apply_filters( 'gfpdf_system_status_report_items', $items );
+	}
+
+	/**
+	 * Build the rows for one of the deprecation sections
+	 *
+	 * Each row is only included when that feature is actually in use on this site, and the section itself is
+	 * discarded by build_gravitypdf_report() when nothing is detected.
+	 *
+	 * @param array $signals The signals belonging to that section
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_feature_items( array $signals ): array {
+		$view = $this->getController()->view;
+
+		$items = [];
+		foreach ( $signals as $key => $signal ) {
+			$items[ $key ] = $view->get_deprecated_feature_report_item( $key, $signal );
+		}
+
+		return $items;
 	}
 
 	/**
@@ -445,7 +495,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 		foreach ( $templates as $path => $core_version ) {
 			$template = $this->templates->get_template_info_by_id( basename( $path, '.php' ) );
 			if ( version_compare( $core_version, $template['version'], '>' ) ) {
-				$relative_template_path = str_replace( ABSPATH, '/', $template['path'] );
+				$relative_template_path = $this->misc->relative_path( $template['path'], '/' );
 				$message                = $this->getController()->view->get_template_check_message( $relative_template_path, $template['version'], $core_version );
 
 				$value        .= $message['value'];

--- a/src/Model/Model_Templates.php
+++ b/src/Model/Model_Templates.php
@@ -389,7 +389,7 @@ class Model_Templates extends Helper_Abstract_Model {
 			/* Check if we have a valid v4 template header in the file */
 			$info = $this->templates->get_template_info_by_path( $file );
 
-			if ( $info['group'] === esc_html__( 'Legacy', 'gravity-pdf' ) ) {
+			if ( $this->templates->is_legacy_template( $info ) ) {
 				/* Check if it's a v3 template */
 				$fp        = fopen( $file, 'rb' );
 				$file_data = fread( $fp, 8192 );

--- a/src/Model/Model_Uninstall.php
+++ b/src/Model/Model_Uninstall.php
@@ -9,6 +9,7 @@ use GFPDF\Helper\Helper_Form;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Helper\Helper_Pdf_Queue;
+use GFPDF\Statics\Deprecation;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -132,6 +133,7 @@ class Model_Uninstall extends Helper_Abstract_Model {
 		delete_option( 'gfpdf_is_installed' );
 		delete_option( 'gfpdf_current_version' );
 		delete_option( 'gfpdf_settings' );
+		Deprecation::delete_stored_data();
 
 		/* Remove license API data. Deleting one by one, not with a raw DELETE, lets WordPress drop its cached copies */
 		global $wpdb;

--- a/src/Statics/Deprecation.php
+++ b/src/Statics/Deprecation.php
@@ -1,0 +1,450 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Detects and reports the deprecated Gravity PDF functionality a site still relies on
+ *
+ * The functionality itself is described by the providers in self::get_providers(), so each new round of removals is
+ * registered rather than wired in. This class only knows how to detect, group and warn about whatever they declare.
+ *
+ * @since 6.17.0
+ */
+class Deprecation {
+
+	/**
+	 * Functionality that has been removed from Gravity PDF
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const GROUP_UNSUPPORTED = 'unsupported';
+
+	/**
+	 * Functionality that still works, but is scheduled for removal
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const GROUP_DEPRECATED = 'deprecated';
+
+	/**
+	 * Memoised self::get_signals(), keyed by the registry that produced it
+	 *
+	 * @var array<string, array>
+	 * @since 6.17.0
+	 */
+	protected static $signals = [];
+
+	/**
+	 * The classes describing the functionality Gravity PDF is removing
+	 *
+	 * Add a class here to have its features detected and reported everywhere the existing ones are.
+	 *
+	 * @return string[] Helper_Interface_Deprecated_Features implementations
+	 * @since 6.17.0
+	 */
+	protected static function get_providers(): array {
+		return [
+			Deprecation_V3::class,
+		];
+	}
+
+	/**
+	 * Every feature the providers declare, keyed by the ID it is detected and reported under
+	 *
+	 * @return array<string, array> See Helper_Interface_Deprecated_Features::get_features() for the shape of an entry
+	 * @since 6.17.0
+	 */
+	public static function get_features(): array {
+		static $features = [];
+
+		/* Keyed by the registry, since a subclass can declare a different one */
+		$key = static::class;
+
+		if ( ! isset( $features[ $key ] ) ) {
+			$registered = [];
+
+			foreach ( static::get_providers() as $provider ) {
+				$registered += $provider::get_features();
+			}
+
+			$features[ $key ] = $registered;
+		}
+
+		return $features[ $key ];
+	}
+
+	/**
+	 * Get a single feature, or an empty array when nothing is registered under that ID
+	 *
+	 * @param string $key The feature ID
+	 *
+	 * @since 6.17.0
+	 */
+	public static function get_feature( string $key ): array {
+		return static::get_features()[ $key ] ?? [];
+	}
+
+	/**
+	 * Get every signal that deprecated functionality is in use on this site
+	 *
+	 * Features with nothing to report are omitted, so the return value doubles as the list of features in use.
+	 *
+	 * @return array<string, array> Feature ID mapped to what its detector found
+	 * @since 6.17.0
+	 */
+	public static function get_signals(): array {
+		/* Keyed by the registry like self::get_features() */
+		$key = static::class;
+
+		if ( ! isset( static::$signals[ $key ] ) ) {
+			$detected = [];
+
+			foreach ( static::get_features() as $feature_key => $feature ) {
+				$detected[ $feature_key ] = call_user_func( $feature['detect'] );
+			}
+
+			static::$signals[ $key ] = array_filter( $detected );
+		}
+
+		return static::$signals[ $key ];
+	}
+
+	/**
+	 * Forget what the detectors found this request, here and in every provider
+	 *
+	 * The one entry point for invalidating detection, so nothing calling it has to know which class holds what.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function flush_cache(): void {
+		/* Every registry, not just this one: a subclass shares the store, and a caller flushing means all of it */
+		static::$signals = [];
+
+		foreach ( static::get_providers() as $provider ) {
+			$provider::flush_cache();
+		}
+	}
+
+	/**
+	 * The features this site was last found to be using
+	 *
+	 * The admin notices read this rather than detecting for themselves: detection walks the database and the
+	 * template directory, which is far too much to repeat on every admin page a notice can appear on. The record is
+	 * rewritten whenever detection genuinely runs — see self::store_detected_features().
+	 *
+	 * @return array A list of feature IDs
+	 * @since 6.17.0
+	 */
+	public static function get_detected_features(): array {
+		return (array) \GPDFAPI::get_options_class()->get_option( 'deprecated_features', [] );
+	}
+
+	/**
+	 * Record what a run of self::get_signals() found
+	 *
+	 * Called on every version change, which is when a new round of removals arrives, and again by the report and
+	 * Site Health screens, which detect live — so a site that has fixed everything stops being told about it
+	 * without waiting for the next release.
+	 *
+	 * @param array $signals The signals from self::get_signals()
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function store_detected_features( array $signals ): void {
+		$detected = array_keys( $signals );
+
+		if ( $detected !== static::get_detected_features() ) {
+			\GPDFAPI::get_options_class()->update_option( 'deprecated_features', $detected );
+		}
+	}
+
+	/**
+	 * Add a single feature to the record, when something detects it outside of a full detection run
+	 *
+	 * @param string $key The feature ID
+	 *
+	 * @since 6.17.0
+	 */
+	public static function mark_feature_detected( string $key ): void {
+		$detected = static::get_detected_features();
+
+		if ( in_array( $key, $detected, true ) ) {
+			return;
+		}
+
+		$detected[] = $key;
+
+		\GPDFAPI::get_options_class()->update_option( 'deprecated_features', $detected );
+	}
+
+	/**
+	 * Delete everything the providers have stored, so a new provider doesn't have to be added to the uninstaller
+	 *
+	 * The engine's own record needs no handling here: it lives in `gfpdf_settings`, which is deleted wholesale.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function delete_stored_data(): void {
+		foreach ( static::get_providers() as $provider ) {
+			foreach ( $provider::get_stored_options() as $option ) {
+				delete_option( $option );
+			}
+		}
+	}
+
+	/**
+	 * Detect what this site is using, and record it for the admin notices to read
+	 *
+	 * The notices read the record rather than detecting for themselves, so every surface that detects live
+	 * refreshes it as it goes and a site that has fixed everything stops being told about it.
+	 *
+	 * @return array<string, array> See self::get_signals()
+	 * @since 6.17.0
+	 */
+	public static function refresh_signals(): array {
+		$signals = static::get_signals();
+
+		static::store_detected_features( $signals );
+
+		return $signals;
+	}
+
+	/**
+	 * State what becomes of a feature, which is all its group and removal version have to say
+	 *
+	 * Read by every surface that reports the feature, so it says the same thing wherever it is named. The fallback
+	 * names the feature and the release, which suits most of them; one that reads badly out of the context its
+	 * report row gives it declares a `notice` of its own instead.
+	 *
+	 * @param array $feature The feature's registration
+	 *
+	 * @since 6.17.0
+	 */
+	public static function get_feature_notice( array $feature ): string {
+		/* A feature saying it better than the fallback can declares its own sentence */
+		if ( isset( $feature['notice'] ) ) {
+			return sprintf( $feature['notice'], $feature['removed_in'] );
+		}
+
+		if ( $feature['group'] === static::GROUP_UNSUPPORTED ) {
+			/* translators: %s: The name of the deprecated feature */
+			return sprintf( __( '%s is no longer supported.', 'gravity-pdf' ), $feature['label'] );
+		}
+
+		/* translators: 1: The name of the deprecated feature, 2: The Gravity PDF version it is removed in */
+		return sprintf( __( 'Support for %1$s will be removed in Gravity PDF %2$s.', 'gravity-pdf' ), $feature['label'], $feature['removed_in'] );
+	}
+
+	/**
+	 * The groups a registered feature belongs to, in the order they are reported
+	 *
+	 * A group nothing declares is left out, so no surface carries an empty section around until a later round of
+	 * removals has something to put in it.
+	 *
+	 * @return string[]
+	 * @since 6.17.0
+	 */
+	public static function get_groups(): array {
+		$declared = array_column( static::get_features(), 'group' );
+
+		return array_values(
+			array_filter(
+				[ static::GROUP_UNSUPPORTED, static::GROUP_DEPRECATED ],
+				static function ( $group ) use ( $declared ) {
+					return in_array( $group, $declared, true );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Split the detected signals by the group their feature belongs to
+	 *
+	 * @param array $signals The signals from self::get_signals()
+	 *
+	 * @return array<string, array> Group mapped to its signals, with empty groups omitted
+	 * @since 6.17.0
+	 */
+	public static function group_signals( array $signals ): array {
+		$features = static::get_features();
+		$groups   = array_fill_keys( static::get_groups(), [] );
+
+		foreach ( $signals as $key => $signal ) {
+			$groups[ $features[ $key ]['group'] ][ $key ] = $signal;
+		}
+
+		return array_filter( $groups );
+	}
+
+	/**
+	 * Fire one of the deprecated hooks, warning any third party still listening to it
+	 *
+	 * The version and replacement come from whichever registered feature owns the hook, so the notice names the
+	 * release it disappears in. It is only emitted when a listener is actually attached, so sites that have already
+	 * moved on stay quiet.
+	 *
+	 * @param string $hook_name   The deprecated filter to fire
+	 * @param array  $args        The arguments to pass to the filter, the first of which is returned
+	 * @param string $replacement Override the mapped replacement, for dynamic hooks
+	 *
+	 * @return mixed
+	 * @since 6.17.0
+	 */
+	public static function apply_filters( string $hook_name, array $args, string $replacement = '' ) {
+		/* Sidestep building the deprecation message on the vast majority of sites, which have no listener */
+		if ( ! has_filter( $hook_name ) ) {
+			return $args[0];
+		}
+
+		$feature    = static::get_feature_by_hook( $hook_name );
+		$removed_in = $feature['removed_in'] ?? '';
+
+		if ( $replacement === '' ) {
+			$replacement = $feature['hooks'][ $hook_name ] ?? '';
+		}
+
+		static::log_deprecated_filter( $hook_name, $replacement, $removed_in );
+
+		return apply_filters_deprecated(
+			$hook_name,
+			$args,
+			$feature['deprecated_in'] ?? '',
+			$replacement,
+			$removed_in === '' ? '' : sprintf(
+				/* translators: %s: The Gravity PDF version the filter is removed in */
+				esc_html__( 'This filter is removed in Gravity PDF %s.', 'gravity-pdf' ),
+				$removed_in
+			)
+		);
+	}
+
+	/**
+	 * Find the registered feature a deprecated hook belongs to
+	 *
+	 * @param string $hook_name The deprecated hook
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function get_feature_by_hook( string $hook_name ): array {
+		foreach ( static::get_features() as $feature ) {
+			$prefix = $feature['hook_prefix'] ?? '';
+
+			if ( isset( $feature['hooks'][ $hook_name ] ) || ( $prefix !== '' && strpos( $hook_name, $prefix ) === 0 ) ) {
+				return $feature;
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * Record a deprecated hook with a third-party listener in the Gravity PDF log
+	 *
+	 * Written once per hook per request so a PDF that fires the same filter for every field doesn't flood the log.
+	 *
+	 * @param string $hook_name   The deprecated filter being fired
+	 * @param string $replacement The filter to use instead, if one exists
+	 * @param string $removed_in  The Gravity PDF version it is removed in, if it is known
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function log_deprecated_filter( string $hook_name, string $replacement, string $removed_in ): void {
+		static $logged = [];
+
+		if ( isset( $logged[ $hook_name ] ) ) {
+			return;
+		}
+
+		/* Some deprecated hooks fire while the container is still being built, so the logger may not exist yet */
+		$log = \GPDFAPI::get_log_class();
+		if ( $log === null ) {
+			return;
+		}
+
+		$logged[ $hook_name ] = true;
+
+		$log->warning(
+			sprintf(
+				'The %1$s filter has a third-party listener attached%2$s.%3$s',
+				$hook_name,
+				$removed_in !== '' ? sprintf( ' and is removed in Gravity PDF %s', $removed_in ) : '',
+				$replacement !== '' ? sprintf( ' Use the %s filter instead.', $replacement ) : ''
+			)
+		);
+	}
+
+	/**
+	 * Get the deprecated hooks that currently have a third-party listener attached
+	 *
+	 * Walks every registered hook so dynamic ones, like `gfpdfe_pdf_template_{form_id}`, are included too. Only the
+	 * System Report and Site Health screens ask for this, so the walk stays off the paths that matter.
+	 *
+	 * @param array  $hooks            The known hooks, mapped to their replacement
+	 * @param string $prefix           Also match any hook starting with this
+	 * @param array  $ignore_callbacks The callbacks Gravity PDF registers itself, which aren't third party
+	 *
+	 * @return array<string, int> Hook name mapped to the number of listeners
+	 * @since 6.17.0
+	 */
+	public static function get_hooks_with_listeners( array $hooks, string $prefix = '', array $ignore_callbacks = [] ): array {
+		global $wp_filter;
+
+		$active = [];
+
+		foreach ( (array) $wp_filter as $name => $hook ) {
+			$name = (string) $name;
+
+			if ( ! isset( $hooks[ $name ] ) && ( $prefix === '' || strpos( $name, $prefix ) !== 0 ) ) {
+				continue;
+			}
+
+			$count = static::count_third_party_callbacks( $hook, $ignore_callbacks );
+			if ( $count > 0 ) {
+				$active[ $name ] = $count;
+			}
+		}
+
+		ksort( $active );
+
+		return $active;
+	}
+
+	/**
+	 * Count the callbacks on a hook, ignoring the ones Gravity PDF registers itself
+	 *
+	 * @param \WP_Hook $hook
+	 * @param array    $ignore_callbacks
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function count_third_party_callbacks( $hook, array $ignore_callbacks ): int {
+		$count = 0;
+
+		foreach ( $hook->callbacks ?? [] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( in_array( $callback['function'] ?? null, $ignore_callbacks, true ) ) {
+					continue;
+				}
+
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+}

--- a/src/Statics/Deprecation_V3.php
+++ b/src/Statics/Deprecation_V3.php
@@ -1,0 +1,555 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+use GFPDF\Helper\Helper_Interface_Deprecated_Features;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The v3 backwards compatibility layer, which Gravity PDF 7.0 removes
+ *
+ * @since 6.17.0
+ */
+class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
+
+	/**
+	 * The release the v3 backwards compatibility layer is removed in
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const REMOVED_IN = '7.0';
+
+	/**
+	 * The release the v3 backwards compatibility layer was deprecated in
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const DEPRECATED_IN = '4.0';
+
+	/**
+	 * The feature ID legacy download URLs are detected and reported under
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const FEATURE_LEGACY_ENDPOINT = 'legacy_endpoint';
+
+	/**
+	 * The query argument every legacy `?gf_pdf=1` download URL carries
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const LEGACY_URL_MARKER = 'gf_pdf=1';
+
+	/**
+	 * The option the forms that have served a legacy download URL are recorded in
+	 *
+	 * Kept out of `gfpdf_settings` and out of the autoloaded set: it is written from the front end, and only the
+	 * report, Site Health and uninstall paths ever read it.
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const LEGACY_ENDPOINT_OPTION = 'gfpdf_legacy_endpoint_usage';
+
+	/**
+	 * How long a form stays recorded after the last legacy download URL was served for it
+	 *
+	 * @var int
+	 * @since 6.17.0
+	 */
+	const LEGACY_ENDPOINT_TTL = 30 * DAY_IN_SECONDS;
+
+	/**
+	 * How often a form already on the record is written again
+	 *
+	 * @var int
+	 * @since 6.17.0
+	 */
+	const LEGACY_ENDPOINT_REFRESH = DAY_IN_SECONDS;
+
+	/**
+	 * The prefix every v3 hook carries, including the dynamic ones the map below can't name
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const HOOK_PREFIX = 'gfpdfe_';
+
+	/**
+	 * The call every Business Plus (Tier 2) template makes, and no plain v3 template does
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const BUSINESS_PLUS_MARKER = '$mpdf->';
+
+	/**
+	 * The class the v3 "Advanced Templating" (Tier 2) add-on declares
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const TIER_2_ADDON_CLASS = 'gfpdfe_business_plus';
+
+	/**
+	 * The `gfpdfe_pre_load_template` callback core registers itself, which the listener scan must ignore
+	 *
+	 * @var array
+	 * @since 6.17.0
+	 */
+	const INTERNAL_FILTER_CALLBACK = [ 'PDFRender', 'prepare_ids' ];
+
+	/**
+	 * What the legacy template scan found this request, keyed on the installed template list it read
+	 *
+	 * @var array<string, array<string, array<string, int[]>>>
+	 * @since 6.17.0
+	 */
+	protected static $legacy_templates = [];
+
+	/**
+	 * @inheritDoc
+	 * @since 6.17.0
+	 */
+	public static function get_features(): array {
+		return [
+			'legacy_templates'              => [
+				'label'      => __( 'Legacy Templates', 'gravity-pdf' ),
+				'group'      => Deprecation::GROUP_DEPRECATED,
+				'removed_in' => static::REMOVED_IN,
+				'url'        => 'https://docs.gravitypdf.com/upgrade/legacy-templates/',
+				'detect'     => [ static::class, 'get_legacy_templates' ],
+			],
+
+			'business_plus_templates'       => [
+				'label'      => __( 'Business Plus Templates', 'gravity-pdf' ),
+				'group'      => Deprecation::GROUP_DEPRECATED,
+				'removed_in' => static::REMOVED_IN,
+				'url'        => 'https://docs.gravitypdf.com/upgrade/legacy-templates/#business-plus--tier-2-template-upgrade-guide',
+				'detect'     => [ static::class, 'get_business_plus_templates' ],
+			],
+
+			static::FEATURE_LEGACY_ENDPOINT => [
+				'label'      => __( 'Legacy Download URLs', 'gravity-pdf' ),
+				'group'      => Deprecation::GROUP_DEPRECATED,
+				'removed_in' => static::REMOVED_IN,
+				'url'        => 'https://docs.gravitypdf.com/upgrade/legacy-download-urls/',
+				'detect'     => [ static::class, 'get_legacy_download_urls' ],
+				/* translators: %s: The Gravity PDF version the feature is removed in */
+				'notice'     => __( 'Support for legacy download URLs will be removed in Gravity PDF %s.', 'gravity-pdf' ),
+			],
+
+			'deprecated_filters'            => [
+				'label'         => __( 'Actions and Filters', 'gravity-pdf' ),
+				'group'         => Deprecation::GROUP_DEPRECATED,
+				'removed_in'    => static::REMOVED_IN,
+				'url'           => 'https://docs.gravitypdf.com/upgrade/deprecated-filters/',
+				'detect'        => [ static::class, 'get_active_deprecated_filters' ],
+				/* The label is a category, so out of its report row the fallback would read as the whole hook API */
+				/* translators: %s: The Gravity PDF version the hooks are removed in */
+				'notice'        => __( 'Code on this site uses Gravity PDF hooks that are removed in version %s.', 'gravity-pdf' ),
+				'hooks'         => static::get_deprecated_filters(),
+				'deprecated_in' => static::DEPRECATED_IN,
+				'hook_prefix'   => static::HOOK_PREFIX,
+			],
+		];
+	}
+
+	/**
+	 * The deprecated v3 filters still fired by core, mapped to their v4+ replacement
+	 *
+	 * An empty replacement means no equivalent exists.
+	 *
+	 * @return array<string, string>
+	 * @since 6.17.0
+	 */
+	protected static function get_deprecated_filters(): array {
+		return [
+			'gfpdfe_template_location'              => 'gfpdf_template_location',
+			'gfpdfe_template_location_uri'          => 'gfpdf_template_location_uri',
+			'gfpdfe_pdf_output_type'                => '',
+			'gfpdfe_pdf_name'                       => 'gfpdf_pdf_config',
+			'gfpdfe_template'                       => 'gfpdf_pdf_config',
+			'gfpdfe_pdf_filename'                   => 'gfpdf_pdf_filename',
+			'gfpdfe_pdf_template'                   => 'gfpdf_pdf_html_output',
+			'gfpdfe_mpdf_class_pre_render'          => 'gfpdf_mpdf_class',
+			'gfpdfe_pre_render_pdf'                 => 'gfpdf_mpdf_class',
+			'gfpdfe_mpdf_class'                     => 'gfpdf_mpdf_class',
+			'gfpdfe_lead_id'                        => 'gfpdf_template_args',
+			'gfpdfe_signature_width'                => 'gfpdf_signature_width',
+			'gfpdfe_pre_load_template'              => '',
+			'gfpdf_orientation'                     => 'gfpdf_pdf_config',
+			'gfpdf_security'                        => 'gfpdf_pdf_config',
+			'gfpdf_privilages'                      => 'gfpdf_pdf_config',
+			'gfpdf_password'                        => 'gfpdf_pdf_config',
+			'gfpdf_master_password'                 => 'gfpdf_pdf_config',
+			'gfpdf_rtl'                             => 'gfpdf_pdf_config',
+
+			/* Fired by the v3 endpoint and template layers, and removed along with them */
+			'gfpdf_legacy_save_path'                => '',
+			'gfpdf_legacy_templates'                => '',
+			'gfpdf_legacy_pre_view_or_download_pdf' => '',
+		];
+	}
+
+	/**
+	 * Get the deprecated v3 filters that currently have a third-party listener attached
+	 *
+	 * @return array<string, int> Hook name mapped to the number of listeners
+	 * @since 6.17.0
+	 */
+	public static function get_active_deprecated_filters(): array {
+		return Deprecation::get_hooks_with_listeners(
+			static::get_deprecated_filters(),
+			static::HOOK_PREFIX,
+			[ static::INTERNAL_FILTER_CALLBACK ]
+		);
+	}
+
+	/**
+	 * Restore the `RGForms` class the v3 template boilerplate guards on
+	 *
+	 * Gravity Forms declared `RGForms` as an empty subclass of `GFForms`, deprecated it in 2.10.5 and removed it in
+	 * 3.0. Every v3 template opens by checking for it and returning when it's missing, so the PDF renders with no
+	 * content at all — no fatal, and nothing in the log to explain the blank page. Aliasing the class it extended
+	 * puts the check back in the only place it still matters, until 7.0 removes these templates along with it.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function restore_v3_form_class(): void {
+		if ( class_exists( 'RGForms' ) || ! class_exists( 'GFForms' ) ) {
+			return;
+		}
+
+		class_alias( 'GFForms', 'RGForms' );
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 6.17.0
+	 */
+	public static function get_stored_options(): array {
+		return [ static::LEGACY_ENDPOINT_OPTION ];
+	}
+
+	/**
+	 * Get the forms still tied to a legacy `?gf_pdf=1` download URL
+	 *
+	 * Two sources are combined: the forms whose stored settings, confirmations or notifications hand one of these
+	 * URLs out, and the forms one has actually been served for — see self::record_legacy_endpoint_usage(). The scan
+	 * finds a URL nobody has followed yet; the record finds one living somewhere the scan can't see, like a page or
+	 * an email that has already gone out.
+	 *
+	 * @return array List of form IDs, ascending
+	 * @since 6.17.0
+	 */
+	public static function get_legacy_download_urls(): array {
+		global $wpdb;
+
+		$marker = '%' . $wpdb->esc_like( static::LEGACY_URL_MARKER ) . '%';
+
+		/* Recorded IDs are cast on the way in and out, so they're safe to interpolate */
+		$recorded        = static::get_recorded_legacy_endpoint_usage();
+		$recorded_clause = $recorded === [] ? '' : sprintf( 'meta.form_id IN ( %s ) OR', implode( ',', $recorded ) );
+
+		$forms = static::scan_forms(
+			'meta.form_id',
+			"{$recorded_clause} meta.display_meta LIKE %s OR meta.confirmations LIKE %s OR meta.notifications LIKE %s",
+			[ $marker, $marker, $marker ]
+		);
+
+		return array_map( 'intval', array_column( $forms, 'form_id' ) );
+	}
+
+	/**
+	 * Scan the stored forms for one of the signals this class detects
+	 *
+	 * Trashed forms are left out of every scan: the user can't see them in their form list, so there's nothing for
+	 * them to act on.
+	 *
+	 * @param string $columns  The columns to select, from the `meta` and `form` tables the query names below
+	 * @param string $criteria What a form has to match, carrying one `%s` placeholder per entry in $values
+	 * @param array  $values   One value per placeholder in $criteria
+	 *
+	 * @return array<int, array<string, string>> One row per matching form, by form ID ascending
+	 * @since 6.17.0
+	 */
+	protected static function scan_forms( string $columns, string $criteria, array $values ): array {
+		global $wpdb;
+
+		$meta_table = \GFFormsModel::get_meta_table_name();
+		$form_table = \GFFormsModel::get_form_table_name();
+
+		/* The table names come from Gravity Forms, and every caller value travels as a placeholder in $values */
+		//phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders
+		return (array) $wpdb->get_results( //phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT {$columns} FROM {$meta_table} meta
+				INNER JOIN {$form_table} form ON form.id = meta.form_id
+				WHERE form.is_trash = 0 AND ( {$criteria} )
+				ORDER BY meta.form_id",
+				$values
+			),
+			ARRAY_A
+		);
+		//phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders
+	}
+
+	/**
+	 * The forms a legacy `?gf_pdf=1` download URL has actually been served for
+	 *
+	 * A record older than self::LEGACY_ENDPOINT_TTL is dropped as it's read, so a form stops being reported once
+	 * the links pointing at it have gone quiet. Gravity PDF can't tell whether a URL it served last year still
+	 * exists, and without an expiry the form would be reported forever.
+	 *
+	 * @return array List of form IDs, ascending
+	 * @since 6.17.0
+	 */
+	public static function get_recorded_legacy_endpoint_usage(): array {
+		$recorded = array_map( 'intval', static::get_legacy_endpoint_records() );
+		$cutoff   = time() - static::LEGACY_ENDPOINT_TTL;
+
+		ksort( $recorded );
+
+		$current = array_filter(
+			$recorded,
+			function ( $last_served ) use ( $cutoff ) {
+				return $last_served >= $cutoff;
+			}
+		);
+
+		if ( $current !== $recorded ) {
+			update_option( static::LEGACY_ENDPOINT_OPTION, $current, false );
+		}
+
+		return array_map( 'intval', array_keys( $current ) );
+	}
+
+	/**
+	 * The raw record, mapping each form to when a legacy download URL was last served for it
+	 *
+	 * Left in the order it was stored: the front end reads this on every legacy download to check one timestamp,
+	 * and only self::get_recorded_legacy_endpoint_usage() promises an order.
+	 *
+	 * @return array<int, int> Form ID mapped to a Unix timestamp
+	 * @since 6.17.0
+	 */
+	protected static function get_legacy_endpoint_records(): array {
+		return (array) get_option( static::LEGACY_ENDPOINT_OPTION, [] );
+	}
+
+	/**
+	 * Record that a legacy `?gf_pdf=1` download URL has been served for a form
+	 *
+	 * Called by the endpoint itself, once it has resolved the request to a real PDF, so a URL that lives outside the
+	 * form's own settings is still reported. The timestamp is what self::get_recorded_legacy_endpoint_usage() expires
+	 * the form on, so it's refreshed while the links are still being followed — at most once a day, since this runs
+	 * on the front end.
+	 *
+	 * @param int $form_id The form the PDF was served from
+	 *
+	 * @since 6.17.0
+	 */
+	public static function record_legacy_endpoint_usage( int $form_id ): void {
+		$recorded = static::get_legacy_endpoint_records();
+		$now      = time();
+
+		if ( ( $recorded[ $form_id ] ?? 0 ) > $now - static::LEGACY_ENDPOINT_REFRESH ) {
+			return;
+		}
+
+		$recorded[ $form_id ] = $now;
+
+		update_option( static::LEGACY_ENDPOINT_OPTION, $recorded, false );
+
+		/* The notices read a record taken at install and on each version change, which a URL followed since then
+		   won't be in yet */
+		Deprecation::mark_feature_detected( static::FEATURE_LEGACY_ENDPOINT );
+
+		/* This is what the endpoint detector reads, so anything detecting later in the request reads it fresh */
+		Deprecation::flush_cache();
+	}
+
+	/**
+	 * Check if the v3 "Advanced Templating" (Tier 2) add-on is installed
+	 *
+	 * @since 6.17.0
+	 */
+	public static function has_tier_2_addon(): bool {
+		return class_exists( static::TIER_2_ADDON_CLASS );
+	}
+
+	/**
+	 * Check if a PDF is configured to use the v3 Advanced Templating mode
+	 *
+	 * Compared case-insensitively, which is how the render path has always read the setting.
+	 *
+	 * @param array $settings The PDF settings
+	 *
+	 * @since 6.17.0
+	 */
+	public static function is_advanced_template_pdf( array $settings ): bool {
+		return strtolower( (string) ( $settings['advanced_template'] ?? '' ) ) === 'yes';
+	}
+
+	/**
+	 * Get the installed legacy (v3) PDF templates written as plain HTML and CSS
+	 *
+	 * @return array<string, int[]> Absolute template path mapped to the forms it is configured on
+	 * @since 6.17.0
+	 */
+	public static function get_legacy_templates(): array {
+		return static::get_legacy_templates_by_kind()['standard'];
+	}
+
+	/**
+	 * Get the installed legacy (v3) PDF templates that drive the PDF engine themselves
+	 *
+	 * These were built by our own team and sold as Business Plus, or Tier 2, alongside the plugin now reported as
+	 * the Advanced Templating add-on. They upgrade differently to a plain v3 template, so they're reported apart.
+	 *
+	 * @return array<string, int[]> Absolute template path mapped to the forms it is configured on
+	 * @since 6.17.0
+	 */
+	public static function get_business_plus_templates(): array {
+		return static::get_legacy_templates_by_kind()['business_plus'];
+	}
+
+	/**
+	 * Get every installed legacy (v3) PDF template, split by the kind of template it is
+	 *
+	 * A template is classified as legacy when it has no `Group` header, which is how Helper_Templates groups
+	 * v3-era templates that predate the v4 header format. What the file does with the PDF engine then says which
+	 * of the two kinds it is — the PDF's own settings aren't consulted, so a template is reported for what it is
+	 * rather than for how one PDF happens to be configured. Which forms select it is then carried alongside, so a
+	 * report says what actually breaks when the file stops rendering.
+	 *
+	 * @return array<string, array<string, int[]>> The `standard` and `business_plus` templates, each mapped to the
+	 *                                            forms it is configured on
+	 * @since 6.17.0
+	 */
+	protected static function get_legacy_templates_by_kind(): array {
+		$templates = \GPDFAPI::get_templates_class();
+
+		/* Both detectors ask, so the walk, the file reads and the form scan happen once rather than once per
+		   detector. Keyed on the installed template list, which a template being added or removed changes; the
+		   form usage carried alongside it is held for the request, and dropped by self::flush_cache() */
+		$key = implode( '|', $templates->get_all_templates() );
+
+		if ( ! isset( static::$legacy_templates[ $key ] ) ) {
+			$legacy = array_filter( $templates->get_all_template_info(), [ $templates, 'is_legacy_template' ] );
+			$usage  = static::get_forms_using_templates( array_column( $legacy, 'id' ) );
+
+			$kinds = [
+				'standard'      => [],
+				'business_plus' => [],
+			];
+
+			foreach ( $legacy as $template ) {
+				$kind = static::is_business_plus_template( $template['path'] ) ? 'business_plus' : 'standard';
+
+				$kinds[ $kind ][ $template['path'] ] = $usage[ $template['id'] ];
+			}
+
+			static::$legacy_templates[ $key ] = $kinds;
+		}
+
+		return static::$legacy_templates[ $key ];
+	}
+
+	/**
+	 * Forget what the legacy template scan found this request
+	 *
+	 * The scan reads the template directory and the stored forms, and nothing changes either between the two
+	 * detectors asking, so what it finds is held for the request. Anything that does change them while a request
+	 * is still running calls Deprecation::flush_cache(), which is what reaches this.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function flush_cache(): void {
+		static::$legacy_templates = [];
+	}
+
+	/**
+	 * Get the forms each of the given templates is selected on
+	 *
+	 * Trashed forms are skipped, as they are everywhere else here: the user can't see them in their form list, so
+	 * there's nothing to act on. A PDF is counted whether or not it's active, since a disabled one still has to be
+	 * moved off the template before it can be turned back on.
+	 *
+	 * @param string[] $template_ids Template IDs, as Helper_Templates writes them into a PDF's settings
+	 *
+	 * @return array<string, int[]> Template ID mapped to the forms configured with it, ascending
+	 * @since 6.17.0
+	 */
+	protected static function get_forms_using_templates( array $template_ids ): array {
+		global $wpdb;
+
+		if ( $template_ids === [] ) {
+			return [];
+		}
+
+		$usage = array_fill_keys( $template_ids, [] );
+
+		/* A form configured with a template carries its ID somewhere in the stored form, so a LIKE per template
+		   narrows the scan to the rows worth reading — the whole form travels back, and on a site of any size
+		   that is most of what the query costs. Which template each PDF actually selects is a JSON value, so the
+		   decode below is what settles it */
+		$criteria = implode( ' OR ', array_fill( 0, count( $usage ), 'meta.display_meta LIKE %s' ) );
+		$values   = array_map(
+			static function ( $id ) use ( $wpdb ) {
+				return '%' . $wpdb->esc_like( $id ) . '%';
+			},
+			array_keys( $usage )
+		);
+
+		foreach ( static::scan_forms( 'meta.form_id, meta.display_meta', $criteria, $values ) as $form ) {
+			$meta    = json_decode( (string) $form['display_meta'], true );
+			$form_id = (int) $form['form_id'];
+
+			foreach ( (array) ( $meta['gfpdf_form_settings'] ?? [] ) as $pdf ) {
+				$template = (string) ( $pdf['template'] ?? '' );
+
+				/* A form with several PDFs on the one template is still the one form to fix */
+				if ( isset( $usage[ $template ] ) && ! in_array( $form_id, $usage[ $template ], true ) ) {
+					$usage[ $template ][] = $form_id;
+				}
+			}
+		}
+
+		return $usage;
+	}
+
+	/**
+	 * Check whether a legacy template drives the PDF engine itself
+	 *
+	 * Direct access to the engine is the one thing the Advanced Templating add-on gave a template and a plain v3
+	 * template never had, so the call is what tells the two apart.
+	 *
+	 * @param string $path The absolute path to the template file
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function is_business_plus_template( string $path ): bool {
+		//phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$contents = is_readable( $path ) ? (string) file_get_contents( $path ) : '';
+
+		return strpos( $contents, static::BUSINESS_PLUS_MARKER ) !== false;
+	}
+}

--- a/src/View/View_Actions.php
+++ b/src/View/View_Actions.php
@@ -3,6 +3,7 @@
 namespace GFPDF\View;
 
 use GFPDF\Helper\Helper_Abstract_View;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -68,6 +69,40 @@ class View_Actions extends Helper_Abstract_View {
 
 		$html  = $this->load( 'core_font', [], false );
 		$html .= $this->get_action_buttons( $type, $button_text, 'disabled' );
+
+		return $html;
+	}
+
+	/**
+	 * Load the notice for the deprecated functionality the site still uses
+	 *
+	 * One notice lists them all, each named the same way so the list scans. That is deliberately the registration's
+	 * own sentence rather than the tailored copy the report writes per feature: "These hooks will be removed"
+	 * makes sense under a row titled Actions and Filters, and not in a list where nothing else names it. The
+	 * detections are left to the report the button links to, since a notice is read at a glance and the template
+	 * files or form IDs behind a feature can run long.
+	 *
+	 * @param string[] $keys        The feature IDs from Deprecation::get_features()
+	 * @param string   $type        The action ID
+	 * @param string   $button_text The primary button text
+	 *
+	 * @return string The notice HTML
+	 * @since 6.17.0
+	 */
+	public function deprecated_features( array $keys, string $type, string $button_text ): string {
+		$features = [];
+
+		foreach ( $keys as $key ) {
+			$feature = Deprecation::get_feature( $key );
+
+			$features[] = [
+				'notice' => Deprecation::get_feature_notice( $feature ),
+				'url'    => $feature['url'],
+			];
+		}
+
+		$html  = $this->load( 'deprecated_features', [ 'features' => $features ], false );
+		$html .= $this->get_action_buttons( $type, $button_text );
 
 		return $html;
 	}

--- a/src/View/View_PDF.php
+++ b/src/View/View_PDF.php
@@ -19,6 +19,8 @@ use GFPDF\Helper\Helper_Form;
 use GFPDF\Helper\Helper_Misc;
 use GFPDF\Helper\Helper_PDF;
 use GFPDF\Helper\Helper_Templates;
+use GFPDF\Statics\Deprecation;
+use GFPDF\Statics\Deprecation_V3;
 use GFPDF\Statics\Kses;
 use GFPDFEntryDetail;
 use GWConditionalLogicDateFields;
@@ -193,13 +195,13 @@ class View_PDF extends Helper_Abstract_View {
 			$pdf->set_template();
 
 			/* Set display type and allow user to override the behaviour */
-			$settings['pdf_action'] = apply_filters( 'gfpdfe_pdf_output_type', $settings['pdf_action'] ); /* Backwards compat */
+			$settings['pdf_action'] = Deprecation::apply_filters( 'gfpdfe_pdf_output_type', [ $settings['pdf_action'] ] );
 			if ( $settings['pdf_action'] === 'download' ) {
 				$pdf->set_output_type( 'download' );
 			}
 
 			/* Add Backwards compatibility support for our v3 Tier 2 Add-on */
-			if ( isset( $settings['advanced_template'] ) && strtolower( $settings['advanced_template'] ) === 'yes' ) {
+			if ( Deprecation_V3::is_advanced_template_pdf( $settings ) ) {
 
 				/* Check if we should process this document using our legacy system */
 				if ( $model->handle_legacy_tier_2_processing( $pdf, $entry, $settings, $args ) ) {
@@ -534,6 +536,7 @@ class View_PDF extends Helper_Abstract_View {
 	 * @deprecated 6.10.1 Page fields are handled like all other fields, with markup generated using a dedicated Field_Page class
 	 */
 	public function display_page_name( $page, $form, Helper_Field_Container $container ) {
+		_deprecated_function( __METHOD__, '6.10.1', 'GFPDF\Helper\Fields\Field_Page' );
 
 		/* Only display the current page name if it exists */
 		if ( isset( $form['pagination']['pages'][ $page ] ) && strlen( trim( $form['pagination']['pages'][ $page ] ) ) > 0 ) {
@@ -578,16 +581,14 @@ class View_PDF extends Helper_Abstract_View {
 	 * @since 4.0
 	 */
 	public function autoprocess_core_template_options( $html, $form, $entry, $settings ) {
-		/* Prevent core styles loading if a v3 template or using our legacy Tier 2 add-on */
 		$template_info = $this->templates->get_template_info_by_id( $settings['template'] );
-		if (
-			( esc_html__( 'Legacy', 'gravity-pdf' ) !== $template_info['group'] ) &&
-			( empty( $settings['advanced_template'] ) || 'Yes' !== $settings['advanced_template'] )
-		) {
-			$html = $this->get_core_template_styles( $settings, $entry ) . $html;
+
+		/* A v3 template brings its own styles, and the Tier 2 add-on renders the document itself */
+		if ( $this->templates->is_legacy_template( $template_info ) || Deprecation_V3::is_advanced_template_pdf( $settings ) ) {
+			return $html;
 		}
 
-		return $html;
+		return $this->get_core_template_styles( $settings, $entry ) . $html;
 	}
 
 	/**

--- a/src/View/View_Settings.php
+++ b/src/View/View_Settings.php
@@ -137,6 +137,8 @@ class View_Settings extends Helper_Abstract_View {
 	 * @deprecated 6.4
 	 */
 	public function tabs() {
+		_deprecated_function( __METHOD__, '6.4', 'View_Settings::sub_menu()' );
+
 		ob_start();
 		$this->sub_menu();
 

--- a/src/View/View_System_Report.php
+++ b/src/View/View_System_Report.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace GFPDF\View;
 
 use GFPDF\Helper\Helper_Abstract_View;
+use GFPDF\Statics\Deprecation;
 
 /**
  * @package     Gravity PDF
@@ -142,6 +143,366 @@ class View_System_Report extends Helper_Abstract_View {
 	public function get_template_upgrade_message(): string {
 		$learn_more_url = 'https://docs.gravitypdf.com/developers/template-hierarchy';
 
-		return $this->markup_warning . ' <a href="' . $learn_more_url . '">' . esc_html__( 'Learn how to update', 'gravity-pdf' ) . '</a>';
+		return $this->markup_warning . ' <a href="' . esc_url( $learn_more_url ) . '">' . esc_html__( 'Learn how to update', 'gravity-pdf' ) . '</a>';
+	}
+
+	/**
+	 * Describe one of the deprecated features detected on this site
+	 *
+	 * Shared by the Gravity Forms system report and the Site Health test, which present the same detections
+	 * differently.
+	 *
+	 * @param string $key    The signal key from Deprecation::get_signals()
+	 * @param array  $signal The detections recorded for that signal
+	 *
+	 * @return array The `label` this feature is known by, one `lines` entry per detection, plus the `notice` its
+	 *               registration states and the `url` explaining it. A feature may also carry `html`, escaped
+	 *               markup the display surfaces show in place of `lines`. Every other value is unescaped, as one
+	 *               of the three consumers is the Site Health Info tab, which escapes what it's given.
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_feature( string $key, array $signal ): array {
+		$feature      = Deprecation::get_feature( $key );
+		$descriptions = $this->get_deprecated_feature_descriptions();
+
+		$description = isset( $descriptions[ $key ] )
+			? call_user_func( $descriptions[ $key ], $signal, $feature )
+			: $this->get_default_feature_description( $signal );
+
+		/* Whatever the description leaves out, the feature's own registration answers */
+		return $description + [
+			'label'  => $feature['label'],
+			'notice' => Deprecation::get_feature_notice( $feature ),
+			'url'    => $feature['url'],
+		];
+	}
+
+	/**
+	 * The method that describes each feature's detections, keyed by the feature it describes
+	 *
+	 * A feature with no entry here is described generically, so a newly registered one reports something usable
+	 * before it has copy of its own.
+	 *
+	 * @return array<string, callable>
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_feature_descriptions(): array {
+		return [
+			'legacy_templates'        => [ $this, 'get_legacy_templates_feature' ],
+			'business_plus_templates' => [ $this, 'get_legacy_templates_feature' ],
+			'legacy_endpoint'         => [ $this, 'get_legacy_endpoint_feature' ],
+			'deprecated_filters'      => [ $this, 'get_deprecated_filter_feature' ],
+		];
+	}
+
+	/**
+	 * Describe a feature's detections when it carries no copy of its own
+	 *
+	 * @param array $signal The detections recorded for the feature
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_default_feature_description( array $signal ): array {
+		$lines = [];
+
+		/* A detection is named by its key where it has one, as the hooks and the templates are, or is the value
+		   itself. A keyed detection's value is the feature's own business, so it is left to describe it */
+		foreach ( $signal as $key => $detection ) {
+			$lines[] = is_string( $key ) ? $key : (string) $detection;
+		}
+
+		return [ 'lines' => $lines ];
+	}
+
+	/**
+	 * Describe any installed legacy (v3) template file(s), and the forms each is configured on
+	 *
+	 * A template no form selects is named as such rather than left bare, so the reader isn't left deciding whether
+	 * the forms were checked or simply not listed.
+	 *
+	 * @param array $templates Absolute template path mapped to the forms it is configured on
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_legacy_templates_feature( array $templates ): array {
+		$lines = [];
+		$html  = [];
+
+		foreach ( $templates as $path => $form_ids ) {
+			/* Templates live in one directory the report states of its own, so the file name is enough to find them */
+			$name = basename( $path );
+
+			if ( $form_ids === [] ) {
+				/* translators: %1$s: The template file name */
+				$format = __( '%1$s (not configured on a form)', 'gravity-pdf' );
+			} else {
+				/* translators: 1: The template file name, 2: Comma separated list of form IDs */
+				$format = _n( '%1$s (form ID %2$s)', '%1$s (form IDs %2$s)', count( $form_ids ), 'gravity-pdf' );
+			}
+
+			/* One format, applied twice: the surfaces taking the plain text get the IDs, the ones taking markup
+			   get them linked. The unused sentence names no forms and ignores the second argument */
+			$lines[] = sprintf( $format, $name, implode( ', ', $form_ids ) );
+			$html[]  = sprintf( esc_html( $format ), esc_html( $name ), implode( ', ', $this->get_form_settings_links( $form_ids ) ) );
+		}
+
+		return [
+			'lines' => $lines,
+			/* Every display surface links to the PDF settings of each form, which is where the template is changed */
+			'html'  => implode( ', ', $html ),
+		];
+	}
+
+	/**
+	 * Describe the forms that still hand out a legacy `?gf_pdf=1` download URL
+	 *
+	 * @param array $form_ids The forms the URLs were found on
+	 * @param array $feature  The feature's registration
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_legacy_endpoint_feature( array $form_ids, array $feature ): array {
+		/* translators: %s: Comma separated list of form IDs */
+		$in_use = __( 'In use on form ID %s', 'gravity-pdf' );
+
+		return [
+			'lines' => [ sprintf( $in_use, implode( ', ', $form_ids ) ) ],
+			/* Every display surface links to the PDF settings of each form, which is where the URLs are replaced */
+			'html'  => sprintf( esc_html( $in_use ), implode( ', ', $this->get_form_settings_links( $form_ids ) ) ),
+		];
+	}
+
+	/**
+	 * Link each form to its Gravity PDF settings, which is where what was detected on it is changed
+	 *
+	 * @param array $form_ids The forms to link
+	 *
+	 * @return string[] One escaped link per form, in the order given
+	 * @since 6.17.0
+	 */
+	protected function get_form_settings_links( array $form_ids ): array {
+		return array_map(
+			static function ( $form_id ) {
+				$url = admin_url( sprintf( 'admin.php?page=gf_edit_forms&view=settings&subview=PDF&id=%d', $form_id ) );
+
+				return '<a href="' . esc_url( $url ) . '">' . (int) $form_id . '</a>';
+			},
+			$form_ids
+		);
+	}
+
+	/**
+	 * Describe the deprecated v3 filters that have a third-party listener attached
+	 *
+	 * @param array $filters Hook name mapped to the number of listeners
+	 * @param array $feature The feature's registration
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_filter_feature( array $filters, array $feature ): array {
+		$lines = [];
+
+		foreach ( $filters as $name => $count ) {
+			$lines[] = sprintf(
+				/* translators: 1: Filter name, 2: Number of callbacks attached to it */
+				_n( '%1$s has %2$d listener', '%1$s has %2$d listeners', $count, 'gravity-pdf' ),
+				$name,
+				$count
+			);
+		}
+
+		return [ 'lines' => $lines ];
+	}
+
+	/**
+	 * Assemble the Gravity Forms system report row for a detected feature
+	 *
+	 * The report keeps a row to a single line, so a feature offering a terser set of detections is listed by that
+	 * instead of the whole story the Site Health screens tell.
+	 *
+	 * @param string $key    The signal key from Deprecation::get_signals()
+	 * @param array  $signal The detections recorded for that signal
+	 *
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_feature_report_item( string $key, array $signal ): array {
+		$feature = $this->get_deprecated_feature( $key, $signal );
+
+		/* Every row is handed over as a failure, so Gravity Forms draws the cross and the red message itself */
+		return [ 'is_valid' => false ] + $this->get_deprecated_feature_values( $feature, $feature['lines'] );
+	}
+
+	/**
+	 * Assemble the Site Health account of a detected feature
+	 *
+	 * Both Site Health screens have room for every detection, so they list them in full: the test takes the escaped
+	 * values and the Info tab the `_export` ones.
+	 *
+	 * @param string $key    The signal key from Deprecation::get_signals()
+	 * @param array  $signal The detections recorded for that signal
+	 *
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_feature_detail( string $key, array $signal ): array {
+		$feature = $this->get_deprecated_feature( $key, $signal );
+
+		return $this->get_deprecated_feature_values( $feature, $feature['lines'] );
+	}
+
+	/**
+	 * Assemble the display and export values a surface shows for a detected feature
+	 *
+	 * @param array $feature The feature, from self::get_deprecated_feature()
+	 * @param array $lines   The detections the surface has room to list
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_deprecated_feature_values( array $feature, array $lines ): array {
+		$value = implode( ', ', $lines );
+
+		return [
+			'label'                     => esc_html( $feature['label'] ),
+			'label_export'              => $feature['label'],
+			'value'                     => $feature['html'] ?? esc_html( $value ),
+			'value_export'              => $value,
+			'validation_message'        => $this->get_removal_message( $feature['notice'], $feature['url'] ),
+			'validation_message_export' => $feature['notice'] . ' ' . $feature['url'],
+		];
+	}
+
+	/**
+	 * The name each group is known by, and what belonging to it means
+	 *
+	 * Both Site Health screens show the description; the system report has no room for it and titles its sections
+	 * with the name alone. Deprecation::get_groups() decides which of them a surface sees.
+	 *
+	 * @return array<string, array<string, string>>
+	 * @since 6.17.0
+	 */
+	public static function get_deprecated_groups(): array {
+		$names = [
+			Deprecation::GROUP_UNSUPPORTED => [
+				'label'       => __( 'Unsupported', 'gravity-pdf' ),
+				'description' => __( 'These features have been removed and any Gravity PDF document that relied on them will stop working.', 'gravity-pdf' ),
+			],
+
+			Deprecation::GROUP_DEPRECATED  => [
+				'label'       => __( 'Deprecated', 'gravity-pdf' ),
+				'description' => __( "Legacy functionality that will be removed in an upcoming release. It's important to fix each item to keep your PDFs working correctly.", 'gravity-pdf' ),
+			],
+		];
+
+		return array_intersect_key( $names, array_flip( Deprecation::get_groups() ) );
+	}
+
+	/**
+	 * Build the Site Health test result for the deprecated features detected on this site
+	 *
+	 * Unlike the one-time admin notice, this surface can't be dismissed: it clears itself once the site stops
+	 * using the deprecated functionality, and returns if it starts again.
+	 *
+	 * @param array $signals The signals from Deprecation::get_signals()
+	 *
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_features_test( array $signals ): array {
+		/* One result covers every round of removals at once, so it names no version: each item below names its own */
+		$result = [
+			'label'       => esc_html__( 'Your PDFs are ready for the next Gravity PDF release', 'gravity-pdf' ),
+			'status'      => 'good',
+			'badge'       => [
+				'label' => esc_html__( 'Gravity PDF', 'gravity-pdf' ),
+				'color' => 'blue',
+			],
+			'description' => '<p>' . esc_html__( 'Nothing on this site relies on Gravity PDF functionality that is scheduled for removal, so there is nothing to do.', 'gravity-pdf' ) . '</p>',
+			'actions'     => '',
+			'test'        => 'gravity_pdf_deprecated_features',
+		];
+
+		if ( $signals === [] ) {
+			return $result;
+		}
+
+		$result['status'] = 'recommended';
+		$result['label']  = esc_html__( 'Your site uses Gravity PDF functionality that is scheduled for removal', 'gravity-pdf' );
+
+		$result['description'] = '<p>' . esc_html__( 'Update each item below before the release that removes it, so the PDFs that rely on it will continue working. Each one links to instructions to upgrade.', 'gravity-pdf' ) . '</p>';
+
+		$groups = static::get_deprecated_groups();
+		foreach ( Deprecation::group_signals( $signals ) as $group => $group_signals ) {
+			$result['description'] .= '<h4>' . esc_html( $groups[ $group ]['label'] ) . '</h4>';
+			$result['description'] .= '<p>' . esc_html( $groups[ $group ]['description'] ) . '</p>';
+
+			foreach ( $group_signals as $key => $signal ) {
+				$message = $this->get_deprecated_feature_detail( $key, $signal );
+
+				$result['description'] .= '<p><strong>' . $message['label'] . '</strong><br>' .
+					$message['value'] . '. ' . $message['validation_message'] . '</p>';
+			}
+		}
+
+		$result['actions'] = '<p><a href="' . esc_url( admin_url( 'admin.php?page=gf_system_status' ) ) . '">' . esc_html__( 'View the Gravity Forms system report', 'gravity-pdf' ) . '</a></p>';
+
+		return $result;
+	}
+
+	/**
+	 * Prepare the advice Gravity Forms shows after a deprecated feature's detections
+	 *
+	 * @param string $notice What happens to the feature
+	 * @param string $url    Where to read more about that action
+	 *
+	 * @since 6.17.0
+	 */
+	protected function get_removal_message( string $notice, string $url ): string {
+		return esc_html( $notice ) . ' <a href="' . esc_url( $url ) . '">' . esc_html__( 'Learn how to upgrade', 'gravity-pdf' ) . '</a>';
+	}
+
+	/**
+	 * Build the Site Health Info tab sections for the features detected on this site
+	 *
+	 * This is the tab users copy into a support ticket, so a section is present whether or not its group has
+	 * anything to report: an empty one says so, rather than leaving the reader to guess whether the check ran.
+	 * They report what the system report exports, which keeps the two plain-text surfaces reading the same by
+	 * construction.
+	 *
+	 * @param array $signals The signals from Deprecation::get_signals()
+	 *
+	 * @return array One Site Health Info section per group, keyed by the ID it is registered under
+	 * @since 6.17.0
+	 */
+	public function get_deprecated_debug_information( array $signals ): array {
+		$grouped  = Deprecation::group_signals( $signals );
+		$sections = [];
+
+		foreach ( static::get_deprecated_groups() as $group => $names ) {
+			$fields = [];
+
+			foreach ( $grouped[ $group ] ?? [] as $key => $signal ) {
+				$message = $this->get_deprecated_feature_detail( $key, $signal );
+
+				$fields[ $key ] = [
+					'label' => $message['label_export'],
+					'value' => $message['value_export'] . '. ' . $message['validation_message_export'],
+				];
+			}
+
+			if ( $fields === [] ) {
+				$fields[ $group ] = [
+					/* translators: %s: The group name, as get_deprecated_groups() gives it */
+					'label' => sprintf( __( '%s functionality', 'gravity-pdf' ), $names['label'] ),
+					'value' => __( 'None detected', 'gravity-pdf' ),
+				];
+			}
+
+			$sections[ 'gravity-pdf-' . $group ] = [
+				/* translators: %s: The group name, as get_deprecated_groups() gives it */
+				'label'       => sprintf( __( 'Gravity PDF - %s Functionality', 'gravity-pdf' ), $names['label'] ),
+				'description' => esc_html( $names['description'] ),
+				'fields'      => $fields,
+			];
+		}
+
+		return $sections;
 	}
 }

--- a/src/View/html/Actions/deprecated_features.php
+++ b/src/View/html/Actions/deprecated_features.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * The Deprecated Features Notice
+ *
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       6.17.0
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** @var $args array */
+
+?>
+
+<div style="font-size:15px; line-height: 25px" role="alert" aria-live="polite">
+
+	<strong>
+		<?php esc_html_e( 'This site uses deprecated Gravity PDF functionality:', 'gravity-pdf' ); ?>
+	</strong>
+
+	<ul style="list-style: disc; margin: 0.5em 0 0.5em 2em">
+		<?php foreach ( $args['features'] as $feature ) : ?>
+			<li>
+				<?php echo esc_html( $feature['notice'] ); ?>
+				<a href="<?php echo esc_url( $feature['url'] ); ?>"><?php esc_html_e( 'Learn how to upgrade', 'gravity-pdf' ); ?></a>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+
+	<?php esc_html_e( 'Dismissing this notice hides the items above. Anything found later is reported again.', 'gravity-pdf' ); ?>
+</div>

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -130,7 +130,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 * @since 4.0
 	 */
 	public function __call( $name, $arguments ) {
-		_doing_it_wrong( esc_html( $name ), esc_html( sprintf( __( '"%s" has been deprecated as of Gravity PDF 4.0', 'gravity-pdf' ), $name ) ), '4.0' );
+		_deprecated_function( esc_html( $name ), '4.0' );
 	}
 
 	/**
@@ -142,7 +142,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	 * @since  4.0
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		_doing_it_wrong( esc_html( $name ), esc_html( sprintf( __( '"%s" has been deprecated as of Gravity PDF 4.0', 'gravity-pdf' ), $name ) ), '4.0' );
+		_deprecated_function( esc_html( $name ), '4.0' );
 	}
 
 	/**
@@ -873,7 +873,7 @@ class Router implements Helper\Helper_Interface_Actions, Helper\Helper_Interface
 	public function check_system_status() {
 		$view  = new View\View_System_Report();
 		$model = new Model\Model_System_Report( $this->options, $this->data, $this->log, $this->misc, new GFPDF_Major_Compatibility_Checks(), $this->templates );
-		$class = new Controller\Controller_System_Report( $model, $view );
+		$class = new Controller\Controller_System_Report( $model, $view, $this->gform );
 		$class->init();
 
 		$this->singleton->add_class( $class );

--- a/src/deprecated.php
+++ b/src/deprecated.php
@@ -42,7 +42,7 @@ abstract class GFPDF_Deprecated_Abstract {
 	 *
 	 */
 	public function __call( $name, $arguments ) {
-		_doing_it_wrong( esc_html( $name ), esc_html( sprintf( __( '"%s" has been deprecated as of Gravity PDF 4.0', 'gravity-pdf' ), $name ) ), '4.0' );
+		_deprecated_function( esc_html( static::class . '::' . $name ), '4.0' );
 	}
 
 	/**
@@ -55,7 +55,7 @@ abstract class GFPDF_Deprecated_Abstract {
 	 *
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		_doing_it_wrong( esc_html( $name ), esc_html( sprintf( __( '"%s" has been deprecated as of Gravity PDF 4.0', 'gravity-pdf' ), $name ) ), '4.0' );
+		_deprecated_function( esc_html( static::class . '::' . $name ), '4.0' );
 	}
 }
 
@@ -130,6 +130,7 @@ class PDFRender extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public function savePDF( $raw_pdf_string, $filename, $id ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::create_pdf()' );
 
 		/* create our path */
 		$path = apply_filters( 'gfpdf_legacy_save_path', PDF_SAVE_LOCATION . $id . '/', $filename, $id );
@@ -166,6 +167,7 @@ class PDFRender extends GFPDF_Deprecated_Abstract {
 	 *
 	 */
 	public static function prepare_ids( $form_id, $lead_id, $template, $id, $output, $filename, $arguments, $args ) {
+		/* No deprecation notice — core registers this callback itself on `gfpdfe_pre_load_template` */
 		global $lead_ids;
 		$lead_ids = $args['lead_ids'];
 
@@ -188,6 +190,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 4.0
 	 */
 	public static function get_ids() {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		global $form_id, $lead_id, $lead_ids;
 
 		$form_id  = ! empty( (int) $form_id ) ? (int) $form_id : (int) rgget( 'fid' );
@@ -209,6 +213,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function get_upload_dir() {
+		_deprecated_function( __METHOD__, '4.0', 'Helper_Misc::get_upload_details()' );
+
 		$misc = GPDFAPI::get_misc_class();
 
 		return $misc->get_upload_details();
@@ -226,6 +232,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function do_mergetags( $text, $form_id, $lead_id ) {
+		_deprecated_function( __METHOD__, '4.0', 'Helper_Form::process_tags()' );
+
 		$gform = GPDFAPI::get_form_class();
 
 		return $gform->process_tags( $text, $gform->get_form( $form_id ), $gform->get_entry( $lead_id ) );
@@ -239,6 +247,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 4.0
 	 */
 	public static function view_data( $form_data ) {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		$pdf_view = \GPDFAPI::get_pdf_class();
 		$pdf_view->maybe_view_form_data( $form_data );
 	}
@@ -253,6 +263,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function post( $name ) {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		/* phpcs:ignore WordPress.Security.NonceVerification.Missing */
 		if ( isset( $_POST[ $name ] ) ) {
 			/* phpcs:ignore WordPress.Security.NonceVerification.Missing */
@@ -272,6 +284,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function get( $name ) {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		/* phpcs:ignore WordPress.Security.NonceVerification.Recommended */
 		if ( isset( $_GET[ $name ] ) ) {
 			/* phpcs:ignore WordPress.Security.NonceVerification.Recommended */
@@ -292,6 +306,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function get_pdf_filename( $form_id, $lead_id ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::get_pdf_filename()' );
+
 		return "form-$form_id-entry-$lead_id.pdf";
 	}
 
@@ -305,6 +321,8 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 4.0
 	 */
 	public static function remove_invalid_characters( $name ) {
+		_deprecated_function( __METHOD__, '4.0', 'Helper_Misc::strip_invalid_characters()' );
+
 		$misc = GPDFAPI::get_misc_class();
 
 		return $misc->strip_invalid_characters( $name );
@@ -316,6 +334,7 @@ class PDF_Common extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function setup_ids() {
+		_deprecated_function( __METHOD__, '4.0' );
 	}
 }
 
@@ -342,6 +361,8 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function lead_detail_grid( $form, $lead, $allow_display_empty_fields = false, $show_html = false, $show_page_name = false, $should_return = false ) {
+		_deprecated_function( __METHOD__, '4.0' );
+
 		$config = [
 			'meta' => [
 				'empty_field' => $allow_display_empty_fields,
@@ -367,6 +388,7 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.7
 	 */
 	public static function do_lead_detail_grid( $form, $lead, $config = [] ) {
+		_deprecated_function( __METHOD__, '4.0' );
 
 		/* Convert old config values to our new ones */
 		if ( ! isset( $config['meta'] ) ) {
@@ -614,6 +636,8 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function lead_detail_grid_array( $form, $lead ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::get_form_data()' );
+
 		$model = GPDFAPI::get_pdf_class( 'model' );
 
 		return $model->get_form_data( $lead );
@@ -630,6 +654,8 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function product_table( $form, $lead ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::product_table()' );
+
 		GPDFAPI::product_table( $lead );
 	}
 
@@ -645,6 +671,8 @@ class GFPDFEntryDetail extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function get_likert( $form, $lead, $field_id ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::likert_table()' );
+
 		return GPDFAPI::likert_table( $lead, $field_id, true );
 	}
 }
@@ -680,6 +708,8 @@ class GFPDF_Core_Model extends GFPDF_Deprecated_Abstract {
 	 * @since 3.0
 	 */
 	public static function gfpdfe_save_pdf( $entry, $form ) {
+		_deprecated_function( __METHOD__, '4.0', 'GPDFAPI::create_pdf()' );
+
 		$pdfs = GPDFAPI::get_form_pdfs( $form['id'] );
 
 		if ( ! is_wp_error( $pdfs ) ) {
@@ -734,6 +764,7 @@ if ( ! class_exists( 'mPDF' ) ) {
 		 * @since 5.0
 		 */
 		public function __construct( $mode = '', $format = 'A4', $default_font_size = 0, $default_font = '', $mgl = 15, $mgr = 15, $mgt = 16, $mgb = 16, $mgh = 9, $mgf = 9, $orientation = 'P' ) {
+			_deprecated_function( 'mPDF::__construct', '5.0', 'GFPDF\Helper\Mpdf\Mpdf' );
 
 			$data                = GPDFAPI::get_data_class();
 			$default_font_config = ( new FontVariables() )->getDefaults();

--- a/tests/phpunit/Concerns/CreatesLegacyDownloadUrls.php
+++ b/tests/phpunit/Concerns/CreatesLegacyDownloadUrls.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GFPDF\Tests\Concerns;
+
+/**
+ * Creates forms that still hand out a v3 `?gf_pdf=1` PDF download URL, which Deprecation detects.
+ */
+trait CreatesLegacyDownloadUrls {
+
+	use UsesFactory;
+
+	/**
+	 * Create a form carrying a legacy download URL in `$location`
+	 *
+	 * Gravity Forms stores the form, its confirmations and its notifications in three separate columns, each of
+	 * which the detector has to search.
+	 *
+	 * @param string $location One of `form`, `confirmations` or `notifications`
+	 * @param string $marker   The query argument the URL carries, so a near miss can be set up too
+	 *
+	 * @return int The new form's ID
+	 */
+	protected function create_form_with_legacy_url( string $location = 'confirmations', string $marker = 'gf_pdf=1' ): int {
+		$form = \GFAPI::get_form( $this->gf_factory()->form->create() );
+		$link = sprintf( '<a href="/?%s&fid=%d&lid=1&template=zadani.php">Download</a>', $marker, $form['id'] );
+
+		switch ( $location ) {
+			case 'confirmations':
+				$form['confirmations'] = [
+					[
+						'id'      => 'abc123',
+						'name'    => 'Default Confirmation',
+						'type'    => 'message',
+						'message' => $link,
+					],
+				];
+				break;
+
+			case 'notifications':
+				$form['notifications'] = [
+					[
+						'id'      => 'def456',
+						'name'    => 'Admin Notification',
+						'to'      => 'admin@example.org',
+						'subject' => 'New submission',
+						'message' => $link,
+					],
+				];
+				break;
+
+			default:
+				$form['description'] = $link;
+		}
+
+		\GFAPI::update_form( $form );
+
+		/* Deprecation holds what its detectors found for the request, and this is one of the things they read */
+		\GFPDF\Statics\Deprecation::flush_cache();
+
+		return (int) $form['id'];
+	}
+}

--- a/tests/phpunit/Concerns/CreatesLegacyTemplates.php
+++ b/tests/phpunit/Concerns/CreatesLegacyTemplates.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GFPDF\Tests\Concerns;
+
+/**
+ * Installs v3 PDF templates in the working directory, which Deprecation detects.
+ */
+trait CreatesLegacyTemplates {
+
+	use UsesFactory;
+
+	/**
+	 * Write a v3 template, which is one carrying no file headers, and return its path
+	 *
+	 * A body calling `$mpdf->` is what makes it a Business Plus (Tier 2) template rather than a plain one.
+	 *
+	 * @param string $name The file to write into the PDF working directory
+	 * @param string $body PHP appended after the v3 boilerplate
+	 *
+	 * @return string The new template's absolute path
+	 */
+	protected function create_legacy_template( string $name = 'my-legacy-template.php', string $body = '' ): string {
+		$path = \GPDFAPI::get_data_class()->template_location . $name;
+
+		file_put_contents( $path, '<?php if ( ! class_exists( "RGForms" ) ) { return; } ' . $body );
+
+		/* the template list is memoized per request by GFCache, and what Deprecation read off it by the detector */
+		\GFCache::flush();
+		\GFPDF\Statics\Deprecation::flush_cache();
+
+		return $path;
+	}
+
+	/**
+	 * Create a form with one PDF set to render through the v3 Advanced Templating mode
+	 *
+	 * The setting is not a detection signal — the template file is — so this exists to prove it isn't one.
+	 *
+	 * @return int The new form's ID
+	 */
+	protected function create_form_with_advanced_templating(): int {
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'advanced_template' => 'Yes' ] );
+
+		return $form_id;
+	}
+
+	/**
+	 * Delete templates written by self::create_legacy_template(), so later tests don't read them
+	 *
+	 * @param string ...$paths
+	 */
+	protected function delete_legacy_templates( string ...$paths ): void {
+		foreach ( $paths as $path ) {
+			@unlink( $path );
+		}
+
+		\GFCache::flush();
+		\GFPDF\Statics\Deprecation::flush_cache();
+	}
+}

--- a/tests/phpunit/Concerns/ResetsDetectedFeatures.php
+++ b/tests/phpunit/Concerns/ResetsDetectedFeatures.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GFPDF\Tests\Concerns;
+
+/**
+ * Clears the deprecation records a test writes, for the classes that write them.
+ */
+trait ResetsDetectedFeatures {
+
+	/**
+	 * Reset what Deprecation and the notices read
+	 *
+	 * Helper_Abstract_Options keeps `gfpdf_settings` in memory, and the WP test transaction rolls the database
+	 * back without touching that copy — so a record written by one test is still readable in the next.
+	 */
+	protected function reset_detected_features(): void {
+		$options = \GPDFAPI::get_options_class();
+
+		$options->update_option( 'deprecated_features', [] );
+		$options->update_option( 'action_dismissal', [] );
+	}
+}

--- a/tests/phpunit/Concerns/UsesFactory.php
+++ b/tests/phpunit/Concerns/UsesFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GFPDF\Tests\Concerns;
+
+/**
+ * Shares one Gravity Forms factory across the tests in a class.
+ */
+trait UsesFactory {
+
+	/**
+	 * @var \GF_UnitTest_Factory
+	 */
+	protected $gf_factory;
+
+	protected function gf_factory(): \GF_UnitTest_Factory {
+		return $this->gf_factory ?? ( $this->gf_factory = new \GF_UnitTest_Factory() );
+	}
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -80,6 +80,9 @@ class GravityPDF_Unit_Tests_Bootstrap {
 
 		/* Load Mocks */
 		$this->mocks();
+
+		/* Load shared test traits */
+		$this->concerns();
 	}
 
 	/**
@@ -89,6 +92,32 @@ class GravityPDF_Unit_Tests_Bootstrap {
 	 */
 	public function mocks() {
 		require_once 'unit-tests/Mocks/zapier-mock.php';
+	}
+
+	/**
+	 * Autoload the traits shared between test classes
+	 *
+	 * @since 6.17
+	 */
+	public function concerns() {
+		$dir = $this->tests_dir . '/Concerns/';
+
+		/* autoloaded rather than required in a batch, since these traits compose each other */
+		spl_autoload_register(
+			function( $class ) use ( $dir ) {
+				$prefix = 'GFPDF\\Tests\\Concerns\\';
+
+				if ( strpos( $class, $prefix ) !== 0 ) {
+					return;
+				}
+
+				$file = $dir . strtr( substr( $class, strlen( $prefix ) ), '\\', '/' ) . '.php';
+
+				if ( file_exists( $file ) ) {
+					require_once $file;
+				}
+			}
+		);
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_System_Report.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_System_Report.php
@@ -2,6 +2,7 @@
 
 namespace GFPDF\Controller;
 
+use GFPDF\Statics\Deprecation;
 use WP_UnitTestCase;
 
 /**
@@ -20,46 +21,50 @@ use WP_UnitTestCase;
  */
 class Test_Controller_System_Report extends WP_UnitTestCase {
 
-	/**
-	 * @dataProvider data_gfpdf_system_status_items_php
-	 */
-	public function test_system_report_php( $table_index, $key ) {
-		$system_report = apply_filters( 'gform_system_report', [] );
-		$this->assertArrayHasKey( $key, $system_report[0]['tables'][ $table_index ]['items'] );
+	public function set_up(): void {
+		parent::set_up();
 
-		/* Test that our data is spliced into the correct location in the array */
-		$system_report = apply_filters( 'gform_system_report', [ [] ] );
-		$this->assertArrayHasKey( $key, $system_report[1]['tables'][ $table_index ]['items'] );
+		/* Deprecation holds its detections for the request; a test process is many requests' worth of site state */
+		Deprecation::flush_cache();
 	}
 
-	public function data_gfpdf_system_status_items_php() {
-		return [
-			[ 0, 'memory' ],
-			[ 0, 'allow_url_fopen' ],
-			[ 0, 'default_charset' ],
-			[ 0, 'internal_encoding' ],
+	public function test_system_report_php() {
+		$system_report = apply_filters( 'gform_system_report', [ [] ] );
 
-			[ 1, 'pdf_working_directory' ],
-			[ 1, 'pdf_working_directory_url' ],
-			[ 1, 'font_folder_location' ],
-			[ 1, 'temp_folder_location' ],
-			[ 1, 'temp_folder_permission' ],
-			[ 1, 'temp_folder_protected' ],
-			[ 1, 'mpdf_temp_folder_location' ],
+		/* Seeded with an existing section, which our report is appended after rather than replacing */
+		$this->assertCount( 2, $system_report );
+		$this->assertSame( [], $system_report[0] );
 
-			[ 2, 'pdf_entry_list_action' ],
-			[ 2, 'background_processing_enabled' ],
-			[ 2, 'debug_mode_enabled' ],
+		$php         = $this->get_report_section( 'php', $system_report );
+		$directories = $this->get_report_section( 'directories', $system_report );
+		$global      = $this->get_report_section( 'global', $system_report );
+		$security    = $this->get_report_section( 'security', $system_report );
 
-			[ 3, 'user_restrictions' ],
-			[ 3, 'logged_out_timeout' ],
-		];
+		$this->assertArrayHasKey( 'memory', $php );
+		$this->assertArrayHasKey( 'allow_url_fopen', $php );
+		$this->assertArrayHasKey( 'default_charset', $php );
+		$this->assertArrayHasKey( 'internal_encoding', $php );
+
+		$this->assertArrayHasKey( 'pdf_working_directory', $directories );
+		$this->assertArrayHasKey( 'pdf_working_directory_url', $directories );
+		$this->assertArrayHasKey( 'font_folder_location', $directories );
+		$this->assertArrayHasKey( 'temp_folder_location', $directories );
+		$this->assertArrayHasKey( 'temp_folder_permission', $directories );
+		$this->assertArrayHasKey( 'temp_folder_protected', $directories );
+		$this->assertArrayHasKey( 'mpdf_temp_folder_location', $directories );
+
+		$this->assertArrayHasKey( 'pdf_entry_list_action', $global );
+		$this->assertArrayHasKey( 'background_processing_enabled', $global );
+		$this->assertArrayHasKey( 'debug_mode_enabled', $global );
+
+		$this->assertArrayHasKey( 'user_restrictions', $security );
+		$this->assertArrayHasKey( 'logged_out_timeout', $security );
 	}
 
 	public function test_system_report_outdated_template() {
 		/* verify no outdated template info */
 		$system_report = apply_filters( 'gform_system_report', [] );
-		$this->assertArrayNotHasKey( 'outdated_templates', $system_report[0]['tables'][1]['items'] );
+		$this->assertArrayNotHasKey( 'outdated_templates', $this->get_report_section( 'directories', $system_report ) );
 
 		/* copy core template to override location and adjust version number, then verify outdated message is included */
 		$data          = \GPDFAPI::get_data_class();
@@ -69,8 +74,74 @@ class Test_Controller_System_Report extends WP_UnitTestCase {
 		file_put_contents( $override_path, preg_replace( '/Version: (.+?)/', 'Version: 1.5.2', $template ) );
 
 		$system_report = apply_filters( 'gform_system_report', [] );
-		$this->assertArrayHasKey( 'outdated_templates', $system_report[0]['tables'][1]['items'] );
+		$this->assertArrayHasKey( 'outdated_templates', $this->get_report_section( 'directories', $system_report ) );
 
 		@unlink( $override_path );
+	}
+
+	public function test_system_report_has_no_deprecated_features_section_by_default() {
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		$this->assertCount( 4, $system_report[0]['tables'] );
+	}
+
+	public function test_site_health_test_is_registered() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$test = $this->get_site_health_test();
+
+		$this->assertIsCallable( $test['test'] );
+		$this->assertSame( 'good', call_user_func( $test['test'] )['status'] );
+	}
+
+	public function test_site_health_test_is_gated_on_the_gravity_forms_capability() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$this->assertSame( [], $this->get_site_health_test() );
+	}
+
+	public function test_debug_information_reports_a_clean_site() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$info = apply_filters( 'debug_information', [] );
+
+		$this->assertSame( 'None detected', $info['gravity-pdf-deprecated']['fields']['deprecated']['value'] );
+
+		/* No registered feature belongs to the other group, so it isn't carried around empty */
+		$this->assertArrayNotHasKey( 'gravity-pdf-unsupported', $info );
+	}
+
+	public function test_debug_information_is_gated_on_the_gravity_forms_capability() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$info = apply_filters( 'debug_information', [] );
+
+		$this->assertArrayNotHasKey( 'gravity-pdf-deprecated', $info );
+	}
+
+	/**
+	 * Get the Site Health test the controller registers
+	 */
+	protected function get_site_health_test(): array {
+		$tests = apply_filters( 'site_status_tests', [ 'direct' => [] ] );
+
+		return $tests['direct']['gravity_pdf_deprecated_features'] ?? [];
+	}
+
+	/**
+	 * Get the items of one Gravity PDF report section, by the ID the section declares
+	 *
+	 * Looked up by name so a section added or dropped above doesn't move every assertion below it.
+	 */
+	protected function get_report_section( string $id, array $system_report ): array {
+		foreach ( $system_report as $section ) {
+			foreach ( $section['tables'] ?? [] as $table ) {
+				if ( ( $table['id'] ?? '' ) === $id ) {
+					return $table['items'];
+				}
+			}
+		}
+
+		return [];
 	}
 }

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_System_Report.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_System_Report.php
@@ -3,6 +3,7 @@
 namespace GFPDF\Controller;
 
 use GFPDF\Statics\Deprecation;
+use GFPDF\Tests\Concerns\CreatesLegacyTemplates;
 use WP_UnitTestCase;
 
 /**
@@ -20,6 +21,8 @@ use WP_UnitTestCase;
  * @group   system-report
  */
 class Test_Controller_System_Report extends WP_UnitTestCase {
+
+	use CreatesLegacyTemplates;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -77,6 +80,108 @@ class Test_Controller_System_Report extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'outdated_templates', $this->get_report_section( 'directories', $system_report ) );
 
 		@unlink( $override_path );
+	}
+
+	/**
+	 * The report was keyed by position until 6.17.0, so an add-on written against it names an index, not a section
+	 */
+	public function test_the_positional_report_items_filter_reaches_the_section_each_index_stood_for() {
+		$this->setExpectedDeprecated( 'gfpdf_system_status_report_items' );
+
+		$callback = static function ( $items ) {
+			foreach ( array_keys( $items ) as $index ) {
+				$items[ $index ][ 'row_' . $index ] = [
+					'label' => 'Third Party Row',
+					'value' => (string) $index,
+				];
+			}
+
+			/* What the filter takes out has to stay out, so the read-back replaces the section rather than merging it */
+			unset( $items[0]['default_charset'] );
+
+			/* No section has ever answered to this, so there is nowhere for it to land */
+			$items[4] = [ 'orphan_row' => [ 'label' => 'Orphan Row' ] ];
+
+			return $items;
+		};
+
+		add_filter( 'gfpdf_system_status_report_items', $callback );
+
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		remove_filter( 'gfpdf_system_status_report_items', $callback );
+
+		$this->assertArrayHasKey( 'row_0', $this->get_report_section( 'php', $system_report ) );
+		$this->assertArrayHasKey( 'row_1', $this->get_report_section( 'directories', $system_report ) );
+		$this->assertArrayHasKey( 'row_2', $this->get_report_section( 'global', $system_report ) );
+		$this->assertArrayHasKey( 'row_3', $this->get_report_section( 'security', $system_report ) );
+
+		$this->assertArrayNotHasKey( 'default_charset', $this->get_report_section( 'php', $system_report ) );
+		$this->assertCount( 4, $system_report[0]['tables'] );
+	}
+
+	/**
+	 * A section added since is held back from the positional filter, since numbering it renumbers the four below it
+	 */
+	public function test_the_positional_report_items_filter_is_held_to_the_four_sections_it_knew() {
+		$this->setExpectedDeprecated( 'gfpdf_system_status_report_items' );
+
+		$path       = $this->create_legacy_template();
+		$positional = [];
+		$named      = [];
+
+		$capture_positional = static function ( $items ) use ( &$positional ) {
+			$positional = $items;
+
+			return $items;
+		};
+
+		$capture_named = static function ( $items ) use ( &$named ) {
+			$named = $items;
+
+			return $items;
+		};
+
+		add_filter( 'gfpdf_system_status_report_items', $capture_positional );
+		add_filter( 'gfpdf_system_status_report_sections', $capture_named );
+
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		remove_filter( 'gfpdf_system_status_report_items', $capture_positional );
+		remove_filter( 'gfpdf_system_status_report_sections', $capture_named );
+
+		$this->assertSame( [ 0, 1, 2, 3 ], array_keys( $positional ) );
+
+		/* The replacement is keyed by name, so the section the positional filter never saw is in it */
+		$this->assertArrayHasKey( Deprecation::GROUP_DEPRECATED, $named );
+		$this->assertArrayHasKey( 'directories', $named );
+
+		/* And the section is still in the report */
+		$this->assertArrayHasKey( 'legacy_templates', $this->get_report_section( Deprecation::GROUP_DEPRECATED, $system_report ) );
+
+		$this->delete_legacy_templates( $path );
+	}
+
+	/**
+	 * Naming the section is what a section added or dropped above it no longer moves
+	 */
+	public function test_the_report_sections_filter_adds_a_row_by_section_name() {
+		$callback = static function ( $items ) {
+			$items['directories']['third_party_row'] = [
+				'label' => 'Third Party Row',
+				'value' => 'From the named filter',
+			];
+
+			return $items;
+		};
+
+		add_filter( 'gfpdf_system_status_report_sections', $callback );
+
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		remove_filter( 'gfpdf_system_status_report_sections', $callback );
+
+		$this->assertArrayHasKey( 'third_party_row', $this->get_report_section( 'directories', $system_report ) );
 	}
 
 	public function test_system_report_has_no_deprecated_features_section_by_default() {

--- a/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
+++ b/tests/phpunit/unit-tests/Controller/Test_Controller_Upgrade_Routines.php
@@ -2,6 +2,8 @@
 
 namespace GFPDF\Controller;
 
+use GFPDF\Statics\Deprecation;
+use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
 use WP_UnitTestCase;
 
 /**
@@ -20,6 +22,8 @@ use WP_UnitTestCase;
  */
 class Test_Controller_Upgrade_Routines extends WP_UnitTestCase {
 
+	use CreatesLegacyDownloadUrls;
+
 	/**
 	 * @var \GFPDF\Helper\Helper_Options_Fields
 	 */
@@ -29,6 +33,36 @@ class Test_Controller_Upgrade_Routines extends WP_UnitTestCase {
 		parent::set_up();
 
 		$this->options = \GPDFAPI::get_options_class();
+
+		Deprecation::flush_cache();
+	}
+
+	/**
+	 * A release is the moment a new round of removals arrives, so it is where detection runs for the notices that
+	 * report it — they would otherwise have to walk the database on every admin page load
+	 */
+	public function test_a_version_change_records_the_deprecated_functionality_in_use() {
+		$form_id = $this->create_form_with_legacy_url();
+
+		do_action( 'gfpdf_version_changed', '6.16.0', '6.17.0' );
+
+		$this->assertSame( [ 'legacy_endpoint' ], Deprecation::get_detected_features() );
+
+		/* Fixed on the site, so the next release clears the record the notices read */
+		\GFAPI::delete_form( $form_id );
+		Deprecation::flush_cache();
+
+		do_action( 'gfpdf_version_changed', '6.17.0', '6.17.1' );
+
+		$this->assertSame( [], Deprecation::get_detected_features() );
+	}
+
+	public function test_an_install_records_the_deprecated_functionality_in_use() {
+		$this->create_form_with_legacy_url();
+
+		do_action( 'gfpdf_plugin_installed' );
+
+		$this->assertSame( [ 'legacy_endpoint' ], Deprecation::get_detected_features() );
 	}
 
 	public function test_6_0_0_background_process_upgrade_routine() {

--- a/tests/phpunit/unit-tests/Model/Test_Model_System_Report.php
+++ b/tests/phpunit/unit-tests/Model/Test_Model_System_Report.php
@@ -46,7 +46,12 @@ class Test_Model_System_Report extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'title', $structure );
 		$this->assertArrayHasKey( 'title_export', $structure );
 		$this->assertArrayHasKey( 'tables', $structure );
-		$this->assertCount( 4, $structure['tables'] );
+
+		/* One section per deprecation group in use, then the four the report has always had */
+		$this->assertSame(
+			[ 'deprecated', 'php', 'directories', 'global', 'security' ],
+			array_column( $structure['tables'], 'id' )
+		);
 	}
 
 	public function test_move_gravitypdf_active_plugins_to_gf_addons() {

--- a/tests/phpunit/unit-tests/Statics/Test_Deprecation.php
+++ b/tests/phpunit/unit-tests/Statics/Test_Deprecation.php
@@ -1,0 +1,173 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+use GFPDF\Helper\Helper_Interface_Deprecated_Features;
+use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group     statics
+ */
+class Test_Deprecation extends WP_UnitTestCase {
+
+	use CreatesLegacyDownloadUrls;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		Deprecation::flush_cache();
+	}
+
+	public function test_apply_filters_skips_hooks_without_a_listener() {
+		$this->assertSame( 'my-pdf', Deprecation::apply_filters( 'gfpdfe_pdf_filename', [ 'my-pdf' ] ) );
+	}
+
+	public function test_apply_filters_warns_when_a_listener_is_attached() {
+		$this->setExpectedDeprecated( 'gfpdfe_pdf_filename' );
+
+		$callback = static function () {
+			return 'filtered-pdf';
+		};
+
+		add_filter( 'gfpdfe_pdf_filename', $callback );
+
+		$this->assertSame( 'filtered-pdf', Deprecation::apply_filters( 'gfpdfe_pdf_filename', [ 'my-pdf' ] ) );
+
+		remove_filter( 'gfpdfe_pdf_filename', $callback );
+	}
+
+	public function test_get_signals_omits_empty_signals() {
+		$this->create_form_with_legacy_url();
+
+		$this->assertSame( [ 'legacy_endpoint' ], array_keys( Deprecation::get_signals() ) );
+	}
+
+	/**
+	 * Nothing here knows about the v3 layer, so a later round of removals only has to register itself
+	 */
+	public function test_a_provider_supplies_its_own_features() {
+		Fake_Deprecated_Features::$detections = [];
+
+		$this->assertSame( [ 'fake_feature', 'fake_gone_feature' ], array_keys( Fake_Deprecation::get_features() ) );
+
+		/* Each feature names the release it goes in, rather than sharing one with everything else */
+		$this->assertSame( '7.1', Fake_Deprecation::get_feature( 'fake_feature' )['removed_in'] );
+
+		/* A feature the site doesn't use isn't reported */
+		$this->assertSame( [], Fake_Deprecation::get_signals() );
+
+		Fake_Deprecated_Features::$detections = [ 'a detection' ];
+		Fake_Deprecation::flush_cache();
+
+		$signals = Fake_Deprecation::get_signals();
+
+		$this->assertSame(
+			[
+				'fake_feature'      => [ 'a detection' ],
+				'fake_gone_feature' => [ 'a detection' ],
+			],
+			$signals
+		);
+
+		/* A provider declaring both groups gets both back, in the order the engine reports them */
+		$this->assertSame(
+			[ Deprecation::GROUP_UNSUPPORTED, Deprecation::GROUP_DEPRECATED ],
+			array_keys( Fake_Deprecation::group_signals( $signals ) )
+		);
+		$this->assertSame(
+			[ Deprecation::GROUP_UNSUPPORTED, Deprecation::GROUP_DEPRECATED ],
+			Fake_Deprecation::get_groups()
+		);
+
+		/* The v3 provider declares one group today, so no surface carries the other around empty */
+		$this->assertSame( [ Deprecation::GROUP_DEPRECATED ], Deprecation::get_groups() );
+
+		Fake_Deprecated_Features::$detections = [];
+	}
+
+	/**
+	 * The uninstaller asks the registry, so a provider's storage goes with it without touching Model_Uninstall
+	 */
+	public function test_delete_stored_data_removes_what_each_provider_stores() {
+		update_option( Fake_Deprecated_Features::OPTION, [ 1 ], false );
+		update_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION, [ 1 => time() ], false );
+
+		Fake_Deprecation::delete_stored_data();
+
+		$this->assertFalse( get_option( Fake_Deprecated_Features::OPTION ) );
+
+		/* The registry is swapped out, so the v3 option is untouched */
+		$this->assertNotFalse( get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
+
+		Deprecation::delete_stored_data();
+
+		$this->assertFalse( get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
+	}
+
+	public function test_get_feature_is_empty_for_an_unregistered_id() {
+		$this->assertSame( [], Deprecation::get_feature( 'not-a-feature' ) );
+	}
+}
+
+/**
+ * A round of removals that has nothing to do with the v3 layer
+ */
+class Fake_Deprecated_Features implements Helper_Interface_Deprecated_Features {
+
+	const OPTION = 'gfpdf_fake_feature_usage';
+
+	/**
+	 * @var array What the feature's detector reports
+	 */
+	public static $detections = [];
+
+	public static function get_features(): array {
+		return [
+			'fake_feature'     => [
+				'label'      => 'Fake Feature',
+				'group'      => Deprecation::GROUP_DEPRECATED,
+				'removed_in' => '7.1',
+				'url'        => 'https://example.org/upgrade/fake-feature/',
+				'detect'     => [ static::class, 'detect' ],
+			],
+
+			'fake_gone_feature' => [
+				'label'      => 'Fake Gone Feature',
+				'group'      => Deprecation::GROUP_UNSUPPORTED,
+				'removed_in' => '7.1',
+				'url'        => 'https://example.org/upgrade/fake-gone-feature/',
+				'detect'     => [ static::class, 'detect' ],
+			],
+		];
+	}
+
+	public static function detect(): array {
+		return static::$detections;
+	}
+
+	public static function get_stored_options(): array {
+		return [ self::OPTION ];
+	}
+
+	public static function flush_cache(): void {
+	}
+}
+
+/**
+ * Swaps the registry out for the fake provider, which is all registering a new one amounts to
+ */
+class Fake_Deprecation extends Deprecation {
+
+	protected static function get_providers(): array {
+		return [ Fake_Deprecated_Features::class ];
+	}
+}

--- a/tests/phpunit/unit-tests/Statics/Test_Deprecation_V3.php
+++ b/tests/phpunit/unit-tests/Statics/Test_Deprecation_V3.php
@@ -1,0 +1,301 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Statics;
+
+use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
+use GFPDF\Tests\Concerns\CreatesLegacyTemplates;
+use GFPDF\Tests\Concerns\ResetsDetectedFeatures;
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group     statics
+ */
+class Test_Deprecation_V3 extends WP_UnitTestCase {
+
+	use CreatesLegacyDownloadUrls;
+	use CreatesLegacyTemplates;
+	use ResetsDetectedFeatures;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->reset_detected_features();
+
+		Deprecation::flush_cache();
+	}
+
+	/**
+	 * Passes either way on Gravity Forms 2.9, which still declares the class; it is 3.0 the shim exists for
+	 */
+	public function test_restore_v3_form_class_puts_back_the_class_v3_templates_guard_on() {
+		Deprecation_V3::restore_v3_form_class();
+
+		$this->assertTrue( class_exists( 'RGForms' ) );
+	}
+
+	/**
+	 * A Business Plus template drives the PDF engine itself, which is the one thing a plain v3 template never does
+	 */
+	public function test_legacy_templates_are_split_by_whether_they_drive_the_pdf_engine() {
+		$standard      = $this->create_legacy_template( 'my-standard-template.php' );
+		$business_plus = $this->create_legacy_template( 'my-business-plus-template.php', '$mpdf->AddPage();' );
+
+		$this->assertSame( [ $business_plus ], array_keys( Deprecation_V3::get_business_plus_templates() ) );
+		$this->assertArrayHasKey( $standard, Deprecation_V3::get_legacy_templates() );
+		$this->assertArrayNotHasKey( $business_plus, Deprecation_V3::get_legacy_templates() );
+
+		$this->delete_legacy_templates( $standard, $business_plus );
+	}
+
+	/**
+	 * A report naming the file alone leaves the reader to search every form for it, so the forms selecting it
+	 * travel with it
+	 */
+	public function test_legacy_templates_are_reported_with_the_forms_they_are_configured_on() {
+		$used   = $this->create_legacy_template( 'my-used-template.php' );
+		$unused = $this->create_legacy_template( 'my-unused-template.php' );
+
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		/* Two PDFs on the one template is still the one form to fix */
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'template' => 'my-used-template' ] );
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'template' => 'my-used-template' ] );
+
+		$templates = Deprecation_V3::get_legacy_templates();
+
+		$this->assertSame( [ $form_id ], $templates[ $used ] );
+		$this->assertSame( [], $templates[ $unused ] );
+
+		$this->delete_legacy_templates( $used, $unused );
+	}
+
+	/**
+	 * The `LIKE` narrowing the scan only gets it to the rows worth reading, so what a PDF actually selects has to
+	 * settle which template a form is reported against
+	 */
+	public function test_a_template_named_elsewhere_in_a_form_is_not_reported_against_it() {
+		$path = $this->create_legacy_template( 'my-mentioned-template.php' );
+		$form = \GFAPI::get_form( $this->gf_factory()->form->create() );
+
+		$form['description'] = 'Grab the my-mentioned-template.php file from the downloads page';
+		\GFAPI::update_form( $form );
+
+		/* The PDF is what puts the form in front of the scan at all, and it selects something else */
+		$this->gf_factory()->pdf->set_form_id( (int) $form['id'] )->create( [ 'template' => 'zadani' ] );
+
+		$this->assertSame( [], Deprecation_V3::get_legacy_templates()[ $path ] );
+
+		$this->delete_legacy_templates( $path );
+	}
+
+	public function test_a_trashed_form_is_not_reported_against_a_template() {
+		$path    = $this->create_legacy_template( 'my-trashed-form-template.php' );
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		$this->gf_factory()->pdf->set_form_id( $form_id )->create( [ 'template' => 'my-trashed-form-template' ] );
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_legacy_templates()[ $path ] );
+
+		/* A trashed form isn't in the user's form list, so there's nothing for them to act on */
+		\GFAPI::delete_form( $form_id );
+		Deprecation::flush_cache();
+
+		$this->assertSame( [], Deprecation_V3::get_legacy_templates()[ $path ] );
+
+		$this->delete_legacy_templates( $path );
+	}
+
+	public function test_the_v3_features_are_registered() {
+		$features = Deprecation::get_features();
+
+		$this->assertSame(
+			[ 'legacy_templates', 'business_plus_templates', 'legacy_endpoint', 'deprecated_filters' ],
+			array_keys( $features )
+		);
+
+		$this->assertSame( Deprecation_V3::REMOVED_IN, $features['legacy_templates']['removed_in'] );
+		$this->assertSame( Deprecation::GROUP_DEPRECATED, $features['legacy_templates']['group'] );
+	}
+
+	public function test_get_legacy_download_urls_searches_the_whole_form() {
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+
+		$form_ids = [
+			$this->create_form_with_legacy_url( 'form' ),
+			$this->create_form_with_legacy_url( 'confirmations' ),
+			$this->create_form_with_legacy_url( 'notifications' ),
+		];
+
+		sort( $form_ids );
+
+		$this->assertSame( $form_ids, Deprecation_V3::get_legacy_download_urls() );
+
+		/* A form that has never handed out a legacy URL isn't reported */
+		$this->gf_factory()->form->create();
+
+		$this->assertSame( $form_ids, Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_get_legacy_download_urls_ignores_a_partial_marker() {
+		$this->create_form_with_legacy_url( 'form', 'gf_pdf=0' );
+
+		/* Only `gf_pdf=1` routes to the legacy endpoint, so anything else is a false positive */
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_get_legacy_download_urls_includes_the_recorded_forms() {
+		$scanned  = $this->create_form_with_legacy_url();
+		$recorded = (int) $this->gf_factory()->form->create();
+
+		Deprecation_V3::record_legacy_endpoint_usage( $recorded );
+
+		/* A URL served for a form that never handed one out lives somewhere the scan can't see */
+		$this->assertSame( [ $recorded ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+		$this->assertSame( [ min( $scanned, $recorded ), max( $scanned, $recorded ) ], Deprecation_V3::get_legacy_download_urls() );
+
+		/* A form found by both sources is only reported once */
+		Deprecation_V3::record_legacy_endpoint_usage( $scanned );
+
+		$this->assertCount( 2, Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_record_legacy_endpoint_usage_writes_once_a_day_per_form() {
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		/* Written from the front end but read on three admin paths, so it stays out of the autoloaded set */
+		$this->assertArrayNotHasKey( Deprecation_V3::LEGACY_ENDPOINT_OPTION, wp_load_alloptions() );
+
+		$writes = 0;
+		add_action(
+			'update_option_' . Deprecation_V3::LEGACY_ENDPOINT_OPTION,
+			function () use ( &$writes ) {
+				++$writes;
+			}
+		);
+
+		/* Every later request that day reads the record and leaves it alone */
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertSame( 0, $writes );
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+
+		/* A link still being followed a day later refreshes the record, so it never reaches the expiry */
+		$stale = time() - Deprecation_V3::LEGACY_ENDPOINT_REFRESH - 1;
+		update_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION, [ $form_id => $stale ], false );
+
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertGreaterThan( $stale, get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION )[ $form_id ] );
+	}
+
+	public function test_get_recorded_legacy_endpoint_usage_expires_a_quiet_form() {
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+
+		/* Nobody has followed a legacy URL for this form in a month, so it's no longer evidence one exists */
+		update_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION, [ $form_id => time() - Deprecation_V3::LEGACY_ENDPOINT_TTL - 1 ], false );
+
+		$this->assertSame( [], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+
+		/* The expired record is flushed on the way out rather than left for the uninstaller */
+		$this->assertSame( [], get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
+
+		/* The next legacy URL served for the form puts it back */
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_recorded_legacy_endpoint_usage() );
+	}
+
+	public function test_get_legacy_download_urls_skips_trashed_recorded_forms() {
+		$form_id = (int) $this->gf_factory()->form->create();
+
+		Deprecation_V3::record_legacy_endpoint_usage( $form_id );
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_legacy_download_urls() );
+
+		/* A trashed form isn't in the user's form list, so there's nothing for them to act on */
+		\GFAPI::delete_form( $form_id );
+
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_get_legacy_download_urls_skips_trashed_forms() {
+		$form_id = $this->create_form_with_legacy_url();
+
+		$this->assertSame( [ $form_id ], Deprecation_V3::get_legacy_download_urls() );
+
+		/* A trashed form isn't in the user's form list, so there's nothing for them to act on */
+		\GFAPI::delete_form( $form_id );
+
+		$this->assertSame( [], Deprecation_V3::get_legacy_download_urls() );
+	}
+
+	public function test_get_active_deprecated_filters_ignores_our_own_callback() {
+		$this->assertNotFalse( has_filter( 'gfpdfe_pre_load_template', Deprecation_V3::INTERNAL_FILTER_CALLBACK ) );
+		$this->assertArrayNotHasKey( 'gfpdfe_pre_load_template', Deprecation_V3::get_active_deprecated_filters() );
+	}
+
+	public function test_get_active_deprecated_filters_includes_dynamic_hooks() {
+		$callback = '__return_true';
+
+		add_filter( 'gfpdfe_pdf_template_10', $callback );
+		add_filter( 'gfpdf_rtl', $callback );
+
+		$active = Deprecation_V3::get_active_deprecated_filters();
+
+		$this->assertSame( 1, $active['gfpdfe_pdf_template_10'] );
+		$this->assertSame( 1, $active['gfpdf_rtl'] );
+
+		remove_filter( 'gfpdfe_pdf_template_10', $callback );
+		remove_filter( 'gfpdf_rtl', $callback );
+	}
+
+	/**
+	 * Only `gfpdfe_pre_load_template` carries a listener of ours, and it is excluded — this fails if core ever
+	 * registers on another deprecated hook, which would report every install as using the v3 layer
+	 */
+	public function test_a_clean_install_reports_no_deprecated_filters() {
+		$this->assertSame( [], Deprecation_V3::get_active_deprecated_filters() );
+	}
+
+	public function test_get_active_deprecated_filters_includes_the_legacy_hooks() {
+		$callback = '__return_true';
+
+		/* These carry the gfpdf_legacy_ prefix rather than gfpdfe_, so only the map can find them */
+		add_filter( 'gfpdf_legacy_save_path', $callback );
+		add_action( 'gfpdf_legacy_pre_view_or_download_pdf', $callback );
+
+		$active = Deprecation_V3::get_active_deprecated_filters();
+
+		$this->assertSame( 1, $active['gfpdf_legacy_save_path'] );
+		$this->assertSame( 1, $active['gfpdf_legacy_pre_view_or_download_pdf'] );
+
+		remove_filter( 'gfpdf_legacy_save_path', $callback );
+		remove_action( 'gfpdf_legacy_pre_view_or_download_pdf', $callback );
+	}
+
+	/**
+	 * The detection reads template files, not PDF settings, so a Core template stays out of the report no matter
+	 * how a PDF using it is configured
+	 */
+	public function test_the_advanced_templating_setting_alone_does_not_report_a_template() {
+		$this->create_form_with_advanced_templating();
+
+		$this->assertArrayNotHasKey( PDF_PLUGIN_DIR . 'src/templates/zadani.php', Deprecation_V3::get_legacy_templates() );
+		$this->assertSame( [], Deprecation_V3::get_business_plus_templates() );
+	}
+}

--- a/tests/phpunit/unit-tests/test-actions.php
+++ b/tests/phpunit/unit-tests/test-actions.php
@@ -158,6 +158,114 @@ class Test_Actions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The deprecation notice styles itself from what was detected, which is a database read — so the route defers it
+	 * rather than paying for it on every admin page that never shows the notice
+	 *
+	 * @since 6.17
+	 */
+	public function test_deprecated_feature_route_defers_its_notice_class() {
+		$route = array_column( $this->controller->get_routes(), null, 'action' )['deprecated_features'];
+
+		$this->assertIsCallable( $route['view_class'] );
+
+		/* Every v3 feature still works until 7.0, so the notice is a warning rather than an error */
+		$this->assertSame( 'notice-warning', call_user_func( $route['view_class'] ) );
+	}
+
+	/**
+	 * `view_class` is public API carrying a CSS class, and plenty of one-word class names are also PHP function
+	 * names — `link`, `key`, `header`. Resolving on `is_callable()` alone would call one and fatal the admin.
+	 *
+	 * @since 6.17
+	 */
+	public function test_route_notices_never_calls_a_string_view_class() {
+		global $gfpdf;
+
+		set_current_screen( 'edit.php' );
+
+		add_filter(
+			'gfpdf_one_time_action_routes',
+			function( $routes ) {
+
+				return [
+					[
+						'action'      => 'test_action',
+						'action_text' => 'My Test Action',
+						'condition'   => '__return_true',
+						'process'     => '__return_true',
+						'view'        => function() {
+							return 'my test view';
+						},
+						'view_class'  => 'link',
+						'capability'  => 'gravityforms_view_settings',
+					],
+				];
+			}
+		);
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->controller->route_notices();
+
+		ob_start();
+		$gfpdf->notices->process();
+		$html = ob_get_clean();
+
+		/* Carried through verbatim as a class, and no `notice-` prefix so it joins the default state */
+		$this->assertStringContainsString( 'class="notice updated link"', $html );
+
+		$gfpdf->notices->clear();
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * A callable is resolved when the notice displays, so nothing queries the site to style one that never renders
+	 *
+	 * @since 6.17
+	 */
+	public function test_route_notices_resolves_a_callable_view_class() {
+		global $gfpdf;
+
+		set_current_screen( 'edit.php' );
+
+		add_filter(
+			'gfpdf_one_time_action_routes',
+			function( $routes ) {
+
+				return [
+					[
+						'action'      => 'test_action',
+						'action_text' => 'My Test Action',
+						'condition'   => '__return_true',
+						'process'     => '__return_true',
+						'view'        => function() {
+							return 'my test view';
+						},
+						'view_class'  => function() {
+							return 'notice-error';
+						},
+						'capability'  => 'gravityforms_view_settings',
+					],
+				];
+			}
+		);
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->controller->route_notices();
+
+		ob_start();
+		$gfpdf->notices->process();
+		$html = ob_get_clean();
+
+		/* A `notice-*` class replaces the default state rather than joining it */
+		$this->assertStringContainsString( 'class="notice notice-error"', $html );
+
+		$gfpdf->notices->clear();
+		wp_set_current_user( 0 );
+	}
+
+	/**
 	 * Test route notices are displayed correctly (verify capability, check for dismissal, check condition met)
 	 *
 	 * @since 4.0

--- a/tests/phpunit/unit-tests/test-deprecated.php
+++ b/tests/phpunit/unit-tests/test-deprecated.php
@@ -89,6 +89,8 @@ class Test_Deprecated extends WP_UnitTestCase {
 	public function test_render_save_pdf() {
 		global $gfpdf;
 
+		$this->setExpectedDeprecated( 'PDFRender::savePDF' );
+
 		$render = new PDFRender();
 		$render->savePDF( 'testing', 'mydocument.pdf', 20 );
 
@@ -121,6 +123,8 @@ class Test_Deprecated extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_common_get_ids() {
+		$this->setExpectedDeprecated( 'PDF_Common::get_ids' );
+
 		$GLOBALS['form_id'] = '20';
 		$_GET['lid']        = '20,21,23';
 
@@ -136,6 +140,8 @@ class Test_Deprecated extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_common_get_pdf_filename() {
+		$this->setExpectedDeprecated( 'PDF_Common::get_pdf_filename' );
+
 		$this->assertEquals( 'form-50-entry-2091.pdf', PDF_Common::get_pdf_filename( 50, 2091 ) );
 	}
 }

--- a/tests/phpunit/unit-tests/test-form-data.php
+++ b/tests/phpunit/unit-tests/test-form-data.php
@@ -1462,6 +1462,8 @@ class Test_Form_Data extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_empty_fields() {
+		$this->setExpectedDeprecated( 'GFPDFEntryDetail::lead_detail_grid_array' );
+
 		$entry     = $this->entries[6];
 		$form_data = GFPDFEntryDetail::lead_detail_grid_array( $this->form, $entry );
 
@@ -1536,6 +1538,8 @@ class Test_Form_Data extends WP_UnitTestCase {
 	 * Ensure the Product data calculations are correct when using Euros (or similar comma/decimal switched currency)
 	 */
 	public function test_euro_product_data() {
+		$this->setExpectedDeprecated( 'GFPDFEntryDetail::lead_detail_grid_array' );
+
 		$json            = json_decode( trim( file_get_contents( dirname( __FILE__ ) . '/json/all-form-euro-product-entry.json' ) ), true );
 		$json['form_id'] = $this->form['id'];
 		$entry_id        = GFAPI::add_entry( $json );

--- a/tests/phpunit/unit-tests/test-gravity-forms.php
+++ b/tests/phpunit/unit-tests/test-gravity-forms.php
@@ -440,6 +440,8 @@ class Test_Gravity_Forms extends WP_UnitTestCase {
 	 * @dataProvider provider_mergetag_test
 	 */
 	public function test_replace_variables( $mergetag, $value ) {
+		$this->setExpectedDeprecated( 'PDF_Common::do_mergetags' );
+
 		$this->assertEquals( $value, PDF_Common::do_mergetags( $mergetag, $GLOBALS['GFPDF_Test']->form['gravityform-1']['id'], $GLOBALS['GFPDF_Test']->entries['gravityform-1'][2]['id'] ) );
 	}
 

--- a/tests/phpunit/unit-tests/test-mvc-abstracts.php
+++ b/tests/phpunit/unit-tests/test-mvc-abstracts.php
@@ -110,6 +110,8 @@ class Test_MVC_Abstracts extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_abstract_view() {
+		$this->setExpectedDeprecated( 'GFPDF\View\View_Settings::tabs' );
+
 		/*
 		 * Test our load function produces the correct output
 		 */

--- a/tests/phpunit/unit-tests/test-notices.php
+++ b/tests/phpunit/unit-tests/test-notices.php
@@ -154,6 +154,33 @@ class Test_Notices extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<p>My First Error</p>', $html );
 	}
 
+	public function test_process_state_class() {
+		$this->notices->add_notice( 'My First Notice' );
+		$this->notices->add_notice( 'My Warning Notice', 'notice-warning' );
+		$this->notices->add_error( 'My Info Error', 'notice-info' );
+
+		ob_start();
+		$this->notices->process();
+		$html = ob_get_clean();
+
+		/* A `notice-*` class replaces the default state, instead of being appended to it */
+		$this->assertStringContainsString( '<div class="notice updated">', $html );
+		$this->assertStringContainsString( '<div class="notice notice-warning">', $html );
+		$this->assertStringContainsString( '<div class="notice notice-info">', $html );
+	}
+
+	public function test_process_same_class_twice() {
+		$this->notices->add_notice( 'My First Notice', 'notice-warning' );
+		$this->notices->add_notice( 'My Second Notice', 'notice-warning' );
+
+		ob_start();
+		$this->notices->process();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( '<p>My First Notice</p>', $html );
+		$this->assertStringContainsString( '<p>My Second Notice</p>', $html );
+	}
+
 	public function test_html_notice() {
 		$form = 'Message <form method="post"><p><button class="button">Action</button><input class="button primary" type="submit" value="Dismiss" /></p></form>';
 

--- a/tests/phpunit/unit-tests/test-pdf.php
+++ b/tests/phpunit/unit-tests/test-pdf.php
@@ -235,6 +235,8 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_process_legacy_pdf_endpoint() {
+		$this->setExpectedDeprecated( 'GFPDF\Controller\Controller_PDF::process_legacy_pdf_endpoint' );
+		$this->setExpectedDeprecated( 'GFPDF\Model\Model_PDF::get_legacy_config' );
 
 		/* Force a failure */
 		$this->assertNull( $this->controller->process_legacy_pdf_endpoint() );
@@ -815,6 +817,7 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_get_pdf_name() {
+		$this->setExpectedDeprecated( 'gfpdfe_pdf_filename' );
 
 		/* Setup some test data */
 		$results = $this->create_form_and_entries();
@@ -1536,6 +1539,7 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_get_legacy_config() {
+		$this->setExpectedDeprecated( 'GFPDF\Model\Model_PDF::get_legacy_config' );
 
 		/* Setup some test data */
 		$results = $this->create_form_and_entries();
@@ -1767,6 +1771,8 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_legacy_display_page_name() {
+		$this->setExpectedDeprecated( 'GFPDF\View\View_PDF::display_page_name' );
+
 		$form = [
 			'pagination' => [
 				'pages' => [
@@ -1859,6 +1865,10 @@ class Test_PDF extends WP_UnitTestCase {
 	 * @since 4.0
 	 */
 	public function test_apply_backwards_compatibility_filters() {
+		foreach ( [ 'gfpdfe_pdf_name', 'gfpdfe_template', 'gfpdf_orientation', 'gfpdf_security', 'gfpdf_privilages', 'gfpdf_password', 'gfpdf_master_password', 'gfpdf_rtl' ] as $hook ) {
+			$this->setExpectedDeprecated( $hook );
+		}
+
 		$entry            = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];
 		$entry['form_id'] = $GLOBALS['GFPDF_Test']->form['all-form-fields']['id'];
 
@@ -2048,6 +2058,8 @@ class Test_PDF extends WP_UnitTestCase {
 	 */
 	public function test_handle_legacy_tier_2_processing() {
 		global $gfpdf;
+
+		$this->setExpectedDeprecated( 'gfpdfe_pre_load_template' );
 
 		$settings  = [ 'id' => '556690c67856b', 'template' => 'zadani' ];
 		$entry     = $GLOBALS['GFPDF_Test']->entries['all-form-fields'][0];

--- a/tests/phpunit/unit-tests/test-slow-pdf-processes.php
+++ b/tests/phpunit/unit-tests/test-slow-pdf-processes.php
@@ -407,6 +407,8 @@ class Test_Slow_PDF_Processes extends WP_UnitTestCase {
 	 * works as expected.
 	 */
 	public function test_deprecated_save_pdf() {
+		$this->setExpectedDeprecated( 'GFPDF_Core_Model::gfpdfe_save_pdf' );
+
 		global $gfpdf;
 
 		$results = $this->create_form_and_entries();

--- a/tests/phpunit/unit-tests/test-uninstaller.php
+++ b/tests/phpunit/unit-tests/test-uninstaller.php
@@ -8,6 +8,7 @@ use GFPDF\Controller\Controller_Uninstaller;
 use GFPDF\Helper\Helper_Pdf_Queue;
 use GFPDF\Model\Model_Install;
 use GFPDF\Model\Model_Uninstall;
+use GFPDF\Statics\Deprecation_V3;
 use WP_UnitTestCase;
 
 /**
@@ -130,9 +131,24 @@ class Test_Uninstaller extends WP_UnitTestCase {
 		$installer       = new Controller_Install( $installer_model, $gfpdf->gform, $gfpdf->log, $gfpdf->notices, $gfpdf->data, $gfpdf->misc );
 		$installer->check_install_status();
 
-		update_option( 'gfpdf_settings', [] );
+		/* The deprecation notices' record of what this site uses, and the dismissals against it, ride in this row */
+		update_option(
+			'gfpdf_settings',
+			[
+				'deprecated_features' => [ 'legacy_endpoint' ],
+				'action_dismissal'    => [ 'deprecated_feature_legacy_endpoint' => 'deprecated_feature_legacy_endpoint' ],
+			]
+		);
+
+		/* The forms a legacy download URL has been served for are recorded in a row of their own */
+		update_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION, [ 1 ], false );
+
 		update_option( 'gpdf_sl_abc_123', true );
 		update_option( 'gpdf_sl_failed_123', true );
+
+		$this->assertArrayHasKey( 'deprecated_features', get_option( 'gfpdf_settings' ) );
+		$this->assertNotFalse( get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
+		$this->assertArrayHasKey( 'action_dismissal', get_option( 'gfpdf_settings' ) );
 
 		$this->assertNotFalse( get_option( 'gfpdf_is_installed' ) );
 		$this->assertNotFalse( get_option( 'gfpdf_current_version' ) );
@@ -146,6 +162,7 @@ class Test_Uninstaller extends WP_UnitTestCase {
 		$this->assertFalse( get_option( 'gfpdf_is_installed' ) );
 		$this->assertFalse( get_option( 'gfpdf_current_version' ) );
 		$this->assertFalse( get_option( 'gfpdf_settings' ) );
+		$this->assertFalse( get_option( Deprecation_V3::LEGACY_ENDPOINT_OPTION ) );
 		$this->assertFalse( get_option( 'gpdf_sl_abc_123' ) );
 		$this->assertFalse( get_option( 'gpdf_sl_failed_123' ) );
 


### PR DESCRIPTION
## Description

The v3 backwards compatibility layer is scheduled for removal in 7.0, and right now we have no way of knowing which sites still depend on it. Legacy (v3) templates render blank under Gravity Forms 3.0 with no fatal, no warning and nothing in the debug log; the `gfpdfe_*` filters fire silently; and the deprecated methods call `_doing_it_wrong()`, which never reaches WordPress' deprecation logging or Query Monitor. This adds the detection first, so the removal in 7.0 can be judged on real data rather than assumption.

Four things are detected — legacy (v3) templates, Business Plus templates, legacy `?gf_pdf=1` download URLs, and third-party listeners on the deprecated `gfpdfe_*` hooks — and reported on three surfaces: a new **Deprecated** section at the head of the System Report, a Site Health test with a matching Info tab section, and a single admin notice covering everything found. Each detection links to the relevant upgrade guide. Nothing appears on a site that isn't using any of it.

It also ships a shim aliasing `GFForms` back to `RGForms`, which fixes v3 templates rendering completely blank under Gravity Forms 3.0, and converts the `_doing_it_wrong()` calls across the deprecated surface to `_deprecated_function()` so they show up in WordPress' deprecation log and Query Monitor.

One unrelated bit of tidying comes along with it: `Controller_PDF::sgoptimizer_html_minification_fix()` has not been required since 6.12, when all buffers began being auto-closed before a PDF is sent to the browser. Its two hook registrations are removed and the method now deprecates, matching `development`.

A second commit keeps the System Status report's positional filter working. Adding the Deprecated section at the head of the report rekeys its items array from positional integer keys to named string keys, so the four sections an add-on knew as `0`–`3` become `php`, `directories`, `global` and `security`. `gfpdf_system_status_report_items` is a public filter keyed by that same index, so any listener writing `$items[1]['my_row']` would silently stop reaching the report — no error, no notice, the row just disappears. Gravity PDF Core Booster's *Outdated Templates* warning is one of them. So the old shape is served alongside the new one: the four sections are handed to the old filter at the indexes they sat at before 6.17 through `apply_filters_deprecated()`, and read back off those same indexes. A listener written against the old shape neither sees nor needs a change; one that has moved on gets a `_deprecated_hook` notice under `WP_DEBUG` naming the replacement, `gfpdf_system_status_report_sections`. This is a port of [#1710](https://github.com/GravityPDF/gravity-pdf/pull/1710), kept as its own commit so both stay byte-comparable against their upstream counterparts.

This is a port of 97831232 from `development`, adapted for this line, and it also carries the follow-up fixes from #1708 so the two lines stay aligned rather than drifting apart the moment this lands. See the toggles at the bottom for what differs and why.

## Testing instructions

**A clean site should stay clean.** Before anything else, check Forms → System Status, Tools → Site Health → Status, and Tools → Site Health → Info. There should be no Deprecated section, no recommendation, and no admin notice. (An earlier revision got this wrong — see the toggle.)

Then set up each signal and confirm it's reported:

1. **Legacy template** — drop a `.php` file with no file headers into the PDF working directory (`/wp-content/uploads/PDF_EXTENDED_TEMPLATES/`). Something as small as `<?php if ( ! class_exists( "RGForms" ) ) { return; }` is enough. Add `$mpdf->AddPage();` to it and it should instead be reported as a Business Plus template, with its own row and a different upgrade link.
2. **Legacy download URL** — put `<a href="/?gf_pdf=1&fid=1&lid=1&template=zadani.php">Download</a>` into a form's confirmation, notification, or a field. All three columns are searched.
3. **Deprecated filter** — add `add_filter( 'gfpdfe_pdf_filename', '__return_true' );` to a snippet plugin.

After each one, check that it shows up in all three places: the System Report's Deprecated section, the Site Health test (which should flip from green to a recommendation), and the Site Health Info tab. An admin notice should appear listing everything found — dismiss it, then add a *different* signal and confirm the notice returns for the new one.

**Permissions** — the detections include form titles, PDF names and template paths, so all three surfaces are gated on `gravityforms_view_settings`. Log in as a Subscriber and confirm the Site Health test and Info section are absent.

**SiteGround** — on a SiteGround host with the HTML minifier active, confirm PDFs still stream to the browser correctly now that `sgoptimizer_html_minification_fix()` no longer runs.

**GF 3.0 blank PDFs** — on Gravity Forms 3.0, generate a PDF using a v3 template. Before this branch it renders blank; it should now render its content.

**Positional report filter** — drop this in an mu-plugin, open **Forms → System Status**, and look at *Directories and Permissions*. The row should render, and with `WP_DEBUG` on you should also get a notice pointing at the replacement filter:

```php
add_filter( 'gfpdf_system_status_report_items', function( $items ) {
	$items[1]['my_row'] = [ 'label' => 'My Row', 'value' => 'Still here' ];
	return $items;
} );
```

Swapping to the new filter should drop the notice and keep the row:

```php
add_filter( 'gfpdf_system_status_report_sections', function( $items ) {
	$items['directories']['my_row'] = [ 'label' => 'My Row', 'value' => 'Still here' ];
	return $items;
} );
```

Remove the signals and confirm every surface goes quiet again without needing a release.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation / docblocks.

## Additional Comments

<details>
<summary>How this differs from 97831232 on <code>development</code>, and why</summary>

`development` is ~150 commits ahead of this line and carries unreleased work that isn't coming to 6.17 — a temporary PDF cache, `GFPDF\Statics\Cache` and `Statics\Debug`, fully scoped `Psr\Log`, the PHPUnit `unit-tests` → `integration` refactor, and the Playwright suite. A straight cherry-pick dragged those consequences along, so the port was resolved against the following rule.

**Deprecated method stubs.** Where upstream converted a method to `_deprecated_function()` because `development` had already gutted it into a stub (a consequence of the PDF cache), the method is still live here and keeps its body with no notice: the two `pdf.php` canonical-release notices, `Helper_Misc::maybe_add_multicurrency_support()`, `Controller_Pdf_Queue::queue_cleanup_task()`, `Queue_Callbacks::cleanup_pdfs()`, `Model_PDF`'s three cleanup methods, and `View_PDF::generate_pdf()` and `::get_template_filename()`. Where upstream only added a warning to a still-live method, the warning is applied.

**`sgoptimizer_html_minification_fix()` is the exception**, and follows `development` instead of that rule, because the buffer fix genuinely isn't needed any more. Removing its registrations also matters for the detection: one of them was on `gfpdf_legacy_pre_view_or_download_pdf`, a hook this change declares deprecated, so while it stood the scan counted core's own listener and reported **every install** as using the v3 layer. With it gone, `Deprecation.php` and `Deprecation_V3.php` are byte-identical to 97831232, so neither will conflict when the two lines next meet. `Test_Deprecation_V3::test_a_clean_install_reports_no_deprecated_filters()` fails if core ever registers on another deprecated hook.

**Playwright.** The suite doesn't exist on this line, so the deprecation spec and its helpers are omitted.

**PHPUnit.** This line's suite predates the harness the upstream tests were written against. `Test_Deprecation`, `Test_Deprecation_V3` and the `Concerns` traits are ported onto `WP_UnitTestCase`, with a `UsesFactory` trait supplying `gf_factory()` from the `GF_UnitTest_Factory` this branch already has, autoloaded from the test bootstrap. `Test_Controller_System_Report` moves from positional table indexes to a name-based lookup, since a section dropped above now renumbers the ones below it. It carries the upstream tests for the Site Health registration, the `debug_information` section and the capability gate on both, plus the clean-site assertions that keep those gates from passing vacuously — both gates were mutation-verified by removing the capability check and confirming they fail.

Not ported: the upstream tests asserting what each surface reports once a signal is detected, and the `Controller_Actions` notice-route tests. Those cover the display layer rather than the "does this fire when it shouldn't" axis.

</details>

<details>
<summary>Test results</summary>

CI is green across the matrix — PHPUnit on PHP 7.4 and 8.0–8.5 plus 8.3 multisite, both coding-standards jobs, and the JavaScript suite. Locally the integration suite runs 1187 tests, three of them added by the report-filter commit.

The 3 errors and 2 failures in `Helper\Mpdf\Test_Request` are a pre-existing artifact of the `vendor_prefixed` build used locally, not this change — they reproduce identically on an untouched worktree of this line.

**The E2E check is red, and was red before this branch.** The last run to complete failed 16/183, every one of them on a selector that no longer matches Gravity Forms' or WordPress' markup — `#the-list td.column-primary` on the entries list (×6), `input[value="Submit"]` on the frontend form (×4), `td.name`, `.gfpdf-deactivate-license` and `.editor-post-title__input`. None of them touch the report, Site Health or the notice. The same suite was already 6/183 red on 27 July on `fix/gf3-international-phone`, and every E2E run in the repo since is a failure or a cancellation: the TestCafe suite on this line has not been maintained against Gravity Forms 3.0. Separately, the workflow's *Dump log files on failure* step passes its whole command as `argv[0]` and exits 127, so the Gravity Forms logs never reach the artifact.

</details>

<details>
<summary>Follow-ups carried from #1708</summary>

Three findings from reviewing the port were in code that arrived verbatim from 97831232, so they were fixed on `development` in #1708 rather than here. Those fixes are now included, so this branch does not ship a knowingly worse version of the same code:

- **`Deprecation::get_signals()` is memoised**, behind a `Deprecation::flush_cache()` that fans out to every provider. `Helper_Interface_Deprecated_Features` gains `flush_cache()`, so a provider owns invalidating whatever it holds and callers don't need to know which class caches what. `Deprecation_V3::record_legacy_endpoint_usage()` flushes, since it writes one of the things a detector reads.
- **The notice's `view_class` accepts a callable**, resolved when the notice displays rather than when the route table is built — nothing queries the site to style a notice that never renders. The string form still works, since `view_class` is public API on the `gfpdf_one_time_action_routes` filter — and only a **non-string** callable is resolved, because `is_callable()` is true for any string naming a PHP function, so a route styling its notice `link` or `key` would have had its class name called and fatalled the admin. That was #1708's bug, fixed on `development` in [#1709](https://github.com/GravityPDF/gravity-pdf/pull/1709) and carried here with it.
- **The unused `use GFPDF\Statics\Deprecation;`** is dropped from `Controller_Actions.php`.

One adaptation: #1708 flushes the memo from the shared `tests/phpunit/integration/TestCase::set_up()`. This line has no shared base class, so the four test classes that touch detection flush in their own `set_up()` instead.

</details>



