### PR TITLE
fix: keep the System Status report's positional filter working

### DIFF
--- a/src/Model/Model_System_Report.php
+++ b/src/Model/Model_System_Report.php
@@ -35,6 +35,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Model_System_Report extends Helper_Abstract_Model {
 
 	/**
+	 * The section each index of the pre-6.17.0 report items array stood for, in order
+	 *
+	 * Frozen — never extend or reorder. These are the four indexes a pre-6.17.0 listener names.
+	 *
+	 * @var array
+	 *
+	 * @since 6.17.0
+	 */
+	private const POSITIONAL_SECTIONS = [ 'php', 'directories', 'global', 'security' ];
+
+	/**
 	 * @var Helper_Abstract_Options
 	 *
 	 * @since 6.0
@@ -187,6 +198,7 @@ class Model_System_Report extends Helper_Abstract_Model {
 	 *
 	 * @return array
 	 * @since 6.0
+	 * @since 6.17.0 Keyed by section name, filtered by `gfpdf_system_status_report_sections`
 	 */
 	protected function get_report_items(): array {
 		$items                  = [];
@@ -344,7 +356,45 @@ class Model_System_Report extends Helper_Abstract_Model {
 			],
 		];
 
-		return apply_filters( 'gfpdf_system_status_report_items', $items );
+		$items = $this->apply_deprecated_report_items_filter( $items );
+
+		return apply_filters( 'gfpdf_system_status_report_sections', $items );
+	}
+
+	/**
+	 * Pass the sections through the positional `gfpdf_system_status_report_items` filter
+	 *
+	 * Deliberately not registered on `Deprecation`: that registry is the v3 layer 7.0 removes, and this filter has
+	 * no removal scheduled.
+	 *
+	 * @param array $items Sections keyed by name
+	 *
+	 * @return array
+	 *
+	 * @since 6.17.0
+	 */
+	protected function apply_deprecated_report_items_filter( array $items ): array {
+		$positional = [];
+
+		/* Only the four a pre-6.17.0 listener knew: numbering the sections added since renumbers these */
+		foreach ( self::POSITIONAL_SECTIONS as $index => $section ) {
+			$positional[ $index ] = $items[ $section ] ?? [];
+		}
+
+		$positional = apply_filters_deprecated(
+			'gfpdf_system_status_report_items',
+			[ $positional ],
+			'6.17.0',
+			'gfpdf_system_status_report_sections',
+			esc_html__( 'The report sections are keyed by name rather than by position.', 'gravity-pdf' )
+		);
+
+		/* Read back off the same indexes, so an index the listener invents has no section to land in */
+		foreach ( self::POSITIONAL_SECTIONS as $index => $section ) {
+			$items[ $section ] = $positional[ $index ] ?? [];
+		}
+
+		return $items;
 	}
 
 	/**

--- a/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
@@ -96,6 +96,108 @@ class Test_Controller_System_Report extends TestCase {
 	}
 
 	/**
+	 * The report was keyed by position until 6.17.0, so an add-on written against it names an index, not a section
+	 */
+	public function test_the_positional_report_items_filter_reaches_the_section_each_index_stood_for() {
+		$this->setExpectedDeprecated( 'gfpdf_system_status_report_items' );
+
+		$callback = static function ( $items ) {
+			foreach ( array_keys( $items ) as $index ) {
+				$items[ $index ][ 'row_' . $index ] = [
+					'label' => 'Third Party Row',
+					'value' => (string) $index,
+				];
+			}
+
+			/* What the filter takes out has to stay out, so the read-back replaces the section rather than merging it */
+			unset( $items[0]['default_charset'] );
+
+			/* No section has ever answered to this, so there is nowhere for it to land */
+			$items[4] = [ 'orphan_row' => [ 'label' => 'Orphan Row' ] ];
+
+			return $items;
+		};
+
+		add_filter( 'gfpdf_system_status_report_items', $callback );
+
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		remove_filter( 'gfpdf_system_status_report_items', $callback );
+
+		$this->assertArrayHasKey( 'row_0', $this->get_report_section( 'php', $system_report ) );
+		$this->assertArrayHasKey( 'row_1', $this->get_report_section( 'directories', $system_report ) );
+		$this->assertArrayHasKey( 'row_2', $this->get_report_section( 'global', $system_report ) );
+		$this->assertArrayHasKey( 'row_3', $this->get_report_section( 'security', $system_report ) );
+
+		$this->assertArrayNotHasKey( 'default_charset', $this->get_report_section( 'php', $system_report ) );
+		$this->assertCount( 4, $system_report[0]['tables'] );
+	}
+
+	/**
+	 * A section added since is held back from the positional filter, since numbering it renumbers the four below it
+	 */
+	public function test_the_positional_report_items_filter_is_held_to_the_four_sections_it_knew() {
+		$this->setExpectedDeprecated( 'gfpdf_system_status_report_items' );
+
+		$path       = $this->create_legacy_template();
+		$positional = [];
+		$named      = [];
+
+		$capture_positional = static function ( $items ) use ( &$positional ) {
+			$positional = $items;
+
+			return $items;
+		};
+
+		$capture_named = static function ( $items ) use ( &$named ) {
+			$named = $items;
+
+			return $items;
+		};
+
+		add_filter( 'gfpdf_system_status_report_items', $capture_positional );
+		add_filter( 'gfpdf_system_status_report_sections', $capture_named );
+
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		remove_filter( 'gfpdf_system_status_report_items', $capture_positional );
+		remove_filter( 'gfpdf_system_status_report_sections', $capture_named );
+
+		$this->assertSame( [ 0, 1, 2, 3 ], array_keys( $positional ) );
+
+		/* The replacement is keyed by name, so the section the positional filter never saw is in it */
+		$this->assertArrayHasKey( Deprecation::GROUP_DEPRECATED, $named );
+		$this->assertArrayHasKey( 'directories', $named );
+
+		/* And the section is still in the report */
+		$this->assertArrayHasKey( 'legacy_templates', $this->get_report_section( Deprecation::GROUP_DEPRECATED, $system_report ) );
+
+		$this->delete_legacy_templates( $path );
+	}
+
+	/**
+	 * Naming the section is what a section added or dropped above it no longer moves
+	 */
+	public function test_the_report_sections_filter_adds_a_row_by_section_name() {
+		$callback = static function ( $items ) {
+			$items['directories']['third_party_row'] = [
+				'label' => 'Third Party Row',
+				'value' => 'From the named filter',
+			];
+
+			return $items;
+		};
+
+		add_filter( 'gfpdf_system_status_report_sections', $callback );
+
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		remove_filter( 'gfpdf_system_status_report_sections', $callback );
+
+		$this->assertArrayHasKey( 'third_party_row', $this->get_report_section( 'directories', $system_report ) );
+	}
+
+	/**
 	 * Get the items of one Gravity PDF report section, by the ID the section declares
 	 *
 	 * Looked up by name so a section added or dropped above doesn't move every assertion below it.


### PR DESCRIPTION
## Summary

6.17 rekeyed the System Status report's items array from positional integer keys to named string keys, so the four sections an add-on knew as `0`–`3` became `php`, `directories`, `global` and `security`. `gfpdf_system_status_report_items` is a public filter keyed by that same index, so any listener writing `$items[1]['my_row']` silently stopped reaching the report — no error, no notice, the row just disappears. Gravity PDF Core Booster's _Outdated Templates_ warning is one of them, and it is unlikely to be the only one.

The rekey itself is worth keeping. Two sections were added at the head of the report and every section added after would renumber the ones below it again, which is exactly what made a positional index a bad contract. But third parties shouldn't have to change their code for it, so this serves the old shape alongside the new one instead.

`get_report_items()` hands the four sections to `gfpdf_system_status_report_items` at the indexes they sat at before 6.17, through `apply_filters_deprecated()`, and reads the result back off those same indexes. A listener written against the old shape neither sees nor needs a change. One that has moved on gets a `_deprecated_hook` notice under `WP_DEBUG` naming the replacement, `gfpdf_system_status_report_sections` — keyed by section name, fired last, so it sees the whole report including anything the positional filter contributed.

6.17.0 has not shipped, so nothing is broken in the field yet. The 6.17 release line (`feat/system-report-detect-legacy-templates-6.16.1`) carries the same change and needs the same fix before it does.

## Try it

Drop this in an mu-plugin, open **Forms → System Status**, and look at _Directories and Permissions_:

```php
add_filter( 'gfpdf_system_status_report_items', function( $items ) {
	$items[1]['my_row'] = [ 'label' => 'My Row', 'value' => 'Still here' ];
	return $items;
} );
```

On `development` today the row is missing. With this branch it renders, and with `WP_DEBUG` on you also get a notice pointing at the replacement filter. Swapping to the new filter drops the notice and keeps the row:

```php
add_filter( 'gfpdf_system_status_report_sections', function( $items ) {
	$items['directories']['my_row'] = [ 'label' => 'My Row', 'value' => 'Still here' ];
	return $items;
} );
```

## Test plan

- [x] Three new tests in `Test_Controller_System_Report`: each legacy index still reaches the section it stood for (including that a removed row stays removed, and that an index the listener invents is dropped rather than drawn as an untitled table); the positional filter is handed exactly the four sections it knew, while the deprecation section it never saw still reaches the report; and a row added by section name through the new filter lands.
- [x] Integration suite green single-site — 1623 tests, 0 failures
- [x] Integration suite green multisite — 1623 tests, 0 failures
- [x] PHPCS clean

<details>
<summary>Design notes</summary>

**Why the deprecation sections are held back from the old filter.** They have no index of their own, and giving them one would renumber the four below them — the break this exists to avoid. They reach the report through `get_report_structure()` and the new named filter only.

**Why an invented index is dropped.** `build_gravitypdf_report()` matches `$items[ $table['id'] ]`, so a key with no matching section id has nowhere to land regardless of the read-back. Pre-6.17, `$items[4]` auto-vivified `$structure[0]['tables'][4]` with rows and no `title`; Gravity Forms reads the caption with `rgar()` so it drew an untitled table rather than erroring. Not a shape worth reproducing.

**Why `POSITIONAL_SECTIONS` is a literal, not derived from `get_report_structure()`.** It is a historical record, not configuration. Deriving it — even filtering out `Deprecation::get_groups()` — would auto-expose a future fifth section at index 4, and re-break every legacy listener the moment a section is inserted above `security`. It is marked frozen, and the tests catch both an append and a reorder.

**Why it doesn't go through `Deprecation::apply_filters()`.** That wrapper sources the version, replacement and removal text from the deprecation registry, which is the v3 layer 7.0 removes. `gfpdf_system_status_report_items` isn't a v3 feature and has no removal scheduled, so registering it would put a developer-facing filter rename into the Deprecated report section and the admin notice alongside "removed in 7.0" guidance. Called unregistered it would render an empty version string. Plain `apply_filters_deprecated()` is the right primitive here.

**`move_gravitypdf_active_plugins_to_gf_addons()` is unaffected** — its positional indexes are into Gravity Forms' own report, which is handed to it before the Gravity PDF report is merged on.

</details>
