### PR TITLE
Memoise deprecation detection and defer the notice's style

### DIFF
--- a/src/Controller/Controller_Actions.php
+++ b/src/Controller/Controller_Actions.php
@@ -10,7 +10,6 @@ use GFPDF\Helper\Helper_Form;
 use GFPDF\Helper\Helper_Interface_Actions;
 use GFPDF\Helper\Helper_Notices;
 use GFPDF\Model\Model_Actions;
-use GFPDF\Statics\Deprecation;
 use GFPDF\View\View_Actions;
 use GFPDF_Vendor\Psr\Log\LoggerInterface;
 
@@ -120,7 +119,8 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 * condition: The function or method to call to determine if a notice should be displayed (Boolean)
 	 * process: The function to handle a successful action. On success the disable_route() method should be called
 	 * view: The function used to display the notice content
-	 * view_class: Optional classes for the notice box, including a `notice-*` state like `notice-warning`
+	 * view_class: Optional classes for the notice box, including a `notice-*` state like `notice-warning`. A
+	 *             callable is resolved when the notice displays, rather than when the route table is built
 	 * dismiss: Optional function to call when the notice is dismissed, instead of dismissing the route's own
 	 *          action ID. A route that supplies one records the dismissal wherever it likes, so it also owns
 	 *          suppressing itself afterwards through `condition`
@@ -176,7 +176,9 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 				'view'        => function ( $action, $button_text ) {
 					return $this->view->deprecated_features( $this->model->get_undismissed_deprecated_features(), $action, $button_text );
 				},
-				'view_class'  => $this->model->has_unsupported_deprecated_feature() ? 'notice-error' : 'notice-warning',
+				'view_class'  => function () {
+					return $this->model->has_unsupported_deprecated_feature() ? 'notice-error' : 'notice-warning';
+				},
 				'capability'  => 'gravityforms_view_settings',
 			],
 		];
@@ -218,9 +220,11 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 					]
 				);
 
+				$view_class = $route['view_class'] ?? '';
+
 				$this->notices->add_notice(
 					call_user_func( $route['view'], $route['action'], $route['action_text'] ),
-					$route['view_class'] ?? ''
+					is_callable( $view_class ) ? call_user_func( $view_class ) : $view_class
 				);
 			}
 		}

