### PR TITLE
fix: stop reporting a third-party listener that is our own (6.17)

### DIFF
--- a/src/Helper/Helper_Interface_Deprecated_Features.php
+++ b/src/Helper/Helper_Interface_Deprecated_Features.php
@@ -38,12 +38,15 @@ interface Helper_Interface_Deprecated_Features {
 	 * - `notice`     (string)   What becomes of the feature, taking the removal version as `%s`. Read by every
 	 *                           surface, so it has to make sense with nothing else around it
 	 *
-	 * A feature made up of hooks declares two more, so Deprecation::apply_filters() can warn the listeners by name:
+	 * A feature made up of hooks declares more, so Deprecation::apply_filters() can warn the listeners by name:
 	 *
-	 * - `hooks`         (array<string, string>) Each deprecated hook mapped to its replacement, '' when none exists
-	 * - `deprecated_in` (string)                The Gravity PDF version the hooks were deprecated in
-	 * - `hook_prefix`   (string)                Optional. Claims any hook starting with it as well, which is how
-	 *                                           the dynamic hooks are matched
+	 * - `hooks`              (array<string, string>) Each deprecated hook mapped to its replacement, '' when none
+	 *                                               exists
+	 * - `deprecated_in`      (string)                The Gravity PDF version the hooks were deprecated in
+	 * - `hook_prefix`        (string)                Optional. Claims any hook starting with it as well, which is
+	 *                                                how the dynamic hooks are matched
+	 * - `internal_callbacks` (array)                 Optional. The callbacks Gravity PDF registers on these hooks
+	 *                                                itself, which don't count as a listener to report
 	 *
 	 * @return array<string, array>
 	 * @since 6.17.0

--- a/src/Statics/Deprecation.php
+++ b/src/Statics/Deprecation.php
@@ -311,7 +311,13 @@ class Deprecation {
 			return $args[0];
 		}
 
-		$feature    = static::get_feature_by_hook( $hook_name );
+		$feature = static::get_feature_by_hook( $hook_name );
+
+		/* Our own listener still has to run — it just isn't a listener worth reporting */
+		if ( ! static::has_reportable_listener( $hook_name, $feature ) ) {
+			return apply_filters_ref_array( $hook_name, $args );
+		}
+
 		$removed_in = $feature['removed_in'] ?? '';
 
 		if ( $replacement === '' ) {
@@ -331,6 +337,48 @@ class Deprecation {
 				$removed_in
 			)
 		);
+	}
+
+	/**
+	 * Whether anything worth reporting is listening to a deprecated hook
+	 *
+	 * Gravity PDF registers callbacks on some of its own deprecated hooks, so a hook carrying only those has no
+	 * third-party listener to name — self::log_deprecated_filter() would write a line saying it does, and
+	 * `deprecated_hook_run` would fire for a deprecation nobody on the site introduced. They are still counted on a
+	 * site being developed against, where the listener is the developer's own to find.
+	 *
+	 * @param string $hook_name The deprecated hook being fired
+	 * @param array  $feature   The registered feature that owns it
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function has_reportable_listener( string $hook_name, array $feature ): bool {
+		global $wp_filter;
+
+		if ( static::is_development_site() ) {
+			return true;
+		}
+
+		/* self::apply_filters() has already established the hook has callbacks, so it is registered */
+		return static::count_third_party_callbacks( $wp_filter[ $hook_name ], $feature['internal_callbacks'] ?? [] ) > 0;
+	}
+
+	/**
+	 * Whether this site is one someone is actively developing against
+	 *
+	 * Both signals are required. WP_DEBUG alone is set on plenty of live sites that log to file, and an environment
+	 * declared `development` alone says nothing about whether anyone is watching for the output.
+	 *
+	 * @since 6.17.0
+	 */
+	protected static function is_development_site(): bool {
+		/* wp_get_environment_type() is WP 5.5, and the plugin still activates on 5.3 — nothing declares itself
+		   development below that, so the site is treated as live */
+		if ( ! function_exists( 'wp_get_environment_type' ) || wp_get_environment_type() !== 'development' ) {
+			return false;
+		}
+
+		return defined( 'WP_DEBUG' ) && WP_DEBUG;
 	}
 
 	/**

--- a/src/Statics/Deprecation_V3.php
+++ b/src/Statics/Deprecation_V3.php
@@ -159,17 +159,19 @@ class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
 			],
 
 			'deprecated_filters'            => [
-				'label'         => __( 'Actions and Filters', 'gravity-pdf' ),
-				'group'         => Deprecation::GROUP_DEPRECATED,
-				'removed_in'    => static::REMOVED_IN,
-				'url'           => 'https://docs.gravitypdf.com/upgrade/deprecated-filters/',
-				'detect'        => [ static::class, 'get_active_deprecated_filters' ],
+				'label'              => __( 'Actions and Filters', 'gravity-pdf' ),
+				'group'              => Deprecation::GROUP_DEPRECATED,
+				'removed_in'         => static::REMOVED_IN,
+				'url'                => 'https://docs.gravitypdf.com/upgrade/deprecated-filters/',
+				'detect'             => [ static::class, 'get_active_deprecated_filters' ],
 				/* The label is a category, so out of its report row the fallback would read as the whole hook API */
 				/* translators: %s: The Gravity PDF version the hooks are removed in */
