### PR TITLE
fix: stop AddPage() fataling on an array second argument (6.17)

### DIFF
--- a/src/Helper/Helper_Options_Fields.php
+++ b/src/Helper/Helper_Options_Fields.php
@@ -498,6 +498,9 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 	 * advanced templates without the need for user intervention, which is why this method doesn't have a filter to manually
 	 * enable it.
 	 *
+	 * The add-on is reported by the deprecation report and its notice, so nothing is raised from here: this runs on
+	 * every PDF settings screen, and the report is the surface that can explain what to do about it.
+	 *
 	 * @param array $settings The 'form_settings_advanced' array
 	 *
 	 * @return array
@@ -510,8 +513,6 @@ class Helper_Options_Fields extends Helper_Abstract_Options implements Helper_In
 		if ( ! Deprecation_V3::has_tier_2_addon() ) {
 			return $settings;
 		}
-
-		_deprecated_function( __METHOD__, '6.12', 'a Gravity PDF 6 template, https://docs.gravitypdf.com/upgrade/legacy-templates/' );
 
 		$settings['advanced_template'] = [
 			'id'   => 'advanced_template',

--- a/src/Helper/Mpdf/Mpdf.php
+++ b/src/Helper/Mpdf/Mpdf.php
@@ -35,6 +35,32 @@ class Mpdf extends MpdfCore {
 	}
 
 	/**
+	 * Discard an array passed as the second argument instead of fataling on it
+	 *
+	 * mPDF reads a `$condition` string in that position ('E', 'O', 'NEXT-ODD'...) and takes a custom page size via
+	 * `$newformat`, the last parameter. That has been the signature since mPDF 5.3, so a page size has never
+	 * belonged there — the supported call is `AddPageByArray( [ 'sheet-size' => [ $w, $h ] ] )`, which is where the
+	 * Business Plus add-on moved its own boilerplate in 1.0.3.
+	 *
+	 * Templates written against the boilerplate before that still call `AddPage( 'P', [ $w, $h ] )`, so the array
+	 * reaches `strtoupper()`. PHP 7 warned, returned null and carried on with no condition, leaving the page at the
+	 * size it already had; PHP 8 raises a TypeError and ends the request instead.
+	 *
+	 * Emptying the condition reproduces the PHP 7 result exactly — mPDF only ever compares it against non-empty
+	 * keywords, and blanks it itself when one doesn't apply. The page size the template asked for goes on being
+	 * ignored, as it always has been, so no existing PDF changes; this only takes away the fatal.
+	 *
+	 * @since 6.17.0
+	 */
+	public function AddPage( $orientation = '', $condition = '', $resetpagenum = '', $pagenumstyle = '', $suppress = '', $mgl = '', $mgr = '', $mgt = '', $mgb = '', $mgh = '', $mgf = '', $ohname = '', $ehname = '', $ofname = '', $efname = '', $ohvalue = 0, $ehvalue = 0, $ofvalue = 0, $efvalue = 0, $pagesel = '', $newformat = '' ) {
+		if ( is_array( $condition ) ) {
+			$condition = '';
+		}
+
+		return parent::AddPage( $orientation, $condition, $resetpagenum, $pagenumstyle, $suppress, $mgl, $mgr, $mgt, $mgb, $mgh, $mgf, $ohname, $ehname, $ofname, $efname, $ohvalue, $ehvalue, $ofvalue, $efvalue, $pagesel, $newformat );
+	}
+
+	/**
 	 * @param int    $pageNumber The page number.
 	 * @param null   $crop_x     mPDF 8.0 removed this parameter
 	 * @param null   $crop_y     mPDF 8.0 removed this parameter

--- a/tests/phpunit/unit-tests/Helper/Mpdf/Test_Mpdf.php
+++ b/tests/phpunit/unit-tests/Helper/Mpdf/Test_Mpdf.php
@@ -1,0 +1,86 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace GFPDF\Helper\Mpdf;
+
+use WP_UnitTestCase;
+
+/**
+ * @package     Gravity PDF
+ * @copyright   Copyright (c) 2026, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * @group   mpdf
+ */
+class Test_Mpdf extends WP_UnitTestCase {
+
+	protected function get_pdf(): Mpdf {
+		return new Mpdf(
+			[
+				'mode'    => 'c',
+				'tempDir' => sys_get_temp_dir(),
+			]
+		);
+	}
+
+	/**
+	 * The call every pre-1.0.3 Business Plus template makes, which reached strtoupper() as an array and, on PHP 8,
+	 * ended the request with a TypeError
+	 *
+	 * The size is still discarded, exactly as PHP 7 discarded it — the page keeps the size it already had. Only the
+	 * fatal goes away.
+	 */
+	public function test_add_page_discards_an_array_second_argument_instead_of_fataling() {
+		$pdf = $this->get_pdf();
+		$pdf->AddPage( 'P', [ 200, 100 ] );
+
+		$this->assertEqualsWithDelta( 210, $pdf->w, 0.01 );
+		$this->assertEqualsWithDelta( 297, $pdf->h, 0.01 );
+	}
+
+	/**
+	 * A template asking for a page of a source PDF it doesn't have used to reach mPDF's "Invalid page format"
+	 * exception; discarding the array means it never gets there
+	 */
+	public function test_add_page_discards_an_array_of_nulls() {
+		$pdf = $this->get_pdf();
+		$pdf->AddPage( 'P', [ null, null ] );
+
+		$this->assertEqualsWithDelta( 210, $pdf->w, 0.01 );
+		$this->assertEqualsWithDelta( 297, $pdf->h, 0.01 );
+	}
+
+	/**
+	 * Only the array is emptied, so a page size mPDF does accept still applies
+	 */
+	public function test_add_page_still_honours_an_explicit_page_size() {
+		$pdf = $this->get_pdf();
+		$pdf->AddPage( 'P', [ 200, 100 ], '', '', '', '', '', '', '', '', '', '', '', '', '', 0, 0, 0, 0, '', [ 300, 150 ] );
+
+		$this->assertEqualsWithDelta( 300, $pdf->w, 0.01 );
+		$this->assertEqualsWithDelta( 150, $pdf->h, 0.01 );
+	}
+
+	/**
+	 * The parameter mPDF actually declares there still has to work
+	 */
+	public function test_add_page_leaves_a_condition_string_alone() {
+		$pdf = $this->get_pdf();
+		$pdf->AddPage( 'P', 'NEXT-ODD' );
+
+		$this->assertEqualsWithDelta( 210, $pdf->w, 0.01 );
+		$this->assertEqualsWithDelta( 297, $pdf->h, 0.01 );
+	}
+
+	public function test_add_page_defaults_to_the_document_page_size() {
+		$pdf = $this->get_pdf();
+		$pdf->AddPage();
+
+		$this->assertEqualsWithDelta( 210, $pdf->w, 0.01 );
+		$this->assertEqualsWithDelta( 297, $pdf->h, 0.01 );
+	}
+
+}


### PR DESCRIPTION
A Business Plus (Tier 2) template opens its page like this:

```php
$pdf->addPage( 'P', [ $template['size'][1]['w'], $template['size'][1]['h'] ] );
```

mPDF has never accepted a page size there. `AddPage()`'s second parameter is `$condition` — a string like `'E'`, `'O'` or `'NEXT-ODD'` — and a custom size arrives as `$newformat`, the 21st. That signature is unchanged across every tagged mPDF release from 5.3.0 to 8.x, and `strtoupper( $condition )` has been in the method just as long, so the array has always landed in it.

The add-on knew. Tier 2 1.0.3's changelog reads:

> 1.0.3 Changes
> Moved from `$pdf->AddPage()` to `$pdf->AddPageByArray()` in example template

and the shipped boilerplate has used `AddPageByArray( [ 'sheet-size' => [ $w, $h ] ] )` ever since. Templates built from the boilerplate before 1.0.3 kept the broken call.

**What changed is PHP, not mPDF.** On PHP 7, `strtoupper( array )` warned and returned null, so the page was added with no condition and kept the size it already had — the size the template asked for was silently dropped. PHP 8 promotes the warning to a `TypeError`, so the same template now ends the request:

```
PHP Fatal error: Uncaught TypeError: strtoupper(): Argument #1 ($string)
must be of type string, array given
  in vendor_prefixed/mpdf/mpdf/src/Mpdf.php:2644
#1 subtrade pre-qualification.php(62): Mpdf->AddPage('P', Array)
#2 gravity-pdf-developer-toolkit/src/Loader/Loader.php(205): include(...)
```

Not a Developer Toolkit regression either — the Toolkit was a drop-in replacement for the add-on when it shipped, and the call was already wrong before that.

## What this does, and what it deliberately doesn't

An array second argument is **emptied** rather than passed through. That reproduces the PHP 7 outcome exactly: mPDF only ever compares `$condition` against non-empty keywords, and blanks it itself when none apply, so `''` and PHP 7's `null` are indistinguishable to it. The requested size goes on being ignored, as it always has been.

This takes away the fatal and nothing else. It does **not** start honouring the size, which would fix what the template meant but would also change output on PHP 7.3/7.4 — pages that render at the document default today would start rendering at the requested size — and Gravity PDF still supports 7.3. Every existing PDF stays byte-identical on both PHP lines.

A template that wants the size honoured should call `AddPageByArray( [ 'sheet-size' => [ $w, $h ] ] )`, which has worked since mPDF 5.3, or the Toolkit's `$w->addPage()`.

## Try it

Needs the Developer Toolkit and a pre-1.0.3-style Tier 2 template, on PHP 8. The per-PDF **Advanced Template** toggle only appears when the hidden global `advanced_templating` setting is truthy — normally written only when the Toolkit deactivates the old `gravity-pdf-tier-2/plus.php`, so on a fresh site set it directly:

```php
$options  = GPDFAPI::get_options_class();
$settings = $options->get_settings();
$settings['advanced_templating'] = true;
$options->update_settings( $settings );
```

Set the PDF's Advanced Template to Yes, point it at a template that calls `addPage( 'P', [ $w, $h ] )`, and render it. Before this change the request dies with the `TypeError` above; after it, the page is added and the template runs on — at the same size PHP 7 would have given it.

Separately, with the Tier 2 add-on active, open any PDF's settings with `WP_DEBUG` on: the `get_advanced_template_field` deprecation should no longer be in the log, while the v3 deprecation notice and the Gravity PDF section of the System Report still report Business Plus templates.

## Test plan

`Test_Mpdf` (new file, `tests/phpunit/unit-tests/Helper/Mpdf/`) covers the behaviour against a live `Mpdf` instance:

| Call | Expected |
|---|---|
| `AddPage('P', [200, 100])` — the call that fatalled | no fatal; page keeps its size (A4), as on PHP 7 |
| `AddPage('P', [null, null])` | no fatal, no `Invalid page format` exception; A4 |
| `AddPage('P', [200,100], …, $newformat = [300,150])` | 300 × 150 — an explicit size still applies |
| `AddPage('P', 'NEXT-ODD')` | A4, condition untouched |
| `AddPage()` | A4 |

Parity was measured, not assumed. PHP 7.4.33 on raw mPDF, against PHP 8.5 through the shim:

```
PHP 7.4.33  (raw mPDF)              PHP 8.5.4  (shimmed)
  AddPage('P', [200,100])    210.00 x 297.00      210.00 x 297.00
  AddPage('P', [null,null])  210.00 x 297.00      210.00 x 297.00
  AddPage('P', 'NEXT-ODD')   210.00 x 297.00      210.00 x 297.00
  AddPage()                  210.00 x 297.00      210.00 x 297.00
```

<details>
<summary>How the signature claim was checked</summary>

Against a full mPDF checkout, every tag from `v5.3.0` to `v8.1.0`:

```
$ for t in $(git tag | sort -V); do git show $t:src/Mpdf.php $t:mpdf.php 2>/dev/null \
    | grep -o "function AddPage([^)]*)"; done | sed 's/.*\$orientation[^,]*, *\(\$[a-z]*\).*/\1/' | sort -u
$condition
```

77 tags, one answer. `$newformat` is last in all of them, and `$condition = strtoupper($condition)` is present from `v5.3.0` onward.

</details>

<details>
<summary>Design notes</summary>

**Where it goes.** `Helper_PDF::begin_pdf()` instantiates `GFPDF\Helper\Mpdf\Mpdf`, and the Toolkit sets the legacy `global $pdf` to that same object, so that is the class a Tier 2 template is handed. `Helper_Mpdf` is an empty subclass nothing instantiates here — a shim there would never run. The class already carries the same kind of compatibility override for `SetImportUse()`, `importPage()`, `useTemplate()` and `WriteHTML()`.

**Only the array is emptied.** A `$condition` string is left alone, and an explicit `$newformat` still applies, so nothing mPDF does support is affected.

**The signature is written out in full** rather than forwarded with `func_get_args()`. Forwarding 21 positional arguments dynamically means re-supplying mPDF's own defaults (`''` for the margin and header arguments, `0` for `$ohvalue`–`$efvalue`), and those drift between mPDF releases. An explicit signature can't silently rot.

**No `_deprecated_argument()` on the discarded array.** The prototype notes suggested one so Tier 2 customers get a nudge toward `AddPageByArray()`. It's left out on purpose, and for the same reason the `get_advanced_template_field()` notice is going: `business_plus_templates` is already a first-class detected feature of the v3 deprecation report, so the migration prompt exists on a surface that can explain it. A notice here would fire once per page of every legacy render, mid-render, at someone who can't act on it there.

**Sibling methods.** `AddPage` was the first fatal, not necessarily the only one. The same template also calls `WriteText`, `SetFontSize`, `GetStringWidth`, `Image`, `useTemplate` and `WriteHTML`; all exist on the current mPDF, so any further breakage would be the same kind of latent-call problem, invisible until execution gets far enough to reach it. Against the real template, execution ran from the failing line 62 through to line 462 before stopping for a test-data reason — the source PDF is a 1-page placeholder where the template wants 4 pages.

</details>