--- a/src/Helper/Helper_Interface_Deprecated_Features.php
+++ b/src/Helper/Helper_Interface_Deprecated_Features.php
@@ -57,4 +57,14 @@ interface Helper_Interface_Deprecated_Features {
 	 * @since 6.17.0
 	 */
 	public static function get_stored_options(): array;
+
+	/**
+	 * Forget anything this class held for the request, so the next detection reads the site as it is now
+	 *
+	 * Called by Deprecation::flush_cache(), which is the one entry point callers use. A class caching nothing
+	 * implements it empty.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function flush_cache(): void;
 }

--- a/src/Statics/Deprecation.php
+++ b/src/Statics/Deprecation.php
@@ -42,6 +42,14 @@ class Deprecation {
 	const GROUP_DEPRECATED = 'deprecated';
 
 	/**
+	 * Memoised self::get_signals(), keyed by the registry that produced it
+	 *
+	 * @var array<string, array>
+	 * @since 6.17.0
+	 */
+	protected static $signals = [];
+
+	/**
 	 * The classes describing the functionality Gravity PDF is removing
 	 *
 	 * Add a class here to have its features detected and reported everywhere the existing ones are.
@@ -100,13 +108,36 @@ class Deprecation {
 	 * @since 6.17.0
 	 */
 	public static function get_signals(): array {
-		$signals = [];
+		/* Keyed by the registry like self::get_features() */
+		$key = static::class;
 
-		foreach ( static::get_features() as $key => $feature ) {
-			$signals[ $key ] = call_user_func( $feature['detect'] );
+		if ( ! isset( static::$signals[ $key ] ) ) {
+			$detected = [];
+
+			foreach ( static::get_features() as $feature_key => $feature ) {
+				$detected[ $feature_key ] = call_user_func( $feature['detect'] );
+			}
+
+			static::$signals[ $key ] = array_filter( $detected );
 		}
 
-		return array_filter( $signals );
+		return static::$signals[ $key ];
+	}
+
+	/**
+	 * Forget what the detectors found this request, here and in every provider
+	 *
+	 * The one entry point for invalidating detection, so nothing calling it has to know which class holds what.
+	 *
+	 * @since 6.17.0
+	 */
+	public static function flush_cache(): void {
+		/* Every registry, not just this one: a subclass shares the store, and a caller flushing means all of it */
+		static::$signals = [];
+
+		foreach ( static::get_providers() as $provider ) {
+			$provider::flush_cache();
+		}
 	}
 
 	/**

--- a/src/Statics/Deprecation_V3.php
+++ b/src/Statics/Deprecation_V3.php
@@ -381,6 +381,9 @@ class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
 		/* The notices read a record taken at install and on each version change, which a URL followed since then
 		   won't be in yet */
 		Deprecation::mark_feature_detected( static::FEATURE_LEGACY_ENDPOINT );
+
+		/* This is what the endpoint detector reads, so anything detecting later in the request reads it fresh */
+		Deprecation::flush_cache();
 	}
 
 	/**
@@ -475,7 +478,7 @@ class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
 	 *
 	 * The scan reads the template directory and the stored forms, and nothing changes either between the two
 	 * detectors asking, so what it finds is held for the request. Anything that does change them while a request
-	 * is still running has to say so here.
+	 * is still running calls Deprecation::flush_cache(), which is what reaches this.
 	 *
 	 * @since 6.17.0
 	 */

--- a/tests/phpunit/Concerns/CreatesLegacyDownloadUrls.php
+++ b/tests/phpunit/Concerns/CreatesLegacyDownloadUrls.php
@@ -55,6 +55,9 @@ trait CreatesLegacyDownloadUrls {
 
 		\GFAPI::update_form( $form );
 
+		/* Deprecation holds what its detectors found for the request, and this is one of the things they read */
+		\GFPDF\Statics\Deprecation::flush_cache();
+
 		return (int) $form['id'];
 	}
 }

--- a/tests/phpunit/Concerns/CreatesLegacyTemplates.php
+++ b/tests/phpunit/Concerns/CreatesLegacyTemplates.php
@@ -26,7 +26,7 @@ trait CreatesLegacyTemplates {
 
 		/* the template list is memoized per request by GFCache, and what Deprecation read off it by the detector */
 		\GFCache::flush();
-		\GFPDF\Statics\Deprecation_V3::flush_cache();
+		\GFPDF\Statics\Deprecation::flush_cache();
 
 		return $path;
 	}
@@ -57,6 +57,6 @@ trait CreatesLegacyTemplates {
 		}
 
 		\GFCache::flush();
-		\GFPDF\Statics\Deprecation_V3::flush_cache();
+		\GFPDF\Statics\Deprecation::flush_cache();
 	}
 }

--- a/tests/phpunit/integration/Controller/Test_Controller_Actions.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Actions.php
@@ -70,8 +70,11 @@ class Test_Controller_Actions extends TestCase {
 		$this->assertIsCallable( $route['view'] );
 		$this->assertIsCallable( $route['dismiss'] );
 
+		/* Resolved when the notice displays, so nothing queries the site to style a notice that never renders */
+		$this->assertIsCallable( $route['view_class'] );
+
 		/* Every v3 feature still works until 7.0, so the notice is a warning rather than an error */
-		$this->assertSame( 'notice-warning', $route['view_class'] );
+		$this->assertSame( 'notice-warning', call_user_func( $route['view_class'] ) );
 	}
 
 	/**

--- a/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
@@ -184,6 +184,7 @@ class Test_Controller_System_Report extends TestCase {
 		};
 
 		add_filter( 'gfpdfe_pdf_filename', $callback );
+		Deprecation::flush_cache();
 
 		$items = $this->get_deprecated_features();
 		$this->assertArrayHasKey( 'deprecated_filters', $items );

--- a/tests/phpunit/integration/Controller/Test_Controller_Upgrade_Routines.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Upgrade_Routines.php
@@ -50,6 +50,7 @@ class Test_Controller_Upgrade_Routines extends TestCase {
 
 		/* Fixed on the site, so the next release clears the record the notices read */
 		\GFAPI::delete_form( $form_id );
