### PR TITLE
chore: add the 6.17.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Gravity PDF
 
+### 6.17.0
+* 🎉 Feature: Add a legacy features alert to Site Health and System Status reports
+* 🐞 Bug: Fix fatal error during update checks when the plugin requirements not met
+* 🐞 Bug: A temporary fix for rendering legacy templates on Gravity Forms 3.0+
+* 💻 Developer: Deprecated functionality now triggers `_deprecated_function()`, so it appears in the WordPress deprecation log and Query Monitor
+
 ### 6.16.0
 * 🎉 Feature: Gravity Forms 3.0 compatibility
 * 🎉 Feature: Support the Gravity Forms 3.0 International (formatted) phone number format, displayed with the country and dial code in front of the number


### PR DESCRIPTION
Adds the 6.17.0 release notes to `development`. The entry is copied verbatim from `hot-patch-6.17.0`, so the two branches carry the same notes ahead of the hot-patch merging back.

Changelog only. No source, test or build changes.

## Try it

```bash
git diff origin/development -- CHANGELOG.md
```

The 6.17.0 block lands between the `## Gravity PDF` header and `### 6.16.0`, matching the position it holds on the hot-patch branch.

## Test plan

- [ ] The 6.17.0 section reads identically to the one on `hot-patch-6.17.0`
- [ ] Nothing outside `CHANGELOG.md` is touched

<details>
<summary>More info</summary>

**Copied, not retyped.** The block is lifted from `git show origin/hot-patch-6.17.0:CHANGELOG.md` so the wording and emoji prefixes cannot drift.

**One difference left between the two files, deliberately.** The 6.16.0 "Auto-activate/deactivate license key" line carries three trailing spaces on `hot-patch-6.17.0` and none on `development`. This keeps development's version, so the diff stays to the six added lines rather than reintroducing whitespace the branch had already cleaned up.

**Entries this does not add.** Five commits landed on `hot-patch-6.17.0` after this entry was written: `fd485177`, `f78b92ec`, `5d72a4ff`, `fa95acc1` and `a6fc0386`. The first four are refinements to the legacy-features alert that the "Add a legacy features alert" line already covers, since that feature has never shipped in a released version. `a6fc0386` is different in kind and is discussed below.

🤖 Generated with AI

</details>
