### PR TITLE
fix: restore the deprecation notice bullets and anchor the report link

### DIFF
--- a/src/Model/Model_Actions.php
+++ b/src/Model/Model_Actions.php
@@ -242,7 +242,7 @@ class Model_Actions extends Helper_Abstract_Model {
 	 * @since 6.17.0
 	 */
 	public function system_report_redirect() {
-		wp_safe_redirect( admin_url( 'admin.php?page=gf_system_status' ) );
+		wp_safe_redirect( Model_System_Report::get_report_url() );
 		exit;
 	}
 }

--- a/src/Model/Model_System_Report.php
+++ b/src/Model/Model_System_Report.php
@@ -35,6 +35,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Model_System_Report extends Helper_Abstract_Model {
 
 	/**
+	 * The ID given to our section heading in the Gravity Forms system report, so it can be linked to directly
+	 *
+	 * @var string
+	 * @since 6.17.0
+	 */
+	const SECTION_ANCHOR = 'gfpdf-system-report';
+
+	/**
 	 * The section each index of the pre-6.17.0 report items array stood for, in order
 	 *
 	 * Frozen — never extend or reorder. These are the four indexes a pre-6.17.0 listener names.
@@ -140,7 +148,12 @@ class Model_System_Report extends Helper_Abstract_Model {
 
 		return [
 			[
-				'title'        => esc_html__( 'Gravity PDF Environment', 'gravity-pdf' ),
+				/* Gravity Forms echoes the title unescaped into an `h3`, which is the only way to anchor our section */
+				'title'        => sprintf(
+					'<span id="%s" style="scroll-margin-top: 50px">%s</span>',
+					self::SECTION_ANCHOR,
+					esc_html__( 'Gravity PDF Environment', 'gravity-pdf' )
+				),
 				'title_export' => 'Gravity PDF Environment',
 				'tables'       => array_merge(
 					$deprecated_tables,
@@ -172,6 +185,15 @@ class Model_System_Report extends Helper_Abstract_Model {
 				),
 			],
 		];
+	}
+
+	/**
+	 * The Gravity Forms system report, scrolled to the Gravity PDF section
+	 *
+	 * @since 6.17.0
+	 */
+	public static function get_report_url(): string {
+		return admin_url( 'admin.php?page=gf_system_status#' . self::SECTION_ANCHOR );
 	}
 
 	/**

--- a/src/View/View_System_Report.php
+++ b/src/View/View_System_Report.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace GFPDF\View;
 
 use GFPDF\Helper\Helper_Abstract_View;
+use GFPDF\Model\Model_System_Report;
 use GFPDF\Statics\Deprecation;
 
 /**
@@ -445,7 +446,7 @@ class View_System_Report extends Helper_Abstract_View {
 			}
 		}
 
-		$result['actions'] = '<p><a href="' . esc_url( admin_url( 'admin.php?page=gf_system_status' ) ) . '">' . esc_html__( 'View the Gravity Forms system report', 'gravity-pdf' ) . '</a></p>';
+		$result['actions'] = '<p><a href="' . esc_url( Model_System_Report::get_report_url() ) . '">' . esc_html__( 'View the Gravity Forms system report', 'gravity-pdf' ) . '</a></p>';
 
 		return $result;
 	}

--- a/src/View/html/Actions/deprecated_features.php
+++ b/src/View/html/Actions/deprecated_features.php
@@ -24,9 +24,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php esc_html_e( 'This site uses deprecated Gravity PDF functionality:', 'gravity-pdf' ); ?>
 	</strong>
 
-	<ul style="list-style: disc; margin: 0.5em 0 0.5em 2em">
+	<?php /* Bullets are set per-item: Gravity Forms resets `ul li` to none, and wp_kses_post() drops the `list-style` shorthand */ ?>
+	<ul style="margin: 0.5em 0 0.5em 2em">
 		<?php foreach ( $args['features'] as $feature ) : ?>
-			<li>
+			<li style="list-style-type: disc">
 				<?php echo esc_html( $feature['notice'] ); ?>
 				<a href="<?php echo esc_url( $feature['url'] ); ?>"><?php esc_html_e( 'Learn how to upgrade', 'gravity-pdf' ); ?></a>
 			</li>

--- a/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace GFPDF\Controller;
 
+use GFPDF\Model\Model_System_Report;
 use GFPDF\Statics\Deprecation;
 use GFPDF\Tests\Concerns\CreatesLegacyDownloadUrls;
 use GFPDF\Tests\Concerns\CreatesLegacyTemplates;