-				'notice'        => __( 'Code on this site uses Gravity PDF hooks that are removed in version %s.', 'gravity-pdf' ),
-				'hooks'         => static::get_deprecated_filters(),
-				'deprecated_in' => static::DEPRECATED_IN,
-				'hook_prefix'   => static::HOOK_PREFIX,
+				'notice'             => __( 'Code on this site uses Gravity PDF hooks that are removed in version %s.', 'gravity-pdf' ),
+				'hooks'              => static::get_deprecated_filters(),
+				'deprecated_in'      => static::DEPRECATED_IN,
+				'hook_prefix'        => static::HOOK_PREFIX,
+				/* Declared so the notice discounts them the same way the detector already does */
+				'internal_callbacks' => [ static::INTERNAL_FILTER_CALLBACK ],
 			],
 		];
 	}

--- a/tests/phpunit/unit-tests/Statics/Test_Deprecation.php
+++ b/tests/phpunit/unit-tests/Statics/Test_Deprecation.php
@@ -45,6 +45,67 @@ class Test_Deprecation extends WP_UnitTestCase {
 		remove_filter( 'gfpdfe_pdf_filename', $callback );
 	}
 
+	/**
+	 * Our own listener is not something a site can act on, so on its own it does not raise the notice — but it
+	 * still has to run, or the hook stops doing what it was fired for
+	 */
+	public function test_apply_filters_stays_quiet_when_only_our_own_callback_listens() {
+		add_filter( Fake_Internal_Listener_Features::HOOK, Fake_Internal_Listener_Features::INTERNAL_CALLBACK );
+
+		$this->assertSame(
+			'my-pdf:internal',
+			Fake_Production_Deprecation::apply_filters( Fake_Internal_Listener_Features::HOOK, [ 'my-pdf' ] )
+		);
+
+		remove_filter( Fake_Internal_Listener_Features::HOOK, Fake_Internal_Listener_Features::INTERNAL_CALLBACK );
+	}
+
+	public function test_apply_filters_warns_when_a_third_party_joins_our_own_callback() {
+		$this->setExpectedDeprecated( Fake_Internal_Listener_Features::HOOK );
+
+		$third_party = static function ( $value ) {
+			return $value . ':third-party';
+		};
+
+		add_filter( Fake_Internal_Listener_Features::HOOK, Fake_Internal_Listener_Features::INTERNAL_CALLBACK );
+		add_filter( Fake_Internal_Listener_Features::HOOK, $third_party );
+
+		$this->assertSame(
+			'my-pdf:internal:third-party',
+			Fake_Production_Deprecation::apply_filters( Fake_Internal_Listener_Features::HOOK, [ 'my-pdf' ] )
+		);
+
+		remove_filter( Fake_Internal_Listener_Features::HOOK, Fake_Internal_Listener_Features::INTERNAL_CALLBACK );
+		remove_filter( Fake_Internal_Listener_Features::HOOK, $third_party );
+	}
+
+	/**
+	 * A developer is in a position to act on it, so nothing is hidden from them
+	 */
+	public function test_apply_filters_warns_about_our_own_callback_on_a_development_site() {
+		$this->setExpectedDeprecated( Fake_Internal_Listener_Features::HOOK );
+
+		add_filter( Fake_Internal_Listener_Features::HOOK, Fake_Internal_Listener_Features::INTERNAL_CALLBACK );
+
+		$this->assertSame(
+			'my-pdf:internal',
+			Fake_Development_Deprecation::apply_filters( Fake_Internal_Listener_Features::HOOK, [ 'my-pdf' ] )
+		);
+
+		remove_filter( Fake_Internal_Listener_Features::HOOK, Fake_Internal_Listener_Features::INTERNAL_CALLBACK );
+	}
+
+	/**
+	 * WP_DEBUG on its own is not enough — plenty of live sites run with it on, logging to file
+	 */
+	public function test_debug_mode_alone_does_not_make_a_site_a_development_site() {
+		if ( wp_get_environment_type() === 'development' || ! ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
+			$this->markTestSkipped( 'Needs a live environment running with WP_DEBUG on' );
+		}
+
+		$this->assertFalse( Exposed_Deprecation::exposed_is_development_site() );
+	}
+
 	public function test_get_signals_omits_empty_signals() {
 		$this->create_form_with_legacy_url();
 
@@ -169,5 +230,79 @@ class Fake_Deprecation extends Deprecation {
 
 	protected static function get_providers(): array {
 		return [ Fake_Deprecated_Features::class ];
+	}
+}
+
+/**
+ * The registry with the real environment check left in place, so the rule itself can be asserted
+ */
+class Exposed_Deprecation extends Deprecation {
+
+	public static function exposed_is_development_site(): bool {
+		return static::is_development_site();
+	}
+}
+
+/**
+ * A feature whose deprecated hook carries a listener Gravity PDF registers itself
+ */
+class Fake_Internal_Listener_Features implements Helper_Interface_Deprecated_Features {
+
+	const HOOK = 'gfpdf_fake_internal_filter';
+
+	const INTERNAL_CALLBACK = [ self::class, 'internal_callback' ];
+
+	public static function get_features(): array {
+		return [
+			'fake_hooks' => [
+				'label'              => 'Fake Hooks',
+				'group'              => Deprecation::GROUP_DEPRECATED,
+				'removed_in'         => '7.1',
+				'url'                => 'https://example.org/upgrade/fake-hooks/',
+				'detect'             => [ static::class, 'detect' ],
+				'hooks'              => [ self::HOOK => '' ],
+				'deprecated_in'      => '6.17.0',
+				'internal_callbacks' => [ self::INTERNAL_CALLBACK ],
+			],
+		];
+	}
+
+	public static function detect(): array {
+		return [];
+	}
+
+	public static function internal_callback( string $value ): string {
+		return $value . ':internal';
+	}
+
+	public static function get_stored_options(): array {
+		return [];
+	}
+
+	public static function flush_cache(): void {
+	}
+}
+
+/**
+ * The registry as a live site sees it, where our own listener is not worth a warning
+ */
+class Fake_Production_Deprecation extends Deprecation {
+
+	protected static function get_providers(): array {
+		return [ Fake_Internal_Listener_Features::class ];
+	}
+
+	protected static function is_development_site(): bool {
+		return false;
+	}
+}
+
+/**
+ * The same registry on a site someone is developing against, where our own listener is worth reporting
+ */
+class Fake_Development_Deprecation extends Fake_Production_Deprecation {
+
+	protected static function is_development_site(): bool {
+		return true;
 	}
 }

--- a/tests/phpunit/unit-tests/Statics/Test_Deprecation_V3.php
+++ b/tests/phpunit/unit-tests/Statics/Test_Deprecation_V3.php
@@ -322,4 +322,13 @@ class Test_Deprecation_V3 extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( PDF_PLUGIN_DIR . 'src/templates/zadani.php', Deprecation_V3::get_legacy_templates() );
 		$this->assertSame( [], Deprecation_V3::get_business_plus_templates() );
 	}
