### PR TITLE
chore(deps): weekly bump of WordPress core + Gravity Forms

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1466,10 +1466,10 @@
         },
         {
             "name": "gravity/gravityforms",
-            "version": "3.1.0.2",
+            "version": "3.1.1",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.gravity.io/downloads/?plugin=gravityforms&version=3.1.0.2"
+                "url": "https://composer.gravity.io/downloads/?plugin=gravityforms&version=3.1.1"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
Automated weekly dependency refresh.

**Composer packages** — `gravity/gravityforms`

| Package | Before | After |
| --- | --- | --- |
| gravity/gravityforms | `3.1.0.2` | `3.1.1` |