### PR TITLE
Don't call a string view_class that shares a PHP function name

### DIFF
--- a/src/Controller/Controller_Actions.php
+++ b/src/Controller/Controller_Actions.php
@@ -120,7 +120,8 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 	 * process: The function to handle a successful action. On success the disable_route() method should be called
 	 * view: The function used to display the notice content
 	 * view_class: Optional classes for the notice box, including a `notice-*` state like `notice-warning`. A
-	 *             callable is resolved when the notice displays, rather than when the route table is built
+	 *             non-string callable is resolved when the notice displays, rather than when the route table is
+	 *             built; a string is always taken as the class itself
 	 * dismiss: Optional function to call when the notice is dismissed, instead of dismissing the route's own
 	 *          action ID. A route that supplies one records the dismissal wherever it likes, so it also owns
 	 *          suppressing itself afterwards through `condition`
@@ -222,9 +223,14 @@ class Controller_Actions extends Helper_Abstract_Controller implements Helper_In
 
 				$view_class = $route['view_class'] ?? '';
 
+				/* A string is always a CSS class: `is_callable()` alone matches any class name sharing a function name */
+				if ( ! is_string( $view_class ) && is_callable( $view_class ) ) {
+					$view_class = call_user_func( $view_class );
+				}
+
 				$this->notices->add_notice(
 					call_user_func( $route['view'], $route['action'], $route['action_text'] ),
-					is_callable( $view_class ) ? call_user_func( $view_class ) : $view_class
+					$view_class
 				);
 			}
 		}

--- a/tests/phpunit/integration/Controller/Test_Controller_Actions.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_Actions.php
@@ -252,6 +252,49 @@ class Test_Controller_Actions extends TestCase {
 		$this->assertFalse( $gfpdf->notices->has_notice() );
 	}
 
+	/**
+	 * `view_class` is public API carrying a CSS class, and plenty of one-word class names are also PHP function
+	 * names — `link`, `key`, `header`. Resolving on `is_callable()` alone would call one and fatal the admin.
+	 */
+	public function test_a_string_view_class_is_never_called() {
+		global $gfpdf;
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		set_current_screen( 'dashboard' );
+
+		add_filter(
+			'gfpdf_one_time_action_routes',
+			static function () {
+				return [
+					[
+						'action'      => 'always_notify',
+						'action_text' => 'Do it',
+						'condition'   => '__return_true',
+						'process'     => '__return_true',
+						'view'        => static function () {
+							return 'A notice';
+						},
+						'view_class'  => 'link',
+						'capability'  => 'gravityforms_view_settings',
+					],
+				];
+			}
+		);
+
+		$gfpdf->notices->clear();
+		$this->controller->route_notices();
+
+		ob_start();
+		$gfpdf->notices->process();
+		$html = ob_get_clean();
+
+		/* Carried through verbatim as a class, and no `notice-` prefix so it joins the default state */
+		$this->assertStringContainsString( 'class="notice updated link"', $html );
+
+		remove_all_filters( 'gfpdf_one_time_action_routes' );
+		$gfpdf->notices->clear();
+	}
+
 	public function test_route_notices_skips_pages_the_notice_cannot_display_on() {
 		global $gfpdf, $pagenow;
 


### PR DESCRIPTION
## Description

Follow-up to #1708. `view_class` is a documented key on the public `gfpdf_one_time_action_routes` filter and its value is a CSS class string. #1708 made the key accept a callable, so the deprecation notice's style is resolved when the notice displays rather than when the route table is built, and it resolved that with a bare `is_callable()`.

`is_callable()` returns `true` for any string naming a PHP function. A route styling its notice `link`, `key`, `header`, `current` or `compact` — all ordinary-looking CSS class names, all PHP functions — had its class name *called* instead of rendered. `call_user_func( 'link' )` raises an uncaught `ArgumentCountError`, which white-screens every admin page the notice can appear on.

Core is unaffected, because `notice-warning` and `notice-error` contain a hyphen and were never callable. This only reaches a site whose add-on or snippet supplies its own `view_class` through the filter.

A string is now always taken as the class itself; only a non-string callable is resolved, so `Closure` and the array/object forms still work.

Found while verifying the 6.17 port of this feature (#1707), which carries the same code.

## Testing instructions

Add a snippet that supplies a `view_class` colliding with a PHP function name, then load any admin page where a Gravity PDF one-time-action notice displays:

```php
add_filter( 'gfpdf_one_time_action_routes', function( $routes ) {
    $routes[] = [
        'action'      => 'my_notice',
        'action_text' => 'Do it',
        'condition'   => '__return_true',
        'process'     => '__return_true',
        'view'        => function() { return 'A notice'; },
        'view_class'  => 'link',
        'capability'  => 'gravityforms_view_settings',
    ];
    return $routes;
} );
```

Before this change the screen is blank with `ArgumentCountError: link() expects exactly 2 arguments, 0 given`. After it, the notice renders with `class="notice updated link"`.

Confirm the deprecation notice still styles itself correctly too — it passes a `Closure`, so it should be unaffected.

## Checklist:
- [x] I've tested the code.
- [x] My code is easy to read, follow, and understand
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation / docblocks.

## Additional Comments

`Test_Controller_Actions::test_a_string_view_class_is_never_called` covers it. Mutation-verified: reverting the guard makes it error with `ArgumentCountError: link() expects exactly 2 arguments, 0 given`, and it passes with the guard in place. `Test_Controller_Actions` is green at 12 tests / 39 assertions; PHPCS and PHP compatibility clean.