+
+	/**
+	 * The notice reads the ignore list off the registration, so it has to name the callback we add ourselves
+	 */
+	public function test_the_hooks_feature_declares_the_listener_core_registers_itself() {
+		$feature = Deprecation::get_feature( 'deprecated_filters' );
+
+		$this->assertSame( [ Deprecation_V3::INTERNAL_FILTER_CALLBACK ], $feature['internal_callbacks'] );
+	}
 }


### PR DESCRIPTION
The 6.17 half of #1715. The source change is byte for byte identical; the tests differ only in living under `tests/phpunit/unit-tests/` and extending `WP_UnitTestCase`.

## Summary

`Controller_PDF` registers `PDFRender::prepare_ids` on the deprecated `gfpdfe_pre_load_template` filter. When that hook fires — which it does for any PDF configured with the v3 Advanced Templating setting — our own callback alone makes `has_filter()` true, so the site was treated as having a third-party listener when it had none.

Two things acted on that. `log_deprecated_filter()` wrote *"The gfpdfe_pre_load_template filter has a third-party listener attached"* into the Gravity PDF log, which is untrue on a site without the Tier 2 add-on installed. And `_deprecated_hook()` fires the `deprecated_hook_run` action regardless of `WP_DEBUG`, so Query Monitor and the error trackers hosts run recorded a deprecation nobody on the site had introduced.