@@ -424,6 +425,18 @@ class Test_Controller_System_Report extends TestCase {
 		$this->assertStringNotContainsString( '<h4>Unsupported</h4>', $result['description'] );
 		$this->assertStringContainsString( 'Legacy Download URLs', $result['description'] );
 		$this->assertStringContainsString( (string) $form_id, $result['description'] );
-		$this->assertStringContainsString( 'page=gf_system_status', $result['actions'] );
+		$this->assertStringContainsString( 'page=gf_system_status#' . Model_System_Report::SECTION_ANCHOR, $result['actions'] );
+	}
+
+	/**
+	 * The notice and the Site Health test both link into the middle of a long report, so the section is anchored
+	 */
+	public function test_the_report_section_can_be_linked_to_directly() {
+		$system_report = apply_filters( 'gform_system_report', [] );
+
+		$this->assertStringContainsString( 'id="' . Model_System_Report::SECTION_ANCHOR . '"', $system_report[0]['title'] );
+		$this->assertStringContainsString( 'Gravity PDF Environment', $system_report[0]['title'] );
+
+		$this->assertStringContainsString( 'page=gf_system_status#' . Model_System_Report::SECTION_ANCHOR, Model_System_Report::get_report_url() );
 	}
 }


### PR DESCRIPTION
## Summary

Two fixes to the deprecated functionality notice found during manual testing.

The notice's bulleted list was rendering as an indented block with no markers. The cause was not Gravity Forms' CSS but our own output filtering: `Helper_Notices::html()` passes every notice through `wp_kses_post()`, and WordPress's `safecss_filter_attr` safelist carries `list-style-type` but not the `list-style` shorthand the template used. The declaration was silently stripped, leaving the margin indent with nothing to mark it. Moving it onto the `ul` as a longhand would not have been enough either, because Gravity Forms ships a blanket `ul li{list-style:none}` in `admin.min.css` that beats an inherited value. The marker now sits inline on each `li`, where it survives kses and out-specifies that reset.

Clicking through to the system report also dropped the reader at the top of a long page and left them to scroll for the Gravity PDF section. There was nothing to link to: Gravity Forms renders each section heading as `h3 > span` with no id. It echoes the section title unescaped, so the title now carries its own anchor, and both routes into the report go through `Model_System_Report::get_report_url()`: the notice's button and the Site Health test's link. The anchor stays out of the copy-to-clipboard export, which reads only table titles.

## Try it

```bash
yarn wp-env:integration start
yarn test:php -- --filter Test_Controller_System_Report
```

To see it, install a v3 template and force a fresh detection, then load any admin page:

```bash
yarn wp-env start
yarn wp-env run cli wp eval 'file_put_contents( GPDFAPI::get_data_class()->template_location . "v3.php", "<?php // a v3 template" );'
yarn wp-env run cli wp option update gfpdf_current_version 6.0.0
open http://localhost:8700/wp-admin/
```

The notice lists each feature with a bullet, and "View the system report" lands on the Gravity PDF Environment heading rather than the top of the page.

## Test plan

- [ ] The notice's feature list shows bullets, on a Gravity Forms page and on the WP dashboard
- [ ] "View the system report" scrolls to the Gravity PDF Environment section, clear of the admin bar
- [ ] The same link in Site Health (Status, "Your site uses Gravity PDF functionality that is scheduled for removal") does the same
- [ ] "Copy System Report" output is unchanged: no stray markup around the section title
- [ ] `Test_Controller_System_Report` passes

<details>
<summary>More info</summary>

**Confirming the kses behaviour** — run inside the container, this is the whole bug:

```
in:  <ul style="list-style: disc; margin: 0.5em 0 0.5em 2em"><li>old</li></ul>
out: <ul style="margin: 0.5em 0 0.5em 2em"><li>old</li></ul>
```

`list-style` appears in `wp-includes/kses.php` only in `$css_url_data_types` — the list of properties whose `url()` values need validating — never in the `$allowed_attr` safelist that `safecss_filter_attr()` filters against. `list-style-type` was added to that safelist in WP 4.6.

**Confirming the specificity** — the two markup variants rendered against Gravity Forms' real `admin.min.css`, computed `listStyleType`:

| markup | computed |
| --- | --- |
| `<ul style="…"><li>` (old, post-kses) | `none` |
| `<ul style="…"><li style="list-style-type: disc">` (new, post-kses) | `disc` |

**The anchor.** `GFSystemReport::system_report()` emits `'<h3><span>' . $section['title'] . '</span></h3>'` with `phpcs:ignore …EscapeOutput`, so the title is the only place a section-level id can come from. `get_system_report_text()` builds the clipboard export from table titles via `get_export( $table, 'title' )` and never touches the section title, so the markup does not leak into a support ticket. `scroll-margin-top: 50px` on the anchor keeps the heading clear of the fixed admin bar.

`SECTION_ANCHOR` and `get_report_url()` live on `Model_System_Report` because that is what builds the section. `View_System_Report` already reaches across for `get_deprecated_groups()`, so the direction is established.

The Chromatic baseline for the notice snapshot in `deprecated-features.spec.ts` will need accepting — the bullets are the change.
</details>
