### PR TITLE
fix: tidy how deprecated features read in Site Health

### DIFF
--- a/src/Statics/Deprecation_V3.php
+++ b/src/Statics/Deprecation_V3.php
@@ -141,7 +141,7 @@ class Deprecation_V3 implements Helper_Interface_Deprecated_Features {
 			],
 
 			'business_plus_templates'       => [
-				'label'      => __( 'Business Plus Templates', 'gravity-pdf' ),
+				'label'      => __( 'Business Plus / Tier 2 Templates', 'gravity-pdf' ),
 				'group'      => Deprecation::GROUP_DEPRECATED,
 				'removed_in' => static::REMOVED_IN,
 				'url'        => 'https://docs.gravitypdf.com/upgrade/legacy-templates/#business-plus--tier-2-template-upgrade-guide',

--- a/src/View/View_System_Report.php
+++ b/src/View/View_System_Report.php
@@ -419,7 +419,7 @@ class View_System_Report extends Helper_Abstract_View {
 				'label' => esc_html__( 'Gravity PDF', 'gravity-pdf' ),
 				'color' => 'blue',
 			],
-			'description' => '<p>' . esc_html__( 'Nothing on this site relies on Gravity PDF functionality that is scheduled for removal, so there is nothing to do.', 'gravity-pdf' ) . '</p>',
+			'description' => '<p>' . esc_html__( 'Nothing on this site uses Gravity PDF functionality that is scheduled for removal.', 'gravity-pdf' ) . '</p>',
 			'actions'     => '',
 			'test'        => 'gravity_pdf_deprecated_features',
 		];