+		Deprecation::flush_cache();
 
 		do_action( 'gfpdf_version_changed', '6.17.0', '6.17.1' );
 

--- a/tests/phpunit/integration/Statics/Test_Deprecation.php
+++ b/tests/phpunit/integration/Statics/Test_Deprecation.php
@@ -60,6 +60,7 @@ class Test_Deprecation extends TestCase {
 		$this->assertSame( [], Fake_Deprecation::get_signals() );
 
 		Fake_Deprecated_Features::$detections = [ 'a detection' ];
+		Fake_Deprecation::flush_cache();
 
 		$signals = Fake_Deprecation::get_signals();
 
@@ -149,6 +150,9 @@ class Fake_Deprecated_Features implements Helper_Interface_Deprecated_Features {
 
 	public static function get_stored_options(): array {
 		return [ self::OPTION ];
+	}
+
+	public static function flush_cache(): void {
 	}
 }
 

--- a/tests/phpunit/integration/Statics/Test_Deprecation_V3.php
+++ b/tests/phpunit/integration/Statics/Test_Deprecation_V3.php
@@ -104,7 +104,7 @@ class Test_Deprecation_V3 extends TestCase {
 
 		/* A trashed form isn't in the user's form list, so there's nothing for them to act on */
 		\GFAPI::delete_form( $form_id );
-		Deprecation_V3::flush_cache();
+		Deprecation::flush_cache();
 
 		$this->assertSame( [], Deprecation_V3::get_legacy_templates()[ $path ] );
 

--- a/tests/phpunit/integration/TestCase.php
+++ b/tests/phpunit/integration/TestCase.php
@@ -26,6 +26,9 @@ abstract class TestCase extends WP_UnitTestCase {
 		 * that Test_PDF / Test_Model_Pdf already do ad-hoc to a blanket reset.
 		 */
 		delete_transient( 'gfpdf_settings_user_data' );
+
+		/* Deprecation holds its detections for the request; a test process is many requests' worth of site state */
+		\GFPDF\Statics\Deprecation::flush_cache();
 	}
 
 	public static function tear_down_after_class(): void {


### PR DESCRIPTION
## Summary

Three follow-ups from the review of #1695. No behaviour changes, and none of them are urgent.

`Deprecation::get_signals()` was the one link in the detection chain that was not memoised. The registry and the legacy template walk are both held for the request; the two detectors those do not cover re-ran in full every call. One is two unindexed `LIKE '%…%'` scans over the whole-form JSON in `wp_rg_form_meta`, the other walks all of `$wp_filter`. That costs nothing today, because no two of the four `refresh_signals()` call sites can fire in one core request. It is a guarantee one plugin away from breaking: anything calling `WP_Debug_Data::debug_data()` outside the Site Health Info tab collides the surfaces and lands the cost on an admin screen.

Invalidation becomes a mechanism instead of a convention. `flush_cache()` is now declared on `Helper_Interface_Deprecated_Features`, and `Deprecation::flush_cache()` clears its own memo then asks each provider to clear theirs. That is the same shape `delete_stored_data()` already uses to keep the uninstaller out of the providers' business: callers get one entry point and never have to know which class holds what, and a future provider that caches inherits the wiring.

The deprecation notice's `view_class` was evaluated inside the route table's array literal, so it ran while the table was being built, before anything had checked the user's capability, whether the notice was dismissed, or whether there was anything to report. The notice's styling was computed before we knew the notice would exist. It resolves when the notice is added now, which drops `get_undismissed_deprecated_features()` from twice per admin page to once when nothing is detected. `view_class` has been a documented string key on the public `gfpdf_one_time_action_routes` filter since 4.0, so the string form still works and only a callable is deferred.

Also drops an unused `Deprecation` import from `Controller_Actions`.

## Try it

```bash
yarn wp-env:integration start
yarn test:php -- --filter 'Test_Deprecation|Test_Controller_Actions|Test_Controller_System_Report|Test_Controller_Upgrade_Routines'
```

## Test plan

- [ ] Full PHPUnit suite passes, single site and multisite
- [ ] PHPCS clean
- [ ] With a legacy v3 template installed, the deprecation notice still appears on an admin page and still reads as a warning
- [ ] Dismissing that notice still clears it, and it does not come back on the next page load
- [ ] System Report and Site Health both still list the detected features

<details>
<summary>More info</summary>

### Why `get_undismissed_deprecated_features()` is not memoised

The original review suggested memoising it per request alongside the `view_class` change. It was deliberately left alone — it is a staleness trap rather than a saving.

`Controller_Actions::route()` runs on `admin_init` at priority 10 and evaluates the route condition (which *is* `get_undismissed_deprecated_features()`) before `dismiss_deprecated_features()` writes the dismissal. `route_notices()` runs at priority 20 and asks again. A request-scoped memo would be populated pre-dismissal and re-render the notice the user just dismissed. `Deprecation::mark_feature_detected()` firing mid-request from a deprecated hook is a second such path.

What is left is two in-memory reads off `Helper_Abstract_Options::$settings` on the rendering path only — no DB round trip. Not worth an invalidation contract on the model. If it ever becomes worth it, the shape is a write-invalidated memo cleared in `dismiss_notices()` and `store_detected_features()`, not an unconditional one.

### The flush direction

The first cut had `Deprecation_V3::flush_cache()` calling up into `Deprecation::flush_cache()`. That reads fine at the one existing call site but leaves `Deprecation::flush_cache()` a half-flush, so every caller has to know which class owns the state it just invalidated. The concrete hole: the blanket per-test reset in `TestCase::set_up()` reads as "forget everything" but would have left `Deprecation_V3::$legacy_templates` alive, and the form-usage map carried inside that memo is not part of its cache key.

Inverting it puts the engine in charge, matching `get_features()` and `delete_stored_data()`. `Deprecation_V3::record_legacy_endpoint_usage()` now flushes as well: it writes `LEGACY_ENDPOINT_OPTION` and calls `mark_feature_detected()`, mutating exactly what the endpoint detector reads. Harmless on today's front-end-only path, but it is the one production writer that the contract has to cover.

The memo is keyed by `static::class` like `get_features()` is, so a subclassed registry does not read the parent's cache. The flush is deliberately global across registries — a subclass shares the store, and a caller flushing means all of it.

### Test-side changes

The signal memo is per request, and a PHPUnit process is many requests' worth of site state:

- the integration `TestCase` flushes in `set_up()`, so no test reads another's detections
- `CreatesLegacyDownloadUrls::create_form_with_legacy_url()` flushes after writing its form, mirroring what `CreatesLegacyTemplates` already did for templates
- three tests that change site state mid-test and re-assert flush at the point of the change: `Test_Controller_System_Report::test_system_report_deprecated_filters` (after `add_filter`), `Test_Controller_Upgrade_Routines::test_a_version_change_records_the_deprecated_functionality_in_use` (after `GFAPI::delete_form`) and `Test_Deprecation::test_a_provider_supplies_its_own_features` (after changing the fake provider's detections)
- the two pre-existing `Deprecation_V3::flush_cache()` call sites now name `Deprecation::flush_cache()`, so every caller uses the one entry point

`Fake_Deprecated_Features` implements `flush_cache()` empty, which is what a provider caching nothing does.

</details>