The detector behind the system report already discounted that callback when counting listeners. The notice path now discounts it too. The ignore list is read off the feature registration rather than wired into the generic layer, so the rule stays with the provider that owns the hook, the same way `hooks` and `hook_prefix` already do.

The hook still fires either way. Where nothing reportable is listening it goes through `apply_filters_ref_array()`, which is exactly what `apply_filters_deprecated()` calls once it has emitted the notice, so our own callback runs as before and the return value is unchanged.

With `WP_DEBUG` on there was a third effect: an `E_USER_DEPRECATED` naming the hook, raised on a live site the reader could do nothing about.

None of it applies where both signals agree someone is developing against the site — `wp_get_environment_type()` is `development` **and** `WP_DEBUG` is on. Either signal alone is common on a live site, and either alone would put us back to warning about ourselves in production.

## Try it

On a site with a PDF using the Advanced Templating setting, no Tier 2 add-on, and `WP_DEBUG` off, generate that PDF. The Gravity PDF log no longer records a third-party listener on `gfpdfe_pre_load_template`, and the PDF renders as before.

```bash
yarn test:php -- --filter Test_Deprecation
```

## Test plan

- [ ] A production site with only our own listener writes no "third-party listener attached" log line, and Advanced Templating PDFs still render
- [ ] Adding a third-party listener to the same hook brings the log line and the notice back
- [ ] `WP_DEBUG` on with `WP_ENVIRONMENT_TYPE=development` reports our own listener again
- [ ] `WP_DEBUG` on *without* the environment declared stays quiet — neither signal is sufficient alone
- [ ] The Actions and Filters row in the system report is unchanged
- [ ] `Test_Deprecation` and `Test_Deprecation_V3` pass

<details>
<summary>More info</summary>

**Why both signals are required.** `_deprecated_hook()` (`wp-includes/functions.php:6063`) fires `deprecated_hook_run` unconditionally, then guards the `trigger_error()` behind `if ( WP_DEBUG && ... )`. An earlier revision of this branch treated `WP_DEBUG` on as sufficient to count as a development site, which made the printed notice unreachable: the guard and the notice were keyed on the same flag, so their intersection was empty and only the log line and the action ever changed. Requiring `development` **and** `WP_DEBUG` fixes that — a `WP_DEBUG`-on live site now takes the quiet path and the printed notice goes with it, while a declared development site keeps everything. A regression test pins it, and skips itself where the environment can't demonstrate the rule.

**Why the hook still has to fire.** `apply_filters_deprecated()` is `_deprecated_hook()` followed by `apply_filters_ref_array( $hook_name, $args )` — see `wp-includes/plugin.php:723`. Returning `$args[0]` early, the way the existing no-listener guard does, would have skipped `PDFRender::prepare_ids` and broken v3 Tier 2 rendering. Substituting the second half alone keeps behaviour identical minus the notice.

**How narrow this is.** `gfpdfe_pre_load_template` is fired only from `Model_PDF::handle_legacy_tier_2_processing()`, reached only when `Deprecation_V3::is_advanced_template_pdf()` is true — `advanced_template === 'yes'`. On a site that still runs the Tier 2 add-on, the add-on is itself listening on that hook, so a third-party listener genuinely exists and everything reports as before. The sites this changes are those carrying the setting without the add-on.

**Where the ignore list lives.** `Deprecation_V3::INTERNAL_FILTER_CALLBACK` is the single source of truth: `Controller_PDF:208` registers it, `get_active_deprecated_filters()` passes it to the detector, and the feature now exposes it as `internal_callbacks` for the notice — documented alongside the other hook keys on `Helper_Interface_Deprecated_Features`. A test asserts the registration carries it.

**WP 5.5 guard.** `wp_get_environment_type()` landed in 5.5, and `pdf.php:111` still enforces `required_wp_version = '5.3'` and blocks activation below it. Calling it unguarded would fatal on the PDF generation path, so it is behind `function_exists()`, falling back to the `WP_DEBUG` check alone.

**Testing the environment branch.** `wp_get_environment_type()` caches in a static and `WP_DEBUG` is a constant, so neither moves at runtime. The two branches are covered by subclassing `Deprecation` and overriding `is_development_site()`, which is what the `static::` late static binding in this class is for. Absence of a report is asserted by *not* declaring the deprecation expected — `WP_UnitTestCase` fails on an unexpected one — and that test fails when the gate is forced open.

This branch's suite was not run locally — the worktree has no `vendor/` and building one for the 6.x line is the multi-step dance in the notes rather than a `composer install`. The identical tests pass on `development`, and this branch's CI runs PHPUnit on 7.4 through 8.5 plus multisite.
</details>
