### PR TITLE
fix: detect Business Plus templates by the add-on call they make (6.17)

### DIFF
--- a/src/Statics/Deprecation_V3.php
+++ b/src/Statics/Deprecation_V3.php
@@ -92,12 +92,15 @@ class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
 	const HOOK_PREFIX = 'gfpdfe_';
 
 	/**
-	 * The call every Business Plus (Tier 2) template makes, and no plain v3 template does
+	 * The call every Business Plus (Tier 2) template opens with, and no plain v3 template makes
+	 *
+	 * This is the first line of the add-on's own template boilerplate, so every template built from it carries the
+	 * call verbatim. `initilise` is misspelt in the add-on itself — matching anything else finds nothing.
 	 *
 	 * @var string
 	 * @since 6.17.0
 	 */
-	const BUSINESS_PLUS_MARKER = '$mpdf->';
+	const BUSINESS_PLUS_MARKER = 'gfpdfe_business_plus::initilise';
 
 	/**
 	 * The class the v3 "Advanced Templating" (Tier 2) add-on declares
@@ -537,10 +540,10 @@ class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
 	}
 
 	/**
-	 * Check whether a legacy template drives the PDF engine itself
+	 * Check whether a legacy template hands itself to the Advanced Templating add-on
 	 *
-	 * Direct access to the engine is the one thing the Advanced Templating add-on gave a template and a plain v3
-	 * template never had, so the call is what tells the two apart.
+	 * Calling into the add-on is the one thing a Business Plus template does and a plain v3 template never did, so
+	 * the call is what tells the two apart. Matched case-insensitively, which is how PHP resolves the identifiers.
 	 *
 	 * @param string $path The absolute path to the template file
 	 *
@@ -550,6 +553,6 @@ class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
 		//phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$contents = is_readable( $path ) ? (string) file_get_contents( $path ) : '';
 
-		return strpos( $contents, static::BUSINESS_PLUS_MARKER ) !== false;
+		return stripos( $contents, static::BUSINESS_PLUS_MARKER ) !== false;
 	}
 }

--- a/tests/phpunit/Concerns/CreatesLegacyTemplates.php
+++ b/tests/phpunit/Concerns/CreatesLegacyTemplates.php
@@ -14,7 +14,8 @@ trait CreatesLegacyTemplates {
 	/**
 	 * Write a v3 template, which is one carrying no file headers, and return its path
 	 *
-	 * A body calling `$mpdf->` is what makes it a Business Plus (Tier 2) template rather than a plain one.
+	 * A body calling `gfpdfe_business_plus::initilise` is what makes it a Business Plus (Tier 2) template rather
+	 * than a plain one.
 	 *
 	 * @param string $name The file to write into the PDF working directory
 	 * @param string $body PHP appended after the v3 boilerplate

--- a/tests/phpunit/unit-tests/Statics/Test_Deprecation_V3.php
+++ b/tests/phpunit/unit-tests/Statics/Test_Deprecation_V3.php
@@ -42,17 +42,41 @@ class Test_Deprecation_V3 extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A Business Plus template drives the PDF engine itself, which is the one thing a plain v3 template never does
+	 * A Business Plus template hands itself to the Advanced Templating add-on, which a plain v3 template never does
 	 */