@@ -431,7 +431,8 @@ class View_System_Report extends Helper_Abstract_View {
 		$result['status'] = 'recommended';
 		$result['label']  = esc_html__( 'Your site uses Gravity PDF functionality that is scheduled for removal', 'gravity-pdf' );
 
-		$result['description'] = '<p>' . esc_html__( 'Update each item below before the release that removes it, so the PDFs that rely on it will continue working. Each one links to instructions to upgrade.', 'gravity-pdf' ) . '</p>';
+		/* The group headings and their descriptions introduce the list, so nothing else does */
+		$result['description'] = '';
 
 		$groups = static::get_deprecated_groups();
 		foreach ( Deprecation::group_signals( $signals ) as $group => $group_signals ) {
@@ -466,10 +467,11 @@ class View_System_Report extends Helper_Abstract_View {
 	/**
 	 * Build the Site Health Info tab sections for the features detected on this site
 	 *
-	 * This is the tab users copy into a support ticket, so a section is present whether or not its group has
-	 * anything to report: an empty one says so, rather than leaving the reader to guess whether the check ran.
-	 * They report what the system report exports, which keeps the two plain-text surfaces reading the same by
-	 * construction.
+	 * A section is the only thing Site Health gives a heading and an intro paragraph of its own, so each group
+	 * takes one and heads it with its own name. This is the tab users copy into a support ticket, so a section is
+	 * present whether or not its group has anything to report: an empty one says so, rather than leaving the
+	 * reader to guess whether the check ran. The fields report what the system report exports, which keeps the two
+	 * plain-text surfaces reading the same by construction.
 	 *
 	 * @param array $signals The signals from Deprecation::get_signals()
 	 *
@@ -481,9 +483,10 @@ class View_System_Report extends Helper_Abstract_View {
 		$sections = [];
 
 		foreach ( static::get_deprecated_groups() as $group => $names ) {
-			$fields = [];
+			$detections = $grouped[ $group ] ?? [];
+			$fields     = [];
 
-			foreach ( $grouped[ $group ] ?? [] as $key => $signal ) {
+			foreach ( $detections as $key => $signal ) {
 				$message = $this->get_deprecated_feature_detail( $key, $signal );
 
 				$fields[ $key ] = [
@@ -500,10 +503,21 @@ class View_System_Report extends Helper_Abstract_View {
 				];
 			}
 
-			$sections[ 'gravity-pdf-' . $group ] = [
+			/* Site Health prints this above the table, unescaped, so the group heads its own panel here */
+			$description = sprintf(
+				'<h4>%s</h4>',
 				/* translators: %s: The group name, as get_deprecated_groups() gives it */
-				'label'       => sprintf( __( 'Gravity PDF - %s Functionality', 'gravity-pdf' ), $names['label'] ),
-				'description' => esc_html( $names['description'] ),
+				esc_html( sprintf( __( '%s Features', 'gravity-pdf' ), $names['label'] ) )
+			);
+
+			/* The intro tells the reader what to do about a list, so a group with nothing detected goes without it */
+			if ( $detections !== [] ) {
+				$description .= '<p>' . esc_html( $names['description'] ) . '</p>';
+			}
+
+			$sections[ 'gravity-pdf-' . $group ] = [
+				'label'       => __( 'Gravity PDF', 'gravity-pdf' ),
+				'description' => $description,
 				'fields'      => $fields,
 			];
 		}

--- a/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
+++ b/tests/phpunit/integration/Controller/Test_Controller_System_Report.php
@@ -327,6 +327,10 @@ class Test_Controller_System_Report extends TestCase {
 
 		$this->assertSame( 'None detected', $info['gravity-pdf-deprecated']['fields']['deprecated']['value'] );
 
+		/* The group still heads its own panel, but the intro only makes sense against a list of detections */
+		$this->assertStringContainsString( '<h4>Deprecated Features</h4>', $info['gravity-pdf-deprecated']['description'] );
+		$this->assertStringNotContainsString( '<p>', $info['gravity-pdf-deprecated']['description'] );
+
 		/* No registered feature belongs to the other group, so it isn't carried around empty */
 		$this->assertArrayNotHasKey( 'gravity-pdf-unsupported', $info );
 	}

--- a/tests/playwright/core/system-status/deprecated-features.spec.ts
+++ b/tests/playwright/core/system-status/deprecated-features.spec.ts
@@ -89,7 +89,7 @@ test.describe('Deprecated Features', () => {
 
 		// A template that drives the PDF engine is a Business Plus one, and reports under its own heading
 		await expect(deprecated).toContainText(
-			'Support for Business Plus Templates will be removed in Gravity PDF 7.0.'
+			'Support for Business Plus / Tier 2 Templates will be removed in Gravity PDF 7.0.'
 		);
 		await expect(deprecated).toContainText(
 			'e2e-business-plus.php (not configured on a form)'
@@ -179,17 +179,24 @@ test.describe('Deprecated Features', () => {
 
 		// The group gets its own section, so a support ticket carries the detections with it
 		const deprecatedHeading = page.locator(
-			'.health-check-accordion-heading',
-			{
-				hasText: 'Gravity PDF - Deprecated Functionality',
-			}
+			'#health-check-section-gravity-pdf-deprecated'
 		);
 
-		await expect(deprecatedHeading).toBeVisible();
+		// The title no longer names the group, which the panel now does for itself
+		await expect(deprecatedHeading).toHaveText('Gravity PDF');
 		await deprecatedHeading.click();
 
 		const deprecated = page.locator(
 			'#health-check-accordion-block-gravity-pdf-deprecated'
+		);
+
+		await expect(
+			deprecated.locator('h4', { hasText: 'Deprecated Features' })
+		).toBeVisible();
+
+		// The intro belongs to a list, so it is present only because there is something to introduce
+		await expect(deprecated).toContainText(
+			'Legacy functionality that will be removed in an upcoming release'
 		);
 
 		// Templates are named by file, with the upgrade URL travelling in the support ticket beside them
@@ -233,7 +240,7 @@ test.describe('Deprecated Features', () => {
 			'Support for Legacy Templates will be removed in Gravity PDF 7.0.'
 		);
 		await expect(notice).toContainText(
-			'Support for Business Plus Templates will be removed in Gravity PDF 7.0.'
+			'Support for Business Plus / Tier 2 Templates will be removed in Gravity PDF 7.0.'
 		);
 		await expect(notice).toContainText(
 			'Support for legacy download URLs will be removed in Gravity PDF 7.0.'


### PR DESCRIPTION
Presentation changes to the surfaces the v3 deprecation report feeds.

The Business Plus feature is now labelled "Business Plus / Tier 2 Templates", since customers knew the add-on under both names. That label is the only input to the sentence `Deprecation::get_feature_notice()` composes, so the system report, the admin notice and Site Health all pick the new name up at once. It also matches the docs anchor the same entry already links to.

The Site Health status result drops its introductory sentence. It told the reader to update each item "before the release that removes it", which points forward to a version that only appears further down, against each item, and then repeated a consequence the group descriptions directly below it already state twice. The all-clear message loses its tail too, and now reads "Nothing on this site uses Gravity PDF functionality that is scheduled for removal."

The Site Health Info sections drop the group from their titles. They read "Gravity PDF - Deprecated Functionality", which is the only place the group was named. Each section is now titled "Gravity PDF" and heads its own panel instead, with a "Deprecated Features" heading and the group intro paragraph above the table. That intro is there to introduce a list, so a group with nothing detected keeps its heading and goes without it.

## Try it

Give the site something to detect:

```bash
yarn wp-env start

yarn wp-env run cli wp eval '
  $dir = GPDFAPI::get_data_class()->template_location;
  file_put_contents( $dir . "try-legacy.php", "<?php // a plain v3 template" );
  file_put_contents( $dir . "try-business-plus.php", "<?php gfpdfe_business_plus::initilise();" );
'
```

Set one of those templates on a form PDF, then:

- **Tools > Site Health > Status**, open "Your site uses Gravity PDF functionality that is scheduled for removal". The paragraph above the "Deprecated" heading is gone.
- **Tools > Site Health > Info**. The section is titled "Gravity PDF", and its panel opens with a "Deprecated Features" heading and an intro paragraph above the table.
- **Forms > System Status**, and the admin notice, now read "Support for Business Plus / Tier 2 Templates will be removed in Gravity PDF 7.0."

Then delete both templates and reload the Info tab. The heading stays, the intro paragraph goes, and the table reads "None detected".

## Test plan

- [ ] Site Health Status shows the group headings with no paragraph above them
- [ ] The Info section is titled "Gravity PDF", with no group name in the title
- [ ] Its panel shows a "Deprecated Features" heading and an intro paragraph above the table
- [ ] With nothing detected, the heading stays and the intro paragraph is gone
- [ ] Copying the Info tab to the clipboard still carries the detections
- [ ] Business Plus detections read "Business Plus / Tier 2 Templates" in the report, the notice and Site Health
- [ ] `deprecated-features.spec.ts` passes, with a refreshed visual snapshot

<details>
<summary>More info</summary>

**The dropped sentence leaves the assignment behind.** `$result['description']` still holds the all-clear paragraph at that point, and the group headings append to it, so deleting the line outright would have left "Nothing on this site uses…" sitting above a list of problems. It is emptied instead:

```php
/* The group headings and their descriptions introduce the list, so nothing else does */
$result['description'] = '';
```

**Where the Info heading goes.** `wp-admin/site-health-info.php` renders a section as an accordion heading, then `printf( '<p>%s</p>', $details['description'] )`, then the table. The description is the only unescaped slot above the table, so the group heading and its intro live there, both interpolations escaped so only the markup this method writes reaches the page. The core `<p>` wrapper closes itself around the `<h4>`, which leaves an empty paragraph either side; that is the cost of the only hook available, and there is no sub-heading primitive to use instead.

**One section per group, still.** A section is the only unit Site Health gives a heading and an intro of its own, so the groups keep one each rather than merging into a single panel. Only the deprecated group is declared today, since `Deprecation::get_groups()` returns groups a provider actually declares, so there is one "Gravity PDF" section on screen.

**Test changes.** `deprecated-features.spec.ts` asserted the old section title. The accordion trigger is now located by its stable `#health-check-section-gravity-pdf-deprecated` id and asserted with `toHaveText('Gravity PDF')`, which covers the rename without depending on the text of a button that wraps its label in spans. The new heading is asserted as an element, `deprecated.locator('h4', …)`, so a regression back to a table row fails. A PHPUnit assertion in `Test_Controller_System_Report` covers the empty case, since the E2E fixtures always have detections.

**What was run.** PHPUnit is green on the full suite, 1637 tests and 5129 assertions. PHPCS and ESLint are clean.

The Playwright spec is not fully green, but not because of this change: `deprecated-features.spec.ts` fails on `gfpdf_rtl has 1 listener` at lines 113, 155 and 210. That reproduces identically on a clean `development` checkout, and the file runs `test.describe.configure({ mode: 'serial' })`, so the earlier failure stops the later tests from running. Every assertion this PR touches passes on the way to it: the section title, the `Deprecated Features` heading, the intro paragraph, and the renamed Business Plus label all pass before the run stops at line 210. The visual snapshot still needs re-baselining for the changed markup.

🤖 Generated with AI

</details>