-	public function test_legacy_templates_are_split_by_whether_they_drive_the_pdf_engine() {
+	public function test_legacy_templates_are_split_by_whether_they_call_the_addon() {
 		$standard      = $this->create_legacy_template( 'my-standard-template.php' );
-		$business_plus = $this->create_legacy_template( 'my-business-plus-template.php', '$mpdf->AddPage();' );
+		$business_plus = $this->create_legacy_template( 'my-business-plus-template.php', 'gfpdfe_business_plus::initilise( $pdf_name );' );
 
 		$this->assertSame( [ $business_plus ], array_keys( Deprecation_V3::get_business_plus_templates() ) );
 		$this->assertArrayHasKey( $standard, Deprecation_V3::get_legacy_templates() );
 		$this->assertArrayNotHasKey( $business_plus, Deprecation_V3::get_legacy_templates() );
 
 		$this->delete_legacy_templates( $standard, $business_plus );
+	}
+
+	/**
+	 * PHP resolves the call whatever case it is written in, so the file is read the same way
+	 */
+	public function test_the_addon_call_is_matched_regardless_of_case() {
+		$path = $this->create_legacy_template( 'my-shouty-template.php', 'GFPDFE_Business_Plus::Initilise( $pdf_name );' );
+
+		$this->assertArrayHasKey( $path, Deprecation_V3::get_business_plus_templates() );
+
+		$this->delete_legacy_templates( $path );
+	}
+
+	/**
+	 * Touching `$mpdf` is not what makes a template Business Plus: the add-on's own boilerplate never does it, and
+	 * plenty of plain v3 templates reach the engine through a filter instead
+	 */
+	public function test_a_template_using_mpdf_alone_is_not_business_plus() {
+		$path = $this->create_legacy_template( 'my-mpdf-template.php', '$mpdf->AddPage();' );
+
+		$this->assertSame( [], Deprecation_V3::get_business_plus_templates() );
+		$this->assertArrayHasKey( $path, Deprecation_V3::get_legacy_templates() );
+
+		$this->delete_legacy_templates( $path );
 	}
 
 	/**


### PR DESCRIPTION
The 6.17 half of #1713. Same source change, byte for byte; the tests differ only in living under `tests/phpunit/unit-tests/`, and this branch has no Playwright fixture to update.


The Business Plus (Tier 2) detector looked for `$mpdf->` in a legacy template, on the reasoning that direct access to the PDF engine was the one thing the Advanced Templating add-on gave a template. The add-on does not work that way. Its templates open by handing the file to the add-on, and never touch `$mpdf` at all:

```php
$template = gfpdfe_business_plus::initilise( $pdf_name );
```

That is the first line of `template/premium-template.php`, the boilerplate every Business Plus template was built from, so the call travels with every one of them. `initilise` is misspelt in the add-on itself, which is why the marker has to carry the typo.

The consequence is that the report showed nothing on exactly the sites the warning exists for, while `$mpdf->` matched plain v3 templates that reach the engine through a filter instead. Both directions were wrong and they do not overlap, so no site saw a correct answer. The marker is now the add-on call, matched case-insensitively because that is how PHP resolves the identifiers.

The fixtures encoded the same assumption, so the PHPUnit and Playwright templates write the call rather than `$mpdf->`. Two regression tests pin the behaviour: a legacy template using `$mpdf` alone is standard, not Business Plus, and the call is found whatever case it is written in.

## Try it

```bash
wp eval 'file_put_contents( GPDFAPI::get_data_class()->template_location . "bp.php", "<?php gfpdfe_business_plus::initilise( \$pdf_name );" );'
wp eval 'print_r( array_keys( GFPDF\Statics\Deprecation_V3::get_business_plus_templates() ) );'
```

The file is listed. Swap the body for `$mpdf->AddPage();` and it is reported as a standard legacy template instead.

## Test plan

- [ ] A template calling `gfpdfe_business_plus::initilise` appears under Business Plus Templates in the system report
- [ ] A legacy template using `$mpdf` alone appears under Legacy Templates, not Business Plus
- [ ] Site Health and the admin notice agree with the report
- [ ] `Test_Deprecation_V3` and `Test_Controller_System_Report` pass

<details>
<summary>More info</summary>

**Where the marker came from.** The add-on is `gravity-pdf-tier-2`, class `gfpdfe_business_plus` in `plus.php`, with `public static function initilise( $pdf_name )` at line 253. `Deprecation_V3` already knew the class — `TIER_2_ADDON_CLASS` is used by `has_tier_2_addon()` to decide whether to offer the Advanced Templating setting — so only the template-content marker was out of step.

**Measured against a real corpus** of 237 templates in a working PDF directory:

| | count |
| --- | --- |
| templates containing `gfpdfe_business_plus::initilise` | 2 |
| templates containing `$mpdf->` | 16 |
| containing both | 0 |

Zero overlap. Narrowed to the templates the detector actually classifies (no `Group` header, so `is_legacy_template()` is true), the one genuine Business Plus template there was missed by the old marker and nothing was flagged in its place.

**Why `$mpdf->` is not merely a weaker signal.** A v4+ template reaches the engine through `gfpdf_mpdf_class`, and several of the 16 do exactly that. Those are legitimately reported as legacy when they carry no headers, but they are not Business Plus, and pointing their owners at the Business Plus upgrade guide sends them to the wrong instructions.

**Known limit.** `gfpdfe_business_plus :: initilise` with spaces around the `::` is legal PHP and would not match. Every template in the wild is a copy of the same boilerplate, so this is theoretical; a regex tolerating the whitespace was written and then dropped as more machinery than the risk warrants.
</details>